### PR TITLE
feat: Add Send tab and functionality

### DIFF
--- a/app/(protected)/(tabs)/_layout.tsx
+++ b/app/(protected)/(tabs)/_layout.tsx
@@ -1,5 +1,5 @@
 import { Tabs } from 'expo-router';
-import { CreditCard, LayoutDashboard, Leaf, Plus, Wallet } from 'lucide-react-native';
+import { CreditCard, LayoutDashboard, Leaf, Plus, Send, Wallet } from 'lucide-react-native';
 import React from 'react';
 import { Platform } from 'react-native';
 
@@ -92,6 +92,14 @@ export default function TabLayout() {
           title: 'Wallet',
           tabBarIcon: ({ color }) => <Wallet size={28} color={color} />,
           href: hasDeposited ? path.WALLET : null,
+        }}
+      />
+      <Tabs.Screen
+        name="send"
+        options={{
+          title: 'Send',
+          tabBarIcon: ({ color }) => <Send size={28} color={color} />,
+          href: hasDeposited ? path.SEND : null,
         }}
       />
     </Tabs>

--- a/app/(protected)/(tabs)/send.tsx
+++ b/app/(protected)/(tabs)/send.tsx
@@ -169,7 +169,7 @@ const SendPage = () => {
         {/* Form Fields */}
         <View className="max-w-md mx-auto w-full gap-4">
           {/* To Section */}
-          <View className="bg-[#1C1C1C] rounded-2xl px-4 py-5">
+          <View className="bg-card rounded-2xl px-4 py-5">
             <Text className="text-gray-400 text-sm mb-2">To</Text>
             <View className="flex-row items-center justify-between">
               <Controller
@@ -181,7 +181,7 @@ const SendPage = () => {
                       "flex-1 text-white text-base web:focus:outline-none",
                       // errors.address && "text-red-400"
                     )}
-                    placeholder="Enter or select and address..."
+                    placeholder="Enter or select an address..."
                     placeholderTextColor="#666"
                     value={value}
                     onChangeText={onChange}
