### PR TITLE
fix: rename 'name' to 'appName' in iOS configuration of eas.json

### DIFF
--- a/eas.json
+++ b/eas.json
@@ -28,7 +28,7 @@
         "ascAppId": "6747710981",
         "appleTeamId": "QC9255BHMY",
         "sku": "xyz.solid.ios",
-        "name": "Solid - The savings super-app",
+        "appName": "Solid - The savings super-app",
         "ascApiKeyIssuerId": "fc2f6907-d5de-4cd6-8eb9-5cd54b7523d3"
       }
     }


### PR DESCRIPTION
- Updated the key from `name` to `appName` for clarity and consistency in the iOS configuration within `eas.json`.