### PR TITLE
fix: update SENTRY_AUTH_TOKEN in eas.json to use environment variable

### DIFF
--- a/eas.json
+++ b/eas.json
@@ -17,7 +17,7 @@
       "autoIncrement": true,
       "channel": "production",
       "env": {
-        "SENTRY_AUTH_TOKEN": "SENTRY_AUTH_TOKEN"
+        "SENTRY_AUTH_TOKEN": "$SENTRY_AUTH_TOKEN"
       }
     }
   },


### PR DESCRIPTION
Changed the SENTRY_AUTH_TOKEN in eas.json from a hardcoded string to an environment variable reference for better security and flexibility.