### PR TITLE
Fetch swap tokens from the backend

### DIFF
--- a/components/CurrencyLogo/index.tsx
+++ b/components/CurrencyLogo/index.tsx
@@ -56,7 +56,9 @@ const CurrencyLogo = ({ currency, size, style = {} }: CurrencyLogoProps) => {
   }
 
   const logoUrl = (currency as Token)?.address
-    ? tokens.find(token => token.address === (currency as Token)?.address)?.logoURI
+    ? tokens.find(
+        token => token.address.toLowerCase() === (currency as Token)?.address.toLowerCase(),
+      )?.logoURI
     : undefined;
 
   if (logoUrl) {

--- a/constants/tokens.ts
+++ b/constants/tokens.ts
@@ -76,4 +76,5 @@ export const WETH_STARGATE_TOKEN = new Token(
   'WETH',
   'Bridged Wrapped Ether (Stargate)'
 );
-export const USDC_STARGATE_TOKEN = new Token(ChainsId.Fuse, USDC_STARGATE, 6, 'USDC.e', 'Bridged USDC (Stargate)');
+export const USDC_STARGATE_TOKEN = new Token(ChainsId.Fuse, USDC_STARGATE, 6, 'USDCe', 'USD Coin on Fuse - Stargate');
+export const soUSDC_TOKEN = new Token(ChainsId.Fuse, '0x75333830E7014e909535389a6E5b0C02aA62ca27', 6, 'soUSDC', 'Solid USD');

--- a/hooks/tokens/useFetchTokenList.ts
+++ b/hooks/tokens/useFetchTokenList.ts
@@ -1,7 +1,26 @@
+import axios from 'axios';
 import { useEffect, useState } from 'react';
 
+import { EXPO_PUBLIC_FLASH_API_BASE_URL } from '@/lib/config';
 import { TokenListItem } from '@/lib/types/tokens';
 
+// Type for the swap token response from backend
+interface SwapTokenResponse {
+  _id: string;
+  name: string;
+  address: string;
+  symbol: string;
+  decimals: number;
+  chainId: number;
+  logoURI?: string;
+  isActive: boolean;
+  displayOrder?: number;
+  isFeatured: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+// Fallback to the original URL if backend is not available
 const VOLTAGE_SWAP_DEFAULT_TOKEN_LIST_URL =
   'https://raw.githubusercontent.com/voltfinance/swap-default-token-list/master/build/voltage-swap-default.tokenlist.json';
 
@@ -13,24 +32,64 @@ export function useFetchTokenList() {
   useEffect(() => {
     async function fetchTokenList() {
       try {
-        const response = await fetch(VOLTAGE_SWAP_DEFAULT_TOKEN_LIST_URL);
-        if (!response.ok) {
-          throw new Error('Failed to fetch token list');
+        // Try to fetch from our backend swap-tokens endpoint
+        const response = await axios.get<SwapTokenResponse[]>(
+          `${EXPO_PUBLIC_FLASH_API_BASE_URL}/accounts/v1/swap-tokens`,
+          {
+            params: {
+              isActive: true,
+            },
+          }
+        );
+
+        // Sort swap tokens by featured first, then by display order, then by symbol
+        const sortedSwapTokens = response.data.sort((a, b) => {
+          // Featured tokens come first
+          if (a.isFeatured && !b.isFeatured) return -1;
+          if (!a.isFeatured && b.isFeatured) return 1;
+
+          // Then sort by display order (lower numbers first)
+          const orderA = a.displayOrder ?? 999999;
+          const orderB = b.displayOrder ?? 999999;
+          if (orderA !== orderB) return orderA - orderB;
+
+          // Finally sort alphabetically by symbol
+          return a.symbol.localeCompare(b.symbol);
+        });
+
+        // Map to TokenListItem format for compatibility
+        const tokens: TokenListItem[] = sortedSwapTokens.map((swapToken) => ({
+          name: swapToken.name,
+          address: swapToken.address,
+          symbol: swapToken.symbol,
+          decimals: swapToken.decimals,
+          chainId: swapToken.chainId,
+          logoURI: swapToken.logoURI,
+        }));
+
+        setTokenList(tokens);
+      } catch (backendError) {
+        console.warn('Failed to fetch swap tokens from backend, falling back to original source:', backendError);
+
+        // Fallback to original source if backend fails
+        try {
+          const response = await fetch(VOLTAGE_SWAP_DEFAULT_TOKEN_LIST_URL);
+          if (!response.ok) {
+            throw new Error('Failed to fetch swap token list from fallback source');
+          }
+          const data = await response.json();
+          const tokenList = data.tokens;
+          setTokenList(tokenList);
+        } catch (fallbackError) {
+          setError(fallbackError as Error);
         }
-        const data = await response.json();
-        const tokenList = data.tokens;
-        setTokenList(tokenList);
-      } catch (err) {
-        setError(err as Error);
       } finally {
         setLoading(false);
       }
     }
 
-    if (!tokenList) {
-      fetchTokenList();
-    }
-  }, [tokenList]);
+    fetchTokenList();
+  }, []);
 
   return { tokenList, loading, error };
 }

--- a/store/swapStore.ts
+++ b/store/swapStore.ts
@@ -1,5 +1,5 @@
 import { SWAP_MODAL } from '@/constants/modals';
-import { VOLT_TOKEN, WFUSE_TOKEN } from '@/constants/tokens';
+import { soUSDC_TOKEN, USDC_STARGATE_TOKEN } from '@/constants/tokens';
 import { useReadAlgebraPoolGlobalState, useReadAlgebraPoolTickSpacing } from '@/generated/wagmi';
 import { useBestTradeExactIn, useBestTradeExactOut } from '@/hooks/swap/useBestTrade';
 import useSwapSlippageTolerance from '@/hooks/swap/useSwapSlippageTolerance';
@@ -60,10 +60,10 @@ export const useSwapState = create<SwapState>((set, get) => ({
   independentField: SwapField.INPUT,
   typedValue: '',
   [SwapField.INPUT]: {
-    currencyId: WFUSE_TOKEN.address as Address, // TOOD: DEFAULT TOKEN, change it to load from localStorage
+    currencyId: USDC_STARGATE_TOKEN.address as Address, // TOOD: DEFAULT TOKEN, change it to load from localStorage
   },
   [SwapField.OUTPUT]: {
-    currencyId: VOLT_TOKEN.address as Address,
+    currencyId: soUSDC_TOKEN.address as Address,
   },
   wasInverted: false,
   lastFocusedField: SwapField.INPUT,


### PR DESCRIPTION
- Adjusted `CurrencyLogo` to compare token addresses in a case-insensitive manner.
- Renamed `USDC_STARGATE_TOKEN` to `USDCe` for clarity.
- Added `soUSDC_TOKEN` to the token constants.
- Refactored `useAllTokens` to prioritize fresh token data from the backend and removed unused `allTokens` query.
- Enhanced `useFetchTokenList` to fetch tokens from a backend API with a fallback to a static URL, including sorting logic for featured tokens.
- Updated `swapStore` to use the new `USDC_STARGATE_TOKEN` and `soUSDC_TOKEN` for default currency settings.