### PR TITLE
Refactor ResponsiveModal layout by removing unnecessary flex classes

### DIFF
--- a/components/ResponsiveModal.tsx
+++ b/components/ResponsiveModal.tsx
@@ -125,7 +125,7 @@ const ResponsiveModal = ({
         <DialogContent className={cn('p-6 md:p-8 md:max-w-md', contentClassName)}>
           <Animated.View style={dialogAnimatedStyle} className="overflow-hidden">
             <View
-              className={cn('gap-8 flex-1', containerClassName)}
+              className={cn('gap-8', containerClassName)}
               onLayout={event => {
                 dialogHeight.value = event.nativeEvent.layout.height;
               }}
@@ -169,7 +169,6 @@ const ResponsiveModal = ({
                     : FadeOutRight.duration(ANIMATION_DURATION)
                 }
                 key={contentKey}
-                className="flex-1"
               >
                 {children}
               </Animated.View>
@@ -207,7 +206,7 @@ const ResponsiveModal = ({
             paddingTop: 12,
           }}
         >
-          <View className={cn('gap-6 flex-1', containerClassName)}>
+          <View className={cn('gap-6', containerClassName)}>
             {title && (
               <View
                 className={cn(
@@ -231,9 +230,7 @@ const ResponsiveModal = ({
                 {showBackButton && <View className="w-10" />}
               </View>
             )}
-            <View key={contentKey} className="flex-1">
-              {children}
-            </View>
+            <View key={contentKey}>{children}</View>
           </View>
         </BottomSheetView>
       </BottomSheetModal>


### PR DESCRIPTION
- Removed `flex-1` class from several components within `ResponsiveModal` to simplify the layout.
- Adjusted the structure of child views to enhance responsiveness while maintaining visual integrity.