### PR TITLE
Add storage keys to USER config and update stores to use them

### DIFF
--- a/lib/config.ts
+++ b/lib/config.ts
@@ -106,4 +106,8 @@ export const USER = {
   referralStorageKey: 'flash_referral',
   activityStorageKey: 'flash_activity',
   balanceStorageKey: 'flash_balance',
+  poolsStorageKey: 'pools-storage',
+  swapTokensStorageKey: 'swap-tokens',
+  tokensStorageKey: 'tokens-storage',
+  pointsStorageKey: 'points-storage',
 };

--- a/store/cachedTokensStore.ts
+++ b/store/cachedTokensStore.ts
@@ -2,6 +2,7 @@ import deepMerge from 'lodash.merge';
 import { create } from 'zustand';
 import { createJSONStorage, persist } from 'zustand/middleware';
 
+import { USER } from '@/lib/config';
 import mmkvStorage from '@/lib/mmvkStorage';
 import { TokenListItem } from '@/lib/types/tokens';
 
@@ -84,8 +85,8 @@ export const useCachedTokensStore = create<CachedTokensState>()(
       },
     }),
     {
-      name: 'swap-tokens',
-      storage: createJSONStorage(() => mmkvStorage('swap-tokens')),
+      name: USER.swapTokensStorageKey,
+      storage: createJSONStorage(() => mmkvStorage(USER.swapTokensStorageKey)),
       merge: (persistedState, currentState) => deepMerge(currentState, persistedState),
       // Only persist if we have valid data
       partialize: state => {

--- a/store/poolsStore.ts
+++ b/store/poolsStore.ts
@@ -1,3 +1,5 @@
+import { USER } from '@/lib/config';
+import mmkvStorage from '@/lib/mmvkStorage';
 import { Address } from 'viem';
 import { create } from 'zustand';
 import { createJSONStorage, persist } from 'zustand/middleware';
@@ -26,8 +28,8 @@ export const usePoolsStore = create(
         }),
     }),
     {
-      name: 'pools-plugins',
-      storage: createJSONStorage(() => sessionStorage),
+      name: USER.poolsStorageKey,
+      storage: createJSONStorage(() => mmkvStorage(USER.poolsStorageKey)),
     },
   ),
 );

--- a/store/tokensStore.ts
+++ b/store/tokensStore.ts
@@ -3,6 +3,7 @@ import { Address } from 'viem';
 import { create } from 'zustand';
 import { createJSONStorage, persist } from 'zustand/middleware';
 
+import { USER } from '@/lib/config';
 import mmkvStorage from '@/lib/mmvkStorage';
 import { TokenListItem } from '@/lib/types/tokens';
 
@@ -49,8 +50,8 @@ export const useTokensState = create(
       },
     }),
     {
-      name: 'tokens-storage',
-      storage: createJSONStorage(() => mmkvStorage('tokens-storage')),
+      name: USER.tokensStorageKey,
+      storage: createJSONStorage(() => mmkvStorage(USER.tokensStorageKey)),
       merge: (persistedState, currentState) => deepMerge(currentState, persistedState),
     },
   ),

--- a/store/usePointsStore.ts
+++ b/store/usePointsStore.ts
@@ -1,11 +1,12 @@
 import { fetchPoints } from '@/lib/api';
+import { USER } from '@/lib/config';
 import mmkvStorage from '@/lib/mmvkStorage';
 import { Points } from '@/lib/types';
 import { withRefreshToken } from '@/lib/utils';
+import * as Sentry from '@sentry/react-native';
 import { produce } from 'immer';
 import { create } from 'zustand';
 import { createJSONStorage, persist } from 'zustand/middleware';
-import * as Sentry from '@sentry/react-native';
 
 interface PointsState {
   points: Points;
@@ -74,8 +75,8 @@ export const usePointsStore = create<PointsState>()(
       },
     }),
     {
-      name: 'points-storage',
-      storage: createJSONStorage(() => mmkvStorage('points-storage')),
+      name: USER.pointsStorageKey,
+      storage: createJSONStorage(() => mmkvStorage(USER.pointsStorageKey)),
     },
   ),
 );


### PR DESCRIPTION
- Introduced new storage keys: `poolsStorageKey`, `swapTokensStorageKey`, `tokensStorageKey`, and `pointsStorageKey` in the USER config.
- Updated `cachedTokensStore`, `poolsStore`, `tokensStore`, and `usePointsStore` to utilize the new keys for storage configuration.