### PR TITLE
Fix savings deposit vault price and token labels

### DIFF
--- a/components/DepositToVault/DepositToVaultForm.tsx
+++ b/components/DepositToVault/DepositToVaultForm.tsx
@@ -40,6 +40,7 @@ import { getAsset } from '@/lib/assets';
 import { getAttributionChannel } from '@/lib/attribution';
 import { EXPO_PUBLIC_FUSE_GAS_RESERVE } from '@/lib/config';
 import { Status, TokenBalance, TokenType } from '@/lib/types';
+import { resolveDepositBridgeTokenKey } from '@/lib/vaults';
 import { compactNumberFormat, eclipseAddress, formatNumber } from '@/lib/utils';
 import { useAttributionStore } from '@/store/useAttributionStore';
 import { useDepositStore } from '@/store/useDepositStore';
@@ -76,18 +77,29 @@ function DepositToVaultForm() {
   const vaultTokenIcon =
     vault.name === 'USDC' ? getAsset('images/sousd-4x.png') : getAsset(vault.icon);
 
+  const bridgeOutputTokenKey = useMemo(
+    () => resolveDepositBridgeTokenKey(srcChainId, outputToken, vault),
+    [srcChainId, outputToken, vault],
+  );
+
+  useEffect(() => {
+    if (bridgeOutputTokenKey !== outputToken) {
+      setOutputToken(bridgeOutputTokenKey);
+    }
+  }, [bridgeOutputTokenKey, outputToken, setOutputToken]);
+
   const selectedTokenInfo = useMemo(() => {
     const tokens = BRIDGE_TOKENS[srcChainId]?.tokens;
-    const tokenData = tokens ? tokens[outputToken as keyof typeof tokens] : undefined;
+    const tokenData = tokens ? tokens[bridgeOutputTokenKey as keyof typeof tokens] : undefined;
 
     return {
       address: tokenData?.address,
-      name: tokenData?.name || outputToken,
+      name: tokenData?.name || bridgeOutputTokenKey,
       image: tokenData?.icon || getAsset('images/usdc.png'),
       fullName: tokenData?.fullName,
       version: tokenData?.version,
     };
-  }, [srcChainId, outputToken]);
+  }, [srcChainId, bridgeOutputTokenKey]);
 
   const { balance, deposit, depositStatus, hash, isEthereum, error } = useDepositFromEOA(
     (selectedTokenInfo?.address as Address) || '',
@@ -158,7 +170,7 @@ function DepositToVaultForm() {
 
   const isFuseVault = vault.name === 'FUSE';
   const isEthVault = vault.name === 'ETH';
-  const isNativeFuse = isFuseVault && outputToken === 'FUSE';
+  const isNativeFuse = isFuseVault && bridgeOutputTokenKey === 'FUSE';
   const useSolidForFuse = isFuseVault && depositFromSolid;
   const useSolidForEth = isEthVault && depositFromSolid;
   const useSolidForUsdc = !isFuseVault && !isEthVault && depositFromSolid;
@@ -362,7 +374,14 @@ function DepositToVaultForm() {
       : Number(watchedAmount || 0) / (vaultExchangeRate ?? 1);
   const isAmountOutLoading =
     vault.name === 'USDC' ? isPreviewDepositLoading : vaultExchangeRate === undefined;
-  const displayRate = vault.name === 'USDC' ? vaultExchangeRate : vaultExchangeRate;
+  const displayRate = vaultExchangeRate;
+  const principalPerVaultToken =
+    vault.name === 'USDC'
+      ? displayRate != null && displayRate > 0
+        ? 1 / displayRate
+        : 0
+      : displayRate ?? 0;
+  const principalSymbolForPrice = selectedTokenInfo.name;
 
   const getButtonText = () => {
     if (errors.amount) return errors.amount.message;
@@ -555,10 +574,7 @@ function DepositToVaultForm() {
             <Text className="text-base text-muted-foreground">Price</Text>
             <View className="ml-auto shrink-0 flex-row items-baseline gap-2">
               <Text className="text-lg font-semibold">
-                {`1 ${vaultToken} = `}
-                {vault.name === 'USDC'
-                  ? `$${formatNumber(displayRate ?? 0)}`
-                  : `${formatNumber(displayRate ?? 0)} ${selectedTokenInfo.name}`}
+                {`1 ${vaultToken} = ${formatNumber(principalPerVaultToken)} ${principalSymbolForPrice}`}
               </Text>
             </View>
           </View>

--- a/lib/__tests__/vaults.test.ts
+++ b/lib/__tests__/vaults.test.ts
@@ -1,0 +1,23 @@
+import { fuse, mainnet } from 'viem/chains';
+
+import { VAULTS } from '@/constants/vaults';
+import { getAllowedTokensForChain, resolveDepositBridgeTokenKey } from '@/lib/vaults';
+
+describe('resolveDepositBridgeTokenKey', () => {
+  const usdcVault = VAULTS[0];
+  const fuseVault = VAULTS[1];
+
+  it('maps legacy vault receipt token soUSD to an allowed principal on FUSE vault', () => {
+    const resolved = resolveDepositBridgeTokenKey(fuse.id, 'soUSD', fuseVault);
+    expect(getAllowedTokensForChain(fuse.id, fuseVault)).toContain(resolved);
+    expect(resolved).not.toMatch(/^so/i);
+  });
+
+  it('keeps a valid bridge token when allowed for the vault', () => {
+    expect(resolveDepositBridgeTokenKey(fuse.id, 'WFUSE', fuseVault)).toBe('WFUSE');
+  });
+
+  it('defaults USDC vault deposit token on mainnet from legacy soUSD', () => {
+    expect(resolveDepositBridgeTokenKey(mainnet.id, 'soUSD', usdcVault)).toBe('USDC');
+  });
+});

--- a/lib/vaults.ts
+++ b/lib/vaults.ts
@@ -47,3 +47,33 @@ export const getDefaultDepositSelection = (vault?: Vault) => {
 
   return { chainId, outputToken };
 };
+
+/** Map persisted or legacy `outputToken` values to a real BRIDGE_TOKENS key for `chainId` and `vault`. */
+export function resolveDepositBridgeTokenKey(
+  chainId: number,
+  outputToken: string | undefined,
+  vault?: Vault,
+): string {
+  const allowed = getAllowedTokensForChain(chainId, vault);
+  const raw = outputToken?.trim() ?? '';
+  if (!allowed.length) {
+    return getDefaultDepositSelection(vault).outputToken;
+  }
+  if (!raw) {
+    return allowed[0];
+  }
+  if (allowed.includes(raw)) return raw;
+  const caseMatch = allowed.find(t => t.toUpperCase() === raw.toUpperCase());
+  if (caseMatch) return caseMatch;
+  // Legacy: vault receipt token (e.g. soUSD) was wrongly stored as the bridge "output" key
+  if (vault?.vaultToken && raw.toUpperCase() === vault.vaultToken.toUpperCase()) {
+    return allowed[0];
+  }
+  const bridgeKeys = Object.keys(BRIDGE_TOKENS[chainId]?.tokens ?? {});
+  const onBridge =
+    bridgeKeys.includes(raw) || bridgeKeys.some(k => k.toUpperCase() === raw.toUpperCase());
+  if (onBridge && !allowed.includes(raw)) {
+    return allowed[0];
+  }
+  return getDefaultDepositSelection(vault).outputToken;
+}

--- a/store/useDepositStore.ts
+++ b/store/useDepositStore.ts
@@ -91,7 +91,7 @@ export const useDepositStore = create<DepositState>()(
       previousModal: DEPOSIT_MODAL.CLOSE,
       transaction: {},
       srcChainId: mainnet.id,
-      outputToken: 'soUSD',
+      outputToken: 'USDC',
       bankTransfer: {},
       kyc: {},
       directDepositSession: {},
@@ -124,7 +124,7 @@ export const useDepositStore = create<DepositState>()(
           previousModal: DEPOSIT_MODAL.CLOSE,
           transaction: {},
           srcChainId: 0, // unset so next open shows options
-          outputToken: 'soUSD',
+          outputToken: 'USDC',
           bankTransfer: {},
           kyc: {},
           directDepositSession: {},


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- **Price row:** Always shows **vault token ↔ principal** (e.g. `1 soFUSE = … WFUSE`, `1 soUSD = … USDC`). The USDC vault no longer shows `1 soUSD = $…` (USD is not the on-chain principal) and cannot show a vault-to-vault style ratio when the wrong symbol leaked through.
- **Token mismatch:** Persisted `outputToken` was incorrectly set to **`soUSD`** (a vault receipt symbol, not a `BRIDGE_TOKENS` key). That made the UI treat the deposit asset as `soUSD` while the selected vault was FUSE, so "You will receive" showed **soFUSE** but balance / gasless copy used **soUSD**. We now resolve invalid keys to an allowed principal for the active vault and sync the store; the default `outputToken` in the deposit store is **`USDC`** (USDC vault principal), not `soUSD`.
- **Tests:** Added `resolveDepositBridgeTokenKey` unit tests.

## How to verify

1. Open Savings → Deposit with FUSE vault selected (or reproduce with persisted `outputToken: soUSD`).
2. Confirm balance, gasless line, and "You will receive" all refer to the same principal token (WFUSE/FUSE/USDC as selected).
3. Confirm Price is `1 <vaultToken> = <n> <principal>` with no `so*` on the right side.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fb2ca921-08ca-4ac4-8ac1-76db587e0192"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fb2ca921-08ca-4ac4-8ac1-76db587e0192"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

