### PR TITLE
fix: update email check in DepositOptionModal

### DIFF
--- a/components/DepositOption/DepositOptionModal.tsx
+++ b/components/DepositOption/DepositOptionModal.tsx
@@ -172,7 +172,8 @@ const DepositOptionModal = ({ buttonText = 'Add funds', trigger }: DepositOption
 
     if (value) {
       // Check if user has email when opening deposit modal
-      if (user && false) {
+      if (user && !user.email) {
+        setModal(DEPOSIT_MODAL.OPEN_EMAIL_GATE);
       } else if (address) {
         if (srcChainId) {
           setModal(DEPOSIT_MODAL.OPEN_FORM);


### PR DESCRIPTION
- Changed the condition to check for user email when opening the deposit modal. Now it correctly sets the modal to OPEN_EMAIL_GATE if the user is present but lacks an email address.