### PR TITLE
feat: Reset signup info state on component mount in Register

### DIFF
--- a/app/register.tsx
+++ b/app/register.tsx
@@ -29,10 +29,15 @@ type RegisterFormData = z.infer<typeof registerSchema>;
 
 export default function Register() {
   const { handleSignup, handleLogin, handleDummyLogin } = useUser();
-  const { signupInfo, loginInfo } = useUserStore();
+  const { signupInfo, loginInfo, setSignupInfo } = useUserStore();
   const { code } = useLocalSearchParams<{ code: string }>();
   // TODO: Add recovery flow
   // const [showRecoveryFlow, setShowRecoveryFlow] = useState(false);
+
+  // Reset signup info state when component mounts
+  useEffect(() => {
+    setSignupInfo({ status: Status.IDLE, message: '' });
+  }, [setSignupInfo]);
 
   const {
     control,


### PR DESCRIPTION
- Added useEffect to reset signup info state to IDLE when the Register component mounts.
- Included setSignupInfo in the destructured user store for state management.