### PR TITLE
fix: restrict Sentry trace propagation to avoid CORS issues

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -80,7 +80,7 @@ Sentry.init({
   },
 
   // Sample events before sending
-  beforeSend(event, hint) {
+  beforeSend(event) {
     // Filter out events from development if they somehow get through
     if (event.environment !== 'production') {
       return null;
@@ -125,7 +125,7 @@ Sentry.init({
 
 export {
   // Catch any errors thrown by the Layout component.
-  ErrorBoundary
+  ErrorBoundary,
 } from 'expo-router';
 
 if (Platform.OS !== 'web') {

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -115,8 +115,7 @@ Sentry.init({
 
   // Network tracking
   tracePropagationTargets: [
-    /^https:\/\/gateway\.thegraph\.com/,
-    /^https:\/\/api\.turnkey\.com/,
+    // Only trace requests to your own backend
     /^https:\/\/.*\.solid\.xyz/,
   ],
 
@@ -126,7 +125,7 @@ Sentry.init({
 
 export {
   // Catch any errors thrown by the Layout component.
-  ErrorBoundary,
+  ErrorBoundary
 } from 'expo-router';
 
 if (Platform.OS !== 'web') {


### PR DESCRIPTION
Configure Sentry to only add tracing headers (Sentry-Trace, Baggage) to requests targeting solid.xyz domains. This prevents external API calls (like The Graph endpoints) from receiving unexpected headers that can cause CORS errors or API rejections.
Also exclude .env.local from git tracking to prevent accidental commits of local development configuration.