### PR TITLE
feat: add ascApiKeyId to iOS configuration in eas.json

### DIFF
--- a/eas.json
+++ b/eas.json
@@ -29,7 +29,8 @@
         "appleTeamId": "QC9255BHMY",
         "sku": "xyz.solid.ios",
         "appName": "Solid - The savings super-app",
-        "ascApiKeyIssuerId": "fc2f6907-d5de-4cd6-8eb9-5cd54b7523d3"
+        "ascApiKeyIssuerId": "fc2f6907-d5de-4cd6-8eb9-5cd54b7523d3",
+        "ascApiKeyId": "467WKX25J2"
       }
     }
   }


### PR DESCRIPTION
- Added `ascApiKeyId` to the iOS configuration in `eas.json` to support app submission and enhance API integration.