### PR TITLE
feat: Add resend OTP functionality

### DIFF
--- a/components/DepositEmailModal/index.tsx
+++ b/components/DepositEmailModal/index.tsx
@@ -19,6 +19,7 @@ const DepositEmailModal: React.FC = () => {
     handleSendOtp,
     handleVerifyOtp,
     handleBack: handleEmailBack,
+    handleResendOtp,
     getButtonText,
     isFormDisabled,
     rateLimitError,
@@ -160,8 +161,22 @@ const DepositEmailModal: React.FC = () => {
         <Text className="text-xs text-gray-500 text-center">
           {currentStep === 'email'
             ? '⚠️ Important: This email will be used for account recovery if you lose access to your passkey.'
-            : "Didn't receive the code? Check your spam folder or go back to try a different email."}
+            : "Didn't receive the code? Check your spam folder."}
         </Text>
+        {currentStep === 'otp' && !rateLimitError && (
+          <View className="mt-2 items-center">
+            <Button
+              onPress={handleResendOtp}
+              variant="ghost"
+              disabled={isLoading}
+              className="h-8"
+            >
+              <Text className="text-blue-600 text-sm underline">
+                Resend verification code
+              </Text>
+            </Button>
+          </View>
+        )}
       </View>
     </View>
   );

--- a/hooks/useEmailManagement.ts
+++ b/hooks/useEmailManagement.ts
@@ -46,6 +46,7 @@ export interface EmailManagementActions {
   handleVerifyOtp: (data: OtpFormData) => Promise<void>;
   handleChangeEmail: () => void;
   handleBack: () => void;
+  handleResendOtp: () => Promise<void>;
   setStep: (step: EmailManagementState['step']) => void;
   getButtonText: () => string;
   isFormDisabled: () => boolean;
@@ -218,6 +219,11 @@ export const useEmailManagement = (
     }
   };
 
+  const handleResendOtp = async () => {
+    if (!emailValue) return;
+    await handleSendOtp({ email: emailValue });
+  };
+
   const handleChangeEmail = () => {
     setStep('email');
     emailForm.reset({ email: '' });
@@ -278,6 +284,7 @@ export const useEmailManagement = (
     handleVerifyOtp,
     handleChangeEmail,
     handleBack,
+    handleResendOtp,
     setStep,
     getButtonText,
     isFormDisabled,

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -6,8 +6,8 @@ import { Address, keccak256, toHex } from "viem";
 import { useUserStore } from "@/store/useUserStore";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import { refreshToken } from "./api";
-import { AuthTokens, User } from "./types";
 import { ADDRESSES } from "./config";
+import { AuthTokens, User } from "./types";
 
 export const IS_SERVER = typeof window === 'undefined';
 
@@ -53,7 +53,7 @@ export const withRefreshToken = async <T>(
   try {
     return await apiCall();
   } catch (error: any) {
-    if (error?.status !== 401) {
+    if (error?.status !== 401 || error?.statusCode !== 401) {
       console.error(error);
       throw error;
     }


### PR DESCRIPTION
- Implemented `handleResendOtp` in `useEmailManagement` to allow users to request a new verification code.
- Updated `DepositEmailModal` to include a button for resending the verification code when in the OTP step and no rate limit error is present.
- Adjusted error handling in `utils.ts` to check for both `status` and `statusCode` in API responses.