### PR TITLE
fix: Include email in OTP verification request

### DIFF
--- a/lib/api.ts
+++ b/lib/api.ts
@@ -487,6 +487,7 @@ export const verifyGenericOtp = async (otpId: string, otpCode: string, email: st
       body: JSON.stringify({
         otpId,
         otpCode,
+        email,
       }),
     }
   );


### PR DESCRIPTION
- Added `email` parameter to the request body in `verifyGenericOtp` to ensure it is sent during OTP verification.