### PR TITLE
refactor: simplify allowed crypto and fiat dropdown items

### DIFF
--- a/components/BankTransfer/BankTransferModalContent.tsx
+++ b/components/BankTransfer/BankTransferModalContent.tsx
@@ -27,11 +27,8 @@ const BankTransferAmountModal = () => {
   );
 
   const allowedCrypto = useMemo(() => {
-    if (fiat === BridgeTransferFiatCurrency.EUR) {
-      return [BridgeTransferCryptoCurrency.USDC];
-    }
-    return [BridgeTransferCryptoCurrency.USDC, BridgeTransferCryptoCurrency.USDT];
-  }, [fiat]);
+    return [BridgeTransferCryptoCurrency.USDC];
+  }, []);
 
   // Ensure crypto selection is valid when fiat changes
   useEffect(() => {

--- a/components/BankTransfer/FiatDropdown.tsx
+++ b/components/BankTransfer/FiatDropdown.tsx
@@ -14,7 +14,7 @@ type FiatDropdownProps = {
 export default function FiatDropdown({ value, onChange }: FiatDropdownProps) {
   const [open, setOpen] = useState(false);
 
-  const items = useMemo(() => [BridgeTransferFiatCurrency.USD, BridgeTransferFiatCurrency.EUR], []);
+  const items = useMemo(() => [BridgeTransferFiatCurrency.USD], []);
 
   // const renderFlag = (code: BridgeTransferFiatCurrency) => {
   //   const Icon = getFiatIcon(code);

--- a/components/BankTransfer/index.tsx
+++ b/components/BankTransfer/index.tsx
@@ -20,11 +20,8 @@ export default function BankTransferAmount() {
   );
 
   const allowedCrypto = useMemo(() => {
-    if (fiat === BridgeTransferFiatCurrency.EUR) {
-      return [BridgeTransferCryptoCurrency.USDC];
-    }
-    return [BridgeTransferCryptoCurrency.USDC, BridgeTransferCryptoCurrency.USDT];
-  }, [fiat]);
+    return [BridgeTransferCryptoCurrency.USDC];
+  }, []);
 
   // Ensure crypto selection is valid when fiat changes
   useEffect(() => {


### PR DESCRIPTION
- Update BankTransferModalContent and BankTransfer components to only allow USDC as the selected cryptocurrency.
- Modify FiatDropdown to only include USD in the dropdown options, removing EUR.