### PR TITLE
chore: remove iOS configuration from eas.json

### DIFF
--- a/eas.json
+++ b/eas.json
@@ -23,14 +23,6 @@
       "android": {
         "serviceAccountKeyPath": "./ServiceAccountSolid.json",
         "track": "internal"
-      },
-      "ios": {
-        "ascAppId": "6747710981",
-        "appleTeamId": "QC9255BHMY",
-        "sku": "xyz.solid.ios",
-        "appName": "Solid - The savings super-app",
-        "ascApiKeyIssuerId": "fc2f6907-d5de-4cd6-8eb9-5cd54b7523d3",
-        "ascApiKeyId": "467WKX25J2"
       }
     }
   }


### PR DESCRIPTION
- Deleted iOS-specific settings including ascAppId, appleTeamId, sku, appName, ascApiKeyIssuerId, and ascApiKeyId from eas.json.