@@ -196,7 +196,7 @@ const SendPage = () => {
           </View>
 
           {/* Send Section */}
-          <View className="bg-[#1C1C1C] rounded-2xl px-4 py-4">
+          <View className="bg-card rounded-2xl px-4 py-4">
             <Text className="text-gray-400 text-sm mb-2">Send</Text>
             <View className="flex-row items-center">
               <Pressable

--- a/app/(protected)/(tabs)/send.tsx
+++ b/app/(protected)/(tabs)/send.tsx
@@ -1,0 +1,284 @@
+import { zodResolver } from '@hookform/resolvers/zod';
+import { ChevronDown } from 'lucide-react-native';
+import React, { useEffect, useMemo, useState } from 'react';
+import { Controller, useForm } from 'react-hook-form';
+import { Platform, Pressable, TextInput, View } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { Address, formatUnits, isAddress } from 'viem';
+import { z } from 'zod';
+
+import Navbar from '@/components/Navbar';
+import NavbarMobile from '@/components/Navbar/NavbarMobile';
+import RenderTokenIcon from '@/components/RenderTokenIcon';
+import TokenSelectorModal from '@/components/SendModal/TokenSelectorModal';
+import { Button } from '@/components/ui/button';
+import { Text } from '@/components/ui/text';
+import { SEND_MODAL } from '@/constants/modals';
+import useSend from '@/hooks/useSend';
+import { useWalletTokens } from '@/hooks/useWalletTokens';
+import getTokenIcon from '@/lib/getTokenIcon';
+import { Status } from '@/lib/types';
+import { cn, eclipseAddress, formatNumber } from '@/lib/utils';
+import { getChain } from '@/lib/wagmi';
+import { useSendStore } from '@/store/useSendStore';
+import Toast from 'react-native-toast-message';
+
+interface TokenBalance {
+  contractTickerSymbol: string;
+  contractName: string;
+  contractAddress: string;
+  balance: string;
+  quoteRate?: number;
+  logoUrl?: string;
+  contractDecimals: number;
+  type: string;
+  verified?: boolean;
+  chainId: number;
+}
+
+const SendPage = () => {
+  const [selectedToken, setSelectedToken] = useState<TokenBalance | null>(null);
+  const [showTokenSelector, setShowTokenSelector] = useState(false);
+  const { setModal, setTransaction } = useSendStore();
+
+  const { ethereumTokens, fuseTokens, isLoading } = useWalletTokens();
+
+  // Combine and sort tokens by USD value (descending)
+  const allTokens = useMemo(() => {
+    const combined = [...ethereumTokens, ...fuseTokens];
+    return combined.sort((a, b) => {
+      const balanceA = Number(formatUnits(BigInt(a.balance || '0'), a.contractDecimals));
+      const balanceUSD_A = balanceA * (a.quoteRate || 0);
+
+      const balanceB = Number(formatUnits(BigInt(b.balance || '0'), b.contractDecimals));
+      const balanceUSD_B = balanceB * (b.quoteRate || 0);
+
+      return balanceUSD_B - balanceUSD_A; // Descending order
+    });
+  }, [ethereumTokens, fuseTokens]);
+
+  // Create form schema with validation (reusing patterns from SendModal)
+  const sendSchema = useMemo(() => {
+    const balanceAmount = selectedToken ? Number(formatUnits(BigInt(selectedToken.balance || '0'), selectedToken.contractDecimals)) : 0;
+    return z.object({
+      amount: z
+        .string()
+        .refine(val => val !== '' && !isNaN(Number(val)), 'Please enter a valid amount')
+        .refine(val => Number(val) > 0, 'Amount must be greater than 0')
+        .refine(
+          val => Number(val) <= balanceAmount,
+          `Available balance is ${formatNumber(balanceAmount)} ${selectedToken?.contractTickerSymbol || ''}`,
+        )
+        .transform(val => Number(val)),
+      address: z
+        .string()
+        .refine(isAddress, 'Please enter a valid Ethereum address')
+        .transform(value => value.toLowerCase()),
+    });
+  }, [selectedToken]);
+
+  const {
+    control,
+    handleSubmit,
+    formState: { errors, isValid },
+    reset,
+  } = useForm({
+    resolver: zodResolver(sendSchema) as any,
+    mode: 'onChange',
+    defaultValues: {
+      amount: '',
+      address: '',
+    },
+  });
+
+  const { send, sendStatus, resetSendStatus } = useSend({
+    tokenAddress: selectedToken?.contractAddress as any,
+    tokenDecimals: selectedToken?.contractDecimals || 18,
+    chainId: selectedToken?.chainId || 1,
+  });
+
+  // Reset form and status after 5 seconds of success
+  useEffect(() => {
+    if (sendStatus === Status.SUCCESS) {
+      const timeout = setTimeout(() => {
+        reset();
+        setSelectedToken(null);
+        resetSendStatus();
+      }, 5000);
+
+      return () => clearTimeout(timeout);
+    }
+  }, [sendStatus, reset, resetSendStatus]);
+
+  const isSendLoading = sendStatus === Status.PENDING;
+
+  const getSendText = () => {
+    if (errors.amount) return errors.amount.message;
+    if (errors.address) return errors.address.message;
+    if (sendStatus === Status.PENDING) return 'Sending...';
+    if (sendStatus === Status.ERROR) return 'Error while Sending';
+    if (sendStatus === Status.SUCCESS) return 'Successfully sent!';
+    if (!selectedToken) return 'Select token';
+    if (!isValid) return 'Send';
+    return 'Send';
+  };
+
+  const onSubmit = async (data: any) => {
+    if (!selectedToken) return;
+
+    try {
+      const transaction = await send(data.amount.toString(), data.address as Address);
+      setTransaction({
+        amount: Number(data.amount),
+        address: data.address,
+      });
+      setModal(SEND_MODAL.OPEN_TRANSACTION_STATUS);
+      Toast.show({
+        type: 'success',
+        text1: 'Send transaction completed',
+        text2: `${data.amount} ${selectedToken?.contractTickerSymbol}`,
+        props: {
+          link: `${getChain(selectedToken?.chainId)?.blockExplorers?.default.url}/tx/${transaction.transactionHash}`,
+          linkText: eclipseAddress(transaction.transactionHash),
+          image: getTokenIcon({
+            logoUrl: selectedToken?.logoUrl,
+            tokenSymbol: selectedToken?.contractTickerSymbol,
+            size: 24
+          }),
+        },
+      });
+      reset();
+    } catch (error) {
+      console.error('Send failed:', error);
+    }
+  };
+
+  return (
+    <SafeAreaView
+      className="bg-background text-foreground flex-1"
+      edges={['right', 'left', 'bottom', 'top']}
+    >
+      {Platform.OS !== 'web' && <NavbarMobile />}
+      {Platform.OS === 'web' && <Navbar />}
+      <View className="flex-1 bg-black px-6 py-12">
+        {/* Header */}
+        <Text className="text-white text-2xl font-semibold text-center mb-12">
+          Send
+        </Text>
+
+        {/* Form Fields */}
+        <View className="max-w-md mx-auto w-full gap-4">
+          {/* To Section */}
+          <View className="bg-[#1C1C1C] rounded-2xl px-4 py-5">
+            <Text className="text-gray-400 text-sm mb-2">To</Text>
+            <View className="flex-row items-center justify-between">
+              <Controller
+                control={control}
+                name="address"
+                render={({ field: { onChange, onBlur, value } }) => (
+                  <TextInput
+                    className={cn(
+                      "flex-1 text-white text-base web:focus:outline-none",
+                      // errors.address && "text-red-400"
+                    )}
+                    placeholder="Enter or select and address..."
+                    placeholderTextColor="#666"
+                    value={value}
+                    onChangeText={onChange}
+                    onBlur={onBlur}
+                    autoCapitalize="none"
+                    autoCorrect={false}
+                  />
+                )}
+              />
+              {/* <ChevronDown size={20} color="#666" /> */}
+            </View>
+          </View>
+
+          {/* Send Section */}
+          <View className="bg-[#1C1C1C] rounded-2xl px-4 py-4">
+            <Text className="text-gray-400 text-sm mb-2">Send</Text>
+            <View className="flex-row items-center">
+              <Pressable
+                className="flex-row items-center gap-3"
+                onPress={() => setShowTokenSelector(true)}
+              >
+                {selectedToken ? (
+                  <>
+                    <RenderTokenIcon
+                      tokenIcon={getTokenIcon({
+                        logoUrl: selectedToken.logoUrl,
+                        tokenSymbol: selectedToken.contractTickerSymbol,
+                        size: 24
+                      })}
+                      size={24}
+                    />
+                    <View>
+                      <Text className="text-white text-base">
+                        {selectedToken.contractTickerSymbol}
+                      </Text>
+                      <Text className="text-gray-400 text-xs">
+                        {formatNumber(Number(formatUnits(BigInt(selectedToken.balance || '0'), selectedToken.contractDecimals)))} {selectedToken.contractTickerSymbol}
+                      </Text>
+                    </View>
+                    <ChevronDown size={16} color="#666" />
+                  </>
+                ) : (
+                  <>
+                    <View className="w-6 h-6 bg-gray-600 rounded-full" />
+                    <Text className="text-gray-400 text-base">Select token</Text>
+                    <ChevronDown size={16} color="#666" />
+                  </>
+                )}
+              </Pressable>
+
+              <View className="flex-1" />
+
+              <Controller
+                control={control}
+                name="amount"
+                render={({ field: { onChange, onBlur, value } }) => (
+                  <TextInput
+                    className={cn(
+                      "w-full web:focus:outline-none text-white text-6xl font-light text-right",
+                      // errors.amount && "text-red-400"
+                    )}
+                    placeholder="0"
+                    placeholderTextColor="#666"
+                    value={value}
+                    onChangeText={onChange}
+                    onBlur={onBlur}
+                    keyboardType="decimal-pad"
+                    style={{ minWidth: 80 }}
+                  />
+                )}
+              />
+            </View>
+          </View>
+
+          {/* Send Button */}
+          <View className="mt-8">
+            <Button
+              className="bg-green-500 rounded-2xl h-14 w-full"
+              onPress={handleSubmit(onSubmit)}
+              disabled={!selectedToken || !isValid || isSendLoading}
+            >
+              <Text className="text-black text-lg font-semibold">{getSendText()}</Text>
+            </Button>
+          </View>
+        </View>
+
+        {/* Token Selector Modal */}
+        <TokenSelectorModal
+          isOpen={showTokenSelector}
+          onClose={() => setShowTokenSelector(false)}
+          tokens={allTokens}
+          onSelectToken={setSelectedToken}
+          selectedToken={selectedToken}
+        />
+      </View>
+    </SafeAreaView>
+  );
+};
+
+export default SendPage;

--- a/app/(protected)/(tabs)/wallet.tsx
+++ b/app/(protected)/(tabs)/wallet.tsx
@@ -16,10 +16,10 @@ import { useDepositCalculations } from '@/hooks/useDepositCalculations';
 import { useDimension } from '@/hooks/useDimension';
 import useUser from '@/hooks/useUser';
 import { useFuseVaultBalance } from '@/hooks/useVault';
-import { ADDRESSES } from '@/lib/config';
 import { useWalletTokens } from '@/hooks/useWalletTokens';
-import { SavingMode } from '@/lib/types';
+import { ADDRESSES } from '@/lib/config';
 import { calculateYield } from '@/lib/financial';
+import { SavingMode } from '@/lib/types';
 
 const renderInfo = (text: string) => {
   return (

--- a/components/Dashboard/DashboardHeaderMobile.tsx
+++ b/components/Dashboard/DashboardHeaderMobile.tsx
@@ -51,7 +51,7 @@ const DashboardHeaderMobile = ({
           <Button
             size="icon"
             className="h-14 w-14 rounded-full"
-            onPress={() => router.push(path.DEPOSIT)}
+            onPress={() => router.push(path.SEND)}
           >
             <SendHorizontal size={28} />
           </Button>

--- a/components/SendModal/TokenSelectorModal.tsx
+++ b/components/SendModal/TokenSelectorModal.tsx
@@ -1,0 +1,110 @@
+import React from 'react';
+import { Pressable, ScrollView, View } from 'react-native';
+import { formatUnits } from 'viem';
+
+import RenderTokenIcon from '@/components/RenderTokenIcon';
+import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog';
+import { Text } from '@/components/ui/text';
+import getTokenIcon from '@/lib/getTokenIcon';
+import { cn, formatNumber } from '@/lib/utils';
+
+interface TokenBalance {
+  contractTickerSymbol: string;
+  contractName: string;
+  contractAddress: string;
+  balance: string;
+  quoteRate?: number;
+  logoUrl?: string;
+  contractDecimals: number;
+  type: string;
+  verified?: boolean;
+  chainId: number;
+}
+
+interface TokenSelectorModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  tokens: TokenBalance[];
+  onSelectToken: (token: TokenBalance) => void;
+  selectedToken: TokenBalance | null;
+}
+
+const TokenSelectorModal: React.FC<TokenSelectorModalProps> = ({
+  isOpen,
+  onClose,
+  tokens,
+  onSelectToken,
+  selectedToken,
+}) => {
+  const handleTokenSelect = (token: TokenBalance) => {
+    onSelectToken(token);
+    onClose();
+  };
+
+  return (
+    <Dialog open={isOpen} onOpenChange={onClose}>
+      <DialogContent className="bg-zinc-900 border-zinc-800 max-w-md mx-auto p-8">
+        <View className="gap-8">
+          <DialogTitle className="text-white text-2xl font-semibold text-center">
+            Select an asset
+          </DialogTitle>
+
+          <View>
+            <Text className="text-gray-400 text-base mb-6">Tokens in your wallet</Text>
+            <ScrollView className="max-h-80" showsVerticalScrollIndicator={false}>
+              <View className="px-2 gap-3">
+                {tokens.map((token, index) => {
+                  const balance = Number(formatUnits(BigInt(token.balance) || 0n, token.contractDecimals));
+                  const balanceUSD = balance * (token.quoteRate || 0);
+                  const isSelected = selectedToken?.contractAddress === token.contractAddress &&
+                    selectedToken?.chainId === token.chainId;
+
+                  return (
+                    <Pressable
+                      key={`${token.contractAddress}-${token.chainId}`}
+                      className={cn(
+                        "bg-zinc-800 rounded-2xl px-4 py-4 flex-row items-center justify-between",
+                        isSelected && "border border-green-500"
+                      )}
+                      onPress={() => handleTokenSelect(token)}
+                    >
+                      <View className="flex-row items-center gap-3 flex-1">
+                        <RenderTokenIcon
+                          tokenIcon={getTokenIcon({
+                            logoUrl: token.logoUrl,
+                            tokenSymbol: token.contractTickerSymbol,
+                            size: 40
+                          })}
+                          size={40}
+                        />
+                        <View className="flex-1">
+                          <Text className="text-white text-lg font-semibold">
+                            {token.contractTickerSymbol}
+                          </Text>
+                          <Text className="text-gray-400 text-sm">
+                            {token.contractTickerSymbol} on {token.chainId === 1 ? 'Ethereum' : 'Fuse'}
+                          </Text>
+                        </View>
+                      </View>
+
+                      <View className="items-end">
+                        <Text className="text-white text-xl font-semibold">
+                          ${formatNumber(balanceUSD, 2)}
+                        </Text>
+                        <Text className="text-gray-400 text-sm">
+                          {formatNumber(balance, 2)}
+                        </Text>
+                      </View>
+                    </Pressable>
+                  );
+                })}
+              </View>
+            </ScrollView>
+          </View>
+        </View>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default TokenSelectorModal;

--- a/components/SendModal/index.tsx
+++ b/components/SendModal/index.tsx
@@ -21,9 +21,9 @@ import { Status, TokenIcon } from '@/lib/types';
 import { cn, eclipseAddress, formatNumber } from '@/lib/utils';
 import { getChain } from '@/lib/wagmi';
 import { useSendStore } from '@/store/useSendStore';
+import Max from '../Max';
 import RenderTokenIcon from '../RenderTokenIcon';
 import { Skeleton } from '../ui/skeleton';
-import Max from '../Max';
 
 type SendProps = {
   tokenAddress: Address;
@@ -96,7 +96,7 @@ const Send = ({ tokenAddress, tokenDecimals, tokenIcon, tokenSymbol, chainId }: 
     if (errors.address) return errors.address.message;
     if (sendStatus === Status.PENDING) return 'Sending';
     if (sendStatus === Status.ERROR) return 'Error while Sending';
-    if (sendStatus === Status.SUCCESS) return 'Sending Successful';
+    if (sendStatus === Status.SUCCESS) return 'Successfully sent!';
     if (!isValid) return 'Please complete the form';
     return 'Send';
   };
@@ -206,15 +206,14 @@ const Send = ({ tokenAddress, tokenDecimals, tokenIcon, tokenSymbol, chainId }: 
           <Text className="text-base text-muted-foreground">Fee</Text>
         </View>
         <Text className="text-base text-muted-foreground">
-          {`~ $${
-            loading
+          {`~ $${loading
               ? '...'
               : !costInUsd
                 ? '0'
                 : costInUsd < 0.01
                   ? '<0.01'
                   : formatNumber(costInUsd, 2)
-          } USD in fee`}
+            } USD in fee`}
         </Text>
       </View>
 

--- a/components/Wallet/index.tsx
+++ b/components/Wallet/index.tsx
@@ -1,4 +1,5 @@
 export { default as PointsBadge } from './PointsBadge';
-export { default as WalletCard } from './WalletCard';
 export { default as SavingCard } from './SavingCard';
+export { default as WalletCard } from './WalletCard';
 export { default as WalletTabs } from './WalletTabs';
+

--- a/constants/path.ts
+++ b/constants/path.ts
@@ -6,6 +6,7 @@ type Path = {
   HOME: Href;
   WALLET: Href;
   DEPOSIT: Href;
+  SEND: Href;
   CARD: Href;
   CARD_ACTIVATE: Route;
   CARD_KYC: Route;
@@ -26,6 +27,7 @@ export const path: Path = {
   HOME: "/",
   WALLET: "/wallet",
   DEPOSIT: "/deposit",
+  SEND: "/send",
   CARD: "/card",
   CARD_ACTIVATE: "/card/activate",
   CARD_KYC: "/card/kyc",

--- a/hooks/useSend.ts
+++ b/hooks/useSend.ts
@@ -19,6 +19,7 @@ type SendResult = {
   send: (amount: string, to: Address) => Promise<TransactionReceipt>;
   sendStatus: Status;
   error: string | null;
+  resetSendStatus: () => void;
 };
 
 const useSend = ({
@@ -81,7 +82,12 @@ const useSend = ({
     }
   };
 
-  return { send, sendStatus, error };
+  const resetSendStatus = () => {
+    setSendStatus(Status.IDLE);
+    setError(null);
+  };
+
+  return { send, sendStatus, error, resetSendStatus };
 };
 
 export default useSend;


### PR DESCRIPTION
- Introduced a new "Send" tab in the layout with a corresponding icon.
- Created a new `send.tsx` component for sending tokens, including form validation and token selection.
- Implemented token selection modal for user-friendly token management.
- Updated routing to navigate to the Send page from the dashboard.
- Enhanced `useSend` hook to include a reset function for send status.