### PR TITLE
refactor: Simplify enabling condition in useSwapCallback

### DIFF
--- a/hooks/swap/useSwapCallback.ts
+++ b/hooks/swap/useSwapCallback.ts
@@ -133,7 +133,7 @@ export function useSwapCallback(
         : undefined,
     chainId: fuse.id,
     query: {
-      enabled: Boolean(bestCall) && !needAllowance, // Don't simulate if approval is needed
+      enabled: Boolean(bestCall),
     },
   });
 


### PR DESCRIPTION
- Updated the enabling condition in useSwapCallback to always enable when bestCall is present, removing the check for needAllowance. This change streamlines the logic and maintains functionality.