### PR TITLE
feat: add ascApiKeyIssuerId to iOS configuration in eas.json

### DIFF
--- a/eas.json
+++ b/eas.json
@@ -28,7 +28,8 @@
         "ascAppId": "6747710981",
         "appleTeamId": "QC9255BHMY",
         "sku": "xyz.solid.ios",
-        "name": "Solid - The savings super-app"
+        "name": "Solid - The savings super-app",
+        "ascApiKeyIssuerId": "fc2f6907-d5de-4cd6-8eb9-5cd54b7523d3"
       }
     }
   }


### PR DESCRIPTION
- Added `ascApiKeyIssuerId` to the iOS configuration in `eas.json` for enhanced app submission capabilities.