### PR TITLE
fix: Native build

### DIFF
--- a/.eas/workflows/deploy-qa.yml
+++ b/.eas/workflows/deploy-qa.yml
@@ -6,16 +6,8 @@ on:
 
 jobs:
   deploy:
+    type: deploy
     name: Deploy QA
     environment: preview
-    steps:
-      - uses: eas/checkout
-      - uses: eas/use_npm_token
-      - name: Install dependencies
-        run: npm install --force
-      - name: Install EAS CLI
-        run: npm install -g eas-cli
-      - name: Build
-        run: npx expo export --platform web
-      - name: Publish
-        run: eas deploy --alias qa
+    params:
+      alias: qa

--- a/.eas/workflows/deploy.yml
+++ b/.eas/workflows/deploy.yml
@@ -6,16 +6,8 @@ on:
 
 jobs:
   deploy:
+    type: deploy
     name: Deploy
     environment: production
-    steps:
-      - uses: eas/checkout
-      - uses: eas/use_npm_token
-      - name: Install dependencies
-        run: npm install --force
-      - name: Install EAS CLI
-        run: npm install -g eas-cli
-      - name: Build
-        run: npx expo export --platform web
-      - name: Publish
-        run: eas deploy --prod
+    params:
+      prod: true

--- a/components/TurnkeyProvider.tsx
+++ b/components/TurnkeyProvider.tsx
@@ -14,7 +14,7 @@ export const TurnkeyProvider: React.FC<{ children: React.ReactNode }> = ({
   children,
 }) =>
   Platform.OS === "web" ? (
-     children 
+    children
   ) : (
     <TurnkeyProviderNative
       config={{

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -1,6 +1,6 @@
 import axios, { AxiosRequestHeaders } from "axios";
 import { Platform } from "react-native";
-import { AuthenticationResponseJSON } from "react-native-passkeys/src/ReactNativePasskeys.types";
+// import { AuthenticationResponseJSON } from "react-native-passkeys/src/ReactNativePasskeys.types";
 import { fuse } from "viem/chains";
 
 import { explorerUrls } from "@/constants/explorers";
@@ -175,28 +175,28 @@ export const generateAuthenticationOptions = async () => {
   return response.json();
 };
 
-export const verifyAuthentication = async (
-  authenticationResponse: AuthenticationResponseJSON,
-  sessionId: string
-): Promise<User> => {
-  const response = await fetch(
-    `${EXPO_PUBLIC_FLASH_API_BASE_URL}/accounts/v1/passkeys/authentication/verify`,
-    {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        ...getPlatformHeaders(),
-      },
-      credentials: "include",
-      body: JSON.stringify({
-        ...authenticationResponse,
-        sessionId,
-      }),
-    }
-  );
-  if (!response.ok) throw response;
-  return response.json();
-};
+// export const verifyAuthentication = async (
+//   authenticationResponse: AuthenticationResponseJSON,
+//   sessionId: string
+// ): Promise<User> => {
+//   const response = await fetch(
+//     `${EXPO_PUBLIC_FLASH_API_BASE_URL}/accounts/v1/passkeys/authentication/verify`,
+//     {
+//       method: "POST",
+//       headers: {
+//         "Content-Type": "application/json",
+//         ...getPlatformHeaders(),
+//       },
+//       credentials: "include",
+//       body: JSON.stringify({
+//         ...authenticationResponse,
+//         sessionId,
+//       }),
+//     }
+//   );
+//   if (!response.ok) throw response;
+//   return response.json();
+// };
 
 export const fetchTotalAPY = async () => {
   const response = await axios.get<number>(

--- a/package-lock.json
+++ b/package-lock.json
@@ -81,7 +81,6 @@
         "react-native-mmkv": "^3.3.0",
         "react-native-modal": "^14.0.0-rc.1",
         "react-native-passkey": "^3.1.0",
-        "react-native-passkeys": "^0.3.3",
         "react-native-qrcode-svg": "^6.3.15",
         "react-native-quick-crypto": "^0.7.15",
         "react-native-reanimated": "~3.17.4",
@@ -10790,9 +10789,9 @@
       }
     },
     "node_modules/@testing-library/dom": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.0.tgz",
-      "integrity": "sha512-pemlzrSESWbdAloYml3bAJMEfNh1Z7EduzqPKprCH5S341frlpYnUEW0H72dLxa6IsYr+mPno20GiSm+h9dEdQ==",
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -10800,9 +10799,9 @@
         "@babel/runtime": "^7.12.5",
         "@types/aria-query": "^5.0.1",
         "aria-query": "5.3.0",
-        "chalk": "^4.1.0",
         "dom-accessibility-api": "^0.5.9",
         "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
         "pretty-format": "^27.0.2"
       },
       "engines": {
@@ -10926,9 +10925,9 @@
       }
     },
     "node_modules/@thirdweb-dev/insight": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@thirdweb-dev/insight/-/insight-1.1.0.tgz",
-      "integrity": "sha512-T8AQdhYaFBZhWD5AUgNt73wpbXiFPzj1zNQkixD85kFcfGnTXVpw4mj1XnPALfW7bTMK53EERSslHzPA2T+kDw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@thirdweb-dev/insight/-/insight-1.1.1.tgz",
+      "integrity": "sha512-24oRscLTW9Mod+XpyLlusLxZIZjqQv0XFNSV4lR5u9eoRPaA/BG2HtlVPr0DUtguzTbEyBz98++s5UWleqchVg==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18"
@@ -24399,17 +24398,6 @@
         "react-native": "*"
       }
     },
-    "node_modules/react-native-passkeys": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/react-native-passkeys/-/react-native-passkeys-0.3.3.tgz",
-      "integrity": "sha512-ACEanOfg1yHOq8rDXKsM0UyqcgwlHM4r7U1kMGTv0pmcydUgqdZQVgRvEMNHiFw2b3XsAil6MYPY7vGa30EaeA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "expo": "*",
-        "react": "*",
-        "react-native": "*"
-      }
-    },
     "node_modules/react-native-qrcode-svg": {
       "version": "6.3.15",
       "resolved": "https://registry.npmjs.org/react-native-qrcode-svg/-/react-native-qrcode-svg-6.3.15.tgz",
@@ -26835,9 +26823,9 @@
       }
     },
     "node_modules/thirdweb": {
-      "version": "5.105.21",
-      "resolved": "https://registry.npmjs.org/thirdweb/-/thirdweb-5.105.21.tgz",
-      "integrity": "sha512-q1QoESoiBxa6+zfq0Azuda97xbN565KcgEJyVwMixEQLytx2MRa11wsNVG7cOQj9rZ1/JfAyehhPARRf77qkQQ==",
+      "version": "5.105.22",
+      "resolved": "https://registry.npmjs.org/thirdweb/-/thirdweb-5.105.22.tgz",
+      "integrity": "sha512-jhiGQ7XDwWKbo3OnN/Oj+ZfguqVxv0lwShk0qa5KoLgF9WYWzplTRemwBReE99/6UESBK76JdvxJ4EzFVgONrw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@coinbase/wallet-sdk": "4.3.0",
@@ -26853,7 +26841,7 @@
         "@storybook/react": "9.0.15",
         "@tanstack/react-query": "5.81.5",
         "@thirdweb-dev/engine": "3.2.1",
-        "@thirdweb-dev/insight": "1.1.0",
+        "@thirdweb-dev/insight": "1.1.1",
         "@walletconnect/sign-client": "2.20.1",
         "@walletconnect/universal-provider": "2.21.4",
         "abitype": "1.0.8",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,6 @@
     "react-native-mmkv": "^3.3.0",
     "react-native-modal": "^14.0.0-rc.1",
     "react-native-passkey": "^3.1.0",
-    "react-native-passkeys": "^0.3.3",
     "react-native-qrcode-svg": "^6.3.15",
     "react-native-quick-crypto": "^0.7.15",
     "react-native-reanimated": "~3.17.4",
@@ -120,7 +119,10 @@
     "lucide-react-native": {
       "react": "^19"
     },
-    "ox": "0.6.12"
+    "ox": "0.6.12",
+    "@thirdweb-dev/react-native-adapter": {
+      "expo-linking": "~7.1.7"
+    }
   },
   "private": true
 }


### PR DESCRIPTION
Update package dependencies, streamline deploy workflows, and clean up unused code

- Removed `react-native-passkeys` from dependencies.
- Updated versions for `@testing-library/dom`, `@thirdweb-dev/insight`, and `thirdweb`.
- Simplified EAS deploy workflows by removing unnecessary steps.
- Commented out unused `verifyAuthentication` function in `api.ts` for clarity.