### PR TITLE
fix: Add crypto module polyfill for React Native builds

### DIFF
--- a/metro.config.js
+++ b/metro.config.js
@@ -26,8 +26,13 @@ config.resolver = {
     }
 
     // Handle Node.js built-ins for React Native
-    if (platform !== 'web' && moduleName === 'stream') {
-      return context.resolveRequest(context, 'stream-browserify', platform);
+    if (platform !== 'web') {
+      if (moduleName === 'stream') {
+        return context.resolveRequest(context, 'stream-browserify', platform);
+      }
+      if (moduleName === 'crypto') {
+        return context.resolveRequest(context, 'react-native-quick-crypto', platform);
+      }
     }
 
     // Default resolver for all other modules


### PR DESCRIPTION
Resolves bundling failures on both iOS and Android where thirdweb's ws library couldn't resolve Node.js 'crypto' module. Enhanced Metro resolver to handle both stream and crypto module polyfills for native platforms.

- Add explicit crypto module resolution in resolveRequest
- Map crypto to react-native-quick-crypto for native builds
- Improve Node.js built-ins handling in Metro bundler