### PR TITLE
fix: correct StakeModal to use useStakeStore instead of useWithdrawStore

### DIFF
--- a/components/Stake/StakeModal.tsx
+++ b/components/Stake/StakeModal.tsx
@@ -6,12 +6,12 @@ import TransactionStatus from '@/components/TransactionStatus';
 import { STAKE_MODAL } from '@/constants/modals';
 import { path } from '@/constants/path';
 import getTokenIcon from '@/lib/getTokenIcon';
-import { useWithdrawStore } from '@/store/useWithdrawStore';
+import { useStakeStore } from '@/store/useStakeStore';
 import { Stake, StakeTrigger } from '.';
 
 const StakeModal = () => {
   const router = useRouter();
-  const { currentModal, previousModal, setModal, transaction } = useWithdrawStore();
+  const { currentModal, previousModal, setModal, transaction } = useStakeStore();
 
   const isTransactionStatus = currentModal.name === STAKE_MODAL.OPEN_TRANSACTION_STATUS.name;
   const isClose = currentModal.name === STAKE_MODAL.CLOSE.name;


### PR DESCRIPTION
StakeModal was incorrectly using useWithdrawStore, causing both Withdraw and Stake buttons to share the same modal state. This resulted in the Withdraw button opening the Stake modal instead of the Withdraw modal.

Changes:
- Import useStakeStore instead of useWithdrawStore in StakeModal.tsx
- Update modal state management to use the correct store

Fixes modal state conflict between Withdraw and Stake actions.

🤖 Generated with [Claude Code](https://claude.ai/code)