### PR TITLE
fix: Add Node.js polyfills for iOS bundle compilation

### DIFF
--- a/metro.config.js
+++ b/metro.config.js
@@ -7,6 +7,11 @@ const config = getDefaultConfig(__dirname)
 // Custom resolver to handle platform-specific modules
 config.resolver = {
   ...config.resolver,
+  alias: {
+    ...config.resolver?.alias,
+    stream: 'stream-browserify',
+    crypto: 'react-native-quick-crypto',
+  },
   resolveRequest: (context, moduleName, platform) => {
     // Block browser-specific modules when building for native platforms
     if (platform !== 'web' && (
@@ -20,9 +25,15 @@ config.resolver = {
       };
     }
 
+    // Handle Node.js built-ins for React Native
+    if (platform !== 'web' && moduleName === 'stream') {
+      return context.resolveRequest(context, 'stream-browserify', platform);
+    }
+
     // Default resolver for all other modules
     return context.resolveRequest(context, moduleName, platform);
   },
+  unstable_enablePackageExports: true,
 };
 
 module.exports = withNativeWind(config, { input: './global.css' })

--- a/package-lock.json
+++ b/package-lock.json
@@ -90,6 +90,7 @@
         "react-native-toast-message": "^2.3.3",
         "react-native-web": "^0.20.0",
         "react-native-webview": "13.13.5",
+        "stream-browserify": "^3.0.0",
         "tailwind-merge": "^3.3.1",
         "tailwindcss": "^3.4.17",
         "tailwindcss-animate": "^1.0.7",
@@ -26223,6 +26224,28 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/stream-browserify": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-3.0.0.tgz",
+      "integrity": "sha512-H73RAHsVBapbim0tU2JwwOiXUj+fikfiaoYAKHF3VJfA0pe2BCzkhAHBlLG6REzE+2WNZcxOXjK7lkso+9euLA==",
+      "dependencies": {
+        "inherits": "~2.0.4",
+        "readable-stream": "^3.5.0"
+      }
+    },
+    "node_modules/stream-browserify/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/stream-buffers": {

--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "react-native-toast-message": "^2.3.3",
     "react-native-web": "^0.20.0",
     "react-native-webview": "13.13.5",
+    "stream-browserify": "^3.0.0",
     "tailwind-merge": "^3.3.1",
     "tailwindcss": "^3.4.17",
     "tailwindcss-animate": "^1.0.7",


### PR DESCRIPTION
Resolves iOS build failure where thirdweb package couldn't resolve Node.js 'stream' module. Added stream-browserify polyfill and enabled package exports in Metro config to handle modern package dependencies.

- Add stream-browserify alias in metro.config.js
- Install stream-browserify package for Node.js stream polyfill
- Enable unstable_enablePackageExports to fix package export warnings
- Add crypto alias for react-native-quick-crypto compatibility