### PR TITLE
fix: Add JWT token to OTP requests

### DIFF
--- a/lib/api.ts
+++ b/lib/api.ts
@@ -452,6 +452,8 @@ export const initGenericOtp = async (
   alphanumeric?: boolean,
   userIdentifier?: string
 ) => {
+  const jwt = getJWTToken();
+
   const response = await fetch(
     `${EXPO_PUBLIC_FLASH_API_BASE_URL}/accounts/v1/auths/init-generic-otp`,
     {
@@ -459,6 +461,7 @@ export const initGenericOtp = async (
       headers: {
         "Content-Type": "application/json",
         ...getPlatformHeaders(),
+        ...(jwt ? { Authorization: `Bearer ${jwt}` } : {}),
       },
       credentials: "include",
       body: JSON.stringify({
@@ -475,6 +478,8 @@ export const initGenericOtp = async (
 };
 
 export const verifyGenericOtp = async (otpId: string, otpCode: string, email: string) => {
+  const jwt = getJWTToken();
+
   const response = await fetch(
     `${EXPO_PUBLIC_FLASH_API_BASE_URL}/accounts/v1/auths/verify-generic-otp`,
     {
@@ -482,6 +487,7 @@ export const verifyGenericOtp = async (otpId: string, otpCode: string, email: st
       headers: {
         "Content-Type": "application/json",
         ...getPlatformHeaders(),
+        ...(jwt ? { Authorization: `Bearer ${jwt}` } : {}),
       },
       credentials: "include",
       body: JSON.stringify({


### PR DESCRIPTION
- Included JWT token in the headers for `initGenericOtp` and `verifyGenericOtp` functions to ensure proper authorization during OTP initialization and verification.