### PR TITLE
fix: update legal link in settings

### DIFF
--- a/constants/settings.ts
+++ b/constants/settings.ts
@@ -31,7 +31,7 @@ const supports: Support[] = [
   },
   {
     title: 'Legal',
-    link: 'https://docs.solid.xyz/privacy-policy',
+    link: 'https://docs.solid.xyz/terms-and-conditions',
   },
 ];
 


### PR DESCRIPTION
- Changed the link for the 'Legal' section from privacy policy to terms and conditions for accuracy.