### PR TITLE
Add info message for Fuse network token support in SwapTokenSelector

### DIFF
--- a/components/TokenSelector/SwapTokenSelector.tsx
+++ b/components/TokenSelector/SwapTokenSelector.tsx
@@ -750,6 +750,11 @@ const SwapTokenSelector = ({
         isLoading={false}
         onQueryChange={setCurrentQuery}
       />
+      <View className="bg-accent/50 border border-accent/40 rounded-2xl p-4">
+        <Text className="text-foreground text-sm font-semibold text-center">
+          Only tokens on the Fuse network are supported for swapping
+        </Text>
+      </View>
       {selectorView === TokenSelectorView.DEFAULT_LIST ? (
         isLoading ? (
           <LoadingState />


### PR DESCRIPTION
- Added a notification in the SwapTokenSelector component to inform users that only tokens on the Fuse network are supported for swapping.