### PR TITLE
Fix vault/principal token mismatches in deposit modal

### DIFF
--- a/components/DepositNetwork/DepositNetworks.tsx
+++ b/components/DepositNetwork/DepositNetworks.tsx
@@ -14,11 +14,11 @@ import { useDepositStore } from '@/store/useDepositStore';
 import DepositNetwork from './DepositNetwork';
 
 const DepositNetworks = () => {
-  const { setModal, setSrcChainId, setOutputToken } = useDepositStore(
+  const { setModal, setSrcChainId, setPrincipalToken } = useDepositStore(
     useShallow(state => ({
       setModal: state.setModal,
       setSrcChainId: state.setSrcChainId,
-      setOutputToken: state.setOutputToken,
+      setPrincipalToken: state.setPrincipalToken,
     })),
   );
   const { user } = useUser();
@@ -64,7 +64,7 @@ const DepositNetworks = () => {
     });
 
     setSrcChainId(id);
-    setOutputToken(selectedToken);
+    setPrincipalToken(selectedToken);
     setModal(DEPOSIT_MODAL.OPEN_FORM);
   };
 
@@ -81,9 +81,7 @@ const DepositNetworks = () => {
             const chainId = Number(id);
             const isComingSoon = network.isComingSoon;
             const estimatedDesc =
-              chainId === 1
-                ? 'Estimated speed: 5 min'
-                : 'Estimated speed: 20 min';
+              chainId === 1 ? 'Estimated speed: 5 min' : 'Estimated speed: 20 min';
 
             return (
               <DepositNetwork

--- a/components/DepositOption/AddFundsToWalletForm.tsx
+++ b/components/DepositOption/AddFundsToWalletForm.tsx
@@ -24,26 +24,26 @@ import { formatNumber } from '@/lib/utils';
 import { useDepositStore } from '@/store/useDepositStore';
 
 function AddFundsToWalletForm() {
-  const { setModal, setTransaction, srcChainId, outputToken } = useDepositStore(
+  const { setModal, setTransaction, srcChainId, principalToken } = useDepositStore(
     useShallow(state => ({
       setModal: state.setModal,
       setTransaction: state.setTransaction,
       srcChainId: state.srcChainId,
-      outputToken: state.outputToken,
+      principalToken: state.principalToken,
     })),
   );
   const selectedTokenInfo = useMemo(() => {
     const tokens = BRIDGE_TOKENS[srcChainId]?.tokens;
-    const tokenData = tokens ? tokens[outputToken as keyof typeof tokens] : undefined;
+    const tokenData = tokens ? tokens[principalToken as keyof typeof tokens] : undefined;
 
     return {
       address: tokenData?.address,
-      name: tokenData?.name || outputToken,
+      name: tokenData?.name || principalToken,
       image: tokenData?.icon || getAsset('images/usdc.png'),
       fullName: tokenData?.fullName,
       isNative: tokenData?.isNative ?? false,
     };
-  }, [srcChainId, outputToken]);
+  }, [srcChainId, principalToken]);
 
   const { balance, transfer, transferStatus, error } = useTransferToWallet(
     (selectedTokenInfo?.address as Address) || '',
@@ -51,7 +51,7 @@ function AddFundsToWalletForm() {
     selectedTokenInfo.isNative,
   );
 
-  const isStablecoin = outputToken === 'USDC' || outputToken === 'USDT';
+  const isStablecoin = principalToken === 'USDC' || principalToken === 'USDT';
   const decimals = isStablecoin ? 6 : 18;
   const isLoading = transferStatus.status === Status.PENDING;
 

--- a/components/DepositToVault/DepositToVaultForm.tsx
+++ b/components/DepositToVault/DepositToVaultForm.tsx
@@ -62,18 +62,18 @@ function DepositToVaultForm() {
     setModal,
     setTransaction,
     srcChainId,
-    outputToken,
+    principalToken,
     depositFromSolid,
-    setOutputToken,
+    setPrincipalToken,
     setSrcChainId,
   } = useDepositStore(
     useShallow(state => ({
       setModal: state.setModal,
       setTransaction: state.setTransaction,
       srcChainId: state.srcChainId,
-      outputToken: state.outputToken,
+      principalToken: state.principalToken,
       depositFromSolid: state.depositFromSolid,
-      setOutputToken: state.setOutputToken,
+      setPrincipalToken: state.setPrincipalToken,
       setSrcChainId: state.setSrcChainId,
     })),
   );
@@ -92,28 +92,28 @@ function DepositToVaultForm() {
         ? srcChainId
         : defaultSelection.chainId;
     const allowedTokens = nextChainId ? getAllowedTokensForChain(nextChainId, vault) : [];
-    const nextOutputToken = allowedTokens.includes(outputToken)
-      ? outputToken
-      : defaultSelection.outputToken;
+    const nextPrincipalToken = allowedTokens.includes(principalToken)
+      ? principalToken
+      : defaultSelection.principalToken;
 
     return {
       chainId: nextChainId ?? srcChainId,
-      outputToken: nextOutputToken,
+      principalToken: nextPrincipalToken,
     };
-  }, [depositConfig.supportedChains, outputToken, srcChainId, vault]);
+  }, [depositConfig.supportedChains, principalToken, srcChainId, vault]);
 
   useEffect(() => {
     if (normalizedSelection.chainId && normalizedSelection.chainId !== srcChainId) {
       setSrcChainId(normalizedSelection.chainId);
     }
-    if (normalizedSelection.outputToken !== outputToken) {
-      setOutputToken(normalizedSelection.outputToken);
+    if (normalizedSelection.principalToken !== principalToken) {
+      setPrincipalToken(normalizedSelection.principalToken);
     }
   }, [
     normalizedSelection.chainId,
-    normalizedSelection.outputToken,
-    outputToken,
-    setOutputToken,
+    normalizedSelection.principalToken,
+    principalToken,
+    setPrincipalToken,
     setSrcChainId,
     srcChainId,
   ]);
@@ -121,17 +121,17 @@ function DepositToVaultForm() {
   const selectedTokenInfo = useMemo(() => {
     const tokens = BRIDGE_TOKENS[normalizedSelection.chainId]?.tokens;
     const tokenData = tokens
-      ? tokens[normalizedSelection.outputToken as keyof typeof tokens]
+      ? tokens[normalizedSelection.principalToken as keyof typeof tokens]
       : undefined;
 
     return {
       address: tokenData?.address,
-      name: tokenData?.name || normalizedSelection.outputToken,
+      name: tokenData?.name || normalizedSelection.principalToken,
       image: tokenData?.icon || getAsset('images/usdc.png'),
       fullName: tokenData?.fullName,
       version: tokenData?.version,
     };
-  }, [normalizedSelection.chainId, normalizedSelection.outputToken]);
+  }, [normalizedSelection.chainId, normalizedSelection.principalToken]);
 
   const { balance, deposit, depositStatus, hash, isEthereum, error } = useDepositFromEOA(
     (selectedTokenInfo?.address as Address) || '',
@@ -202,7 +202,7 @@ function DepositToVaultForm() {
 
   const isFuseVault = vault.name === 'FUSE';
   const isEthVault = vault.name === 'ETH';
-  const isNativeFuse = isFuseVault && normalizedSelection.outputToken === 'FUSE';
+  const isNativeFuse = isFuseVault && normalizedSelection.principalToken === 'FUSE';
   const useSolidForFuse = isFuseVault && depositFromSolid;
   const useSolidForEth = isEthVault && depositFromSolid;
   const useSolidForUsdc = !isFuseVault && !isEthVault && depositFromSolid;
@@ -226,9 +226,9 @@ function DepositToVaultForm() {
   // Auto-switch to WFUSE if native FUSE is selected but not depositing from Solid
   useEffect(() => {
     if (isNativeFuse && !useSolidForFuse) {
-      setOutputToken('WFUSE');
+      setPrincipalToken('WFUSE');
     }
-  }, [isNativeFuse, useSolidForFuse, setOutputToken]);
+  }, [isNativeFuse, useSolidForFuse, setPrincipalToken]);
 
   const balanceForVault = isEthVault
     ? useSolidForEth

--- a/components/DepositToVault/DepositToVaultForm.tsx
+++ b/components/DepositToVault/DepositToVaultForm.tsx
@@ -41,6 +41,7 @@ import { getAttributionChannel } from '@/lib/attribution';
 import { EXPO_PUBLIC_FUSE_GAS_RESERVE } from '@/lib/config';
 import { Status, TokenBalance, TokenType } from '@/lib/types';
 import { compactNumberFormat, eclipseAddress, formatNumber } from '@/lib/utils';
+import { getAllowedTokensForChain, getDefaultDepositSelection } from '@/lib/vaults';
 import { useAttributionStore } from '@/store/useAttributionStore';
 import { useDepositStore } from '@/store/useDepositStore';
 
@@ -57,37 +58,80 @@ function getGaslessText(
 }
 
 function DepositToVaultForm() {
-  const { setModal, setTransaction, srcChainId, outputToken, depositFromSolid, setOutputToken } =
-    useDepositStore(
-      useShallow(state => ({
-        setModal: state.setModal,
-        setTransaction: state.setTransaction,
-        srcChainId: state.srcChainId,
-        outputToken: state.outputToken,
-        depositFromSolid: state.depositFromSolid,
-        setOutputToken: state.setOutputToken,
-      })),
-    );
+  const {
+    setModal,
+    setTransaction,
+    srcChainId,
+    outputToken,
+    depositFromSolid,
+    setOutputToken,
+    setSrcChainId,
+  } = useDepositStore(
+    useShallow(state => ({
+      setModal: state.setModal,
+      setTransaction: state.setTransaction,
+      srcChainId: state.srcChainId,
+      outputToken: state.outputToken,
+      depositFromSolid: state.depositFromSolid,
+      setOutputToken: state.setOutputToken,
+      setSrcChainId: state.setSrcChainId,
+    })),
+  );
   const { isScreenMedium } = useDimension();
-  const { vault } = useVaultDepositConfig();
+  const { vault, depositConfig } = useVaultDepositConfig();
   const { data: vaultExchangeRate } = useVaultExchangeRate(vault.name);
 
   const vaultToken = vault.vaultToken ?? 'soUSD';
   const vaultTokenIcon =
     vault.name === 'USDC' ? getAsset('images/sousd-4x.png') : getAsset(vault.icon);
 
+  const normalizedSelection = useMemo(() => {
+    const defaultSelection = getDefaultDepositSelection(vault);
+    const nextChainId =
+      srcChainId && depositConfig.supportedChains.includes(srcChainId)
+        ? srcChainId
+        : defaultSelection.chainId;
+    const allowedTokens = nextChainId ? getAllowedTokensForChain(nextChainId, vault) : [];
+    const nextOutputToken = allowedTokens.includes(outputToken)
+      ? outputToken
+      : defaultSelection.outputToken;
+
+    return {
+      chainId: nextChainId ?? srcChainId,
+      outputToken: nextOutputToken,
+    };
+  }, [depositConfig.supportedChains, outputToken, srcChainId, vault]);
+
+  useEffect(() => {
+    if (normalizedSelection.chainId && normalizedSelection.chainId !== srcChainId) {
+      setSrcChainId(normalizedSelection.chainId);
+    }
+    if (normalizedSelection.outputToken !== outputToken) {
+      setOutputToken(normalizedSelection.outputToken);
+    }
+  }, [
+    normalizedSelection.chainId,
+    normalizedSelection.outputToken,
+    outputToken,
+    setOutputToken,
+    setSrcChainId,
+    srcChainId,
+  ]);
+
   const selectedTokenInfo = useMemo(() => {
-    const tokens = BRIDGE_TOKENS[srcChainId]?.tokens;
-    const tokenData = tokens ? tokens[outputToken as keyof typeof tokens] : undefined;
+    const tokens = BRIDGE_TOKENS[normalizedSelection.chainId]?.tokens;
+    const tokenData = tokens
+      ? tokens[normalizedSelection.outputToken as keyof typeof tokens]
+      : undefined;
 
     return {
       address: tokenData?.address,
-      name: tokenData?.name || outputToken,
+      name: tokenData?.name || normalizedSelection.outputToken,
       image: tokenData?.icon || getAsset('images/usdc.png'),
       fullName: tokenData?.fullName,
       version: tokenData?.version,
     };
-  }, [srcChainId, outputToken]);
+  }, [normalizedSelection.chainId, normalizedSelection.outputToken]);
 
   const { balance, deposit, depositStatus, hash, isEthereum, error } = useDepositFromEOA(
     (selectedTokenInfo?.address as Address) || '',
@@ -158,14 +202,15 @@ function DepositToVaultForm() {
 
   const isFuseVault = vault.name === 'FUSE';
   const isEthVault = vault.name === 'ETH';
-  const isNativeFuse = isFuseVault && outputToken === 'FUSE';
+  const isNativeFuse = isFuseVault && normalizedSelection.outputToken === 'FUSE';
   const useSolidForFuse = isFuseVault && depositFromSolid;
   const useSolidForEth = isEthVault && depositFromSolid;
   const useSolidForUsdc = !isFuseVault && !isEthVault && depositFromSolid;
 
   // Synthesize a TokenBalance for the WalletTokenButton when depositFromSolid
   const selectedWalletToken: TokenBalance | null = useMemo(() => {
-    if (!depositFromSolid || !srcChainId || !selectedTokenInfo.address) return null;
+    if (!depositFromSolid || !normalizedSelection.chainId || !selectedTokenInfo.address)
+      return null;
     return {
       contractTickerSymbol: selectedTokenInfo.name,
       contractName: selectedTokenInfo.fullName || selectedTokenInfo.name,
@@ -173,10 +218,10 @@ function DepositToVaultForm() {
       balance: '0',
       contractDecimals: isFuseVault || isEthVault ? 18 : 6,
       type: TokenType.ERC20,
-      chainId: srcChainId,
+      chainId: normalizedSelection.chainId,
       logoUrl: undefined,
     };
-  }, [depositFromSolid, srcChainId, selectedTokenInfo, isFuseVault, isEthVault]);
+  }, [depositFromSolid, normalizedSelection.chainId, selectedTokenInfo, isFuseVault, isEthVault]);
 
   // Auto-switch to WFUSE if native FUSE is selected but not depositing from Solid
   useEffect(() => {
@@ -353,7 +398,11 @@ function DepositToVaultForm() {
     amountOut: previewAmountOut,
     isLoading: isPreviewDepositLoading,
     routingFee,
-  } = usePreviewDeposit(watchedAmount || '0', selectedTokenInfo?.address, srcChainId);
+  } = usePreviewDeposit(
+    watchedAmount || '0',
+    selectedTokenInfo?.address,
+    normalizedSelection.chainId,
+  );
 
   // Use vault's accountant rate for display; amountOut from preview (USDC + LiFi) or vault rate (e.g. FUSE)
   const amountOut =

--- a/components/DepositToVault/DepositTokenSelector/DepositTokenSelector.native.tsx
+++ b/components/DepositToVault/DepositTokenSelector/DepositTokenSelector.native.tsx
@@ -10,10 +10,10 @@ import { getAllowedTokensForChain } from '@/lib/vaults';
 import { useDepositStore } from '@/store/useDepositStore';
 
 const DepositTokenSelector = () => {
-  const { setModal, setOutputToken, srcChainId } = useDepositStore(
+  const { setModal, setPrincipalToken, srcChainId } = useDepositStore(
     useShallow(state => ({
       setModal: state.setModal,
-      setOutputToken: state.setOutputToken,
+      setPrincipalToken: state.setPrincipalToken,
       srcChainId: state.srcChainId,
     })),
   );
@@ -22,7 +22,7 @@ const DepositTokenSelector = () => {
   const allowedTokens = getAllowedTokensForChain(srcChainId);
 
   const handlePress = (token: string) => {
-    setOutputToken(token);
+    setPrincipalToken(token);
     setModal(DEPOSIT_MODAL.OPEN_FORM);
   };
 

--- a/components/DepositToVault/DepositTokenSelector/DepositTokenSelector.web.tsx
+++ b/components/DepositToVault/DepositTokenSelector/DepositTokenSelector.web.tsx
@@ -10,10 +10,10 @@ import { getAllowedTokensForChain } from '@/lib/vaults';
 import { useDepositStore } from '@/store/useDepositStore';
 
 const DepositTokenSelector = () => {
-  const { setModal, setOutputToken, srcChainId } = useDepositStore(
+  const { setModal, setPrincipalToken, srcChainId } = useDepositStore(
     useShallow(state => ({
       setModal: state.setModal,
-      setOutputToken: state.setOutputToken,
+      setPrincipalToken: state.setPrincipalToken,
       srcChainId: state.srcChainId,
     })),
   );
@@ -22,7 +22,7 @@ const DepositTokenSelector = () => {
   const allowedTokens = getAllowedTokensForChain(srcChainId);
 
   const handlePress = (token: string) => {
-    setOutputToken(token);
+    setPrincipalToken(token);
     setModal(DEPOSIT_MODAL.OPEN_FORM);
   };
 

--- a/components/DepositToVault/SavingsDepositTokenSelector.tsx
+++ b/components/DepositToVault/SavingsDepositTokenSelector.tsx
@@ -16,14 +16,14 @@ import { useSavingStore } from '@/store/useSavingStore';
 /**
  * Token selector for the Savings deposit flow (Step 2).
  * Shows tokens from the user's Solid wallet that can be deposited into vaults,
- * with chain names displayed. Selecting a token sets the srcChainId, outputToken,
+ * with chain names displayed. Selecting a token sets the srcChainId, principalToken,
  * and appropriate vault, then navigates to the deposit form.
  */
 const SavingsDepositTokenSelector: React.FC = () => {
-  const { setSrcChainId, setOutputToken, setModal } = useDepositStore(
+  const { setSrcChainId, setPrincipalToken, setModal } = useDepositStore(
     useShallow(state => ({
       setSrcChainId: state.setSrcChainId,
-      setOutputToken: state.setOutputToken,
+      setPrincipalToken: state.setPrincipalToken,
       setModal: state.setModal,
     })),
   );
@@ -84,10 +84,10 @@ const SavingsDepositTokenSelector: React.FC = () => {
         : undefined;
 
       setSrcChainId(chainId);
-      setOutputToken(tokenKey || symbol);
+      setPrincipalToken(tokenKey || symbol);
       setModal(DEPOSIT_MODAL.OPEN_FORM);
     },
-    [setSrcChainId, setOutputToken, setModal, selectVaultForDeposit],
+    [setSrcChainId, setPrincipalToken, setModal, selectVaultForDeposit],
   );
 
   return (

--- a/hooks/useDepositOption.tsx
+++ b/hooks/useDepositOption.tsx
@@ -11,12 +11,12 @@ import { KycModalContent } from '@/components/BankTransfer/KycModalContent';
 import BuyCrypto from '@/components/BuyCrypto';
 import DepositEmailModal from '@/components/DepositEmailModal';
 import DepositNetworks from '@/components/DepositNetwork/DepositNetworks';
+import AddFundsToWalletForm from '@/components/DepositOption/AddFundsToWalletForm';
 import DepositBuyCryptoOptions from '@/components/DepositOption/DepositBuyCryptoOptions';
 import DepositDirectlyAddress from '@/components/DepositOption/DepositDirectlyAddress';
 import DepositDirectlyNetworks from '@/components/DepositOption/DepositDirectlyNetworks';
 import DepositDirectlyTokens from '@/components/DepositOption/DepositDirectlyTokens';
 import DepositExternalWalletOptions from '@/components/DepositOption/DepositExternalWalletOptions';
-import AddFundsToWalletForm from '@/components/DepositOption/AddFundsToWalletForm';
 import DepositOptions from '@/components/DepositOption/DepositOptions';
 import DepositPublicAddress from '@/components/DepositOption/DepositPublicAddress';
 import { DepositTokenSelector, DepositToVaultForm } from '@/components/DepositToVault';
@@ -32,7 +32,11 @@ import useUser from '@/hooks/useUser';
 import { track } from '@/lib/analytics';
 import getTokenIcon from '@/lib/getTokenIcon';
 import { DepositModal } from '@/lib/types';
-import { getAllowedTokensForChain, getDefaultDepositSelection, getVaultDepositConfig } from '@/lib/vaults';
+import {
+  getAllowedTokensForChain,
+  getDefaultDepositSelection,
+  getVaultDepositConfig,
+} from '@/lib/vaults';
 import { useDepositStore } from '@/store/useDepositStore';
 
 import useResponsiveModal from './useResponsiveModal';
@@ -56,14 +60,14 @@ const useDepositOption = ({
     transaction,
     setModal,
     srcChainId,
-    outputToken,
+    principalToken,
     bankTransfer,
     directDepositSession,
     sessionStartTime,
     setSessionStartTime,
     clearSessionStartTime,
     setSrcChainId,
-    setOutputToken,
+    setPrincipalToken,
     setDirectDepositSession,
     resetDepositFlow,
     depositFromSolid,
@@ -75,14 +79,14 @@ const useDepositOption = ({
       transaction: state.transaction,
       setModal: state.setModal,
       srcChainId: state.srcChainId,
-      outputToken: state.outputToken,
+      principalToken: state.principalToken,
       bankTransfer: state.bankTransfer,
       directDepositSession: state.directDepositSession,
       sessionStartTime: state.sessionStartTime,
       setSessionStartTime: state.setSessionStartTime,
       clearSessionStartTime: state.clearSessionStartTime,
       setSrcChainId: state.setSrcChainId,
-      setOutputToken: state.setOutputToken,
+      setPrincipalToken: state.setPrincipalToken,
       setDirectDepositSession: state.setDirectDepositSession,
       resetDepositFlow: state.resetDepositFlow,
       depositFromSolid: state.depositFromSolid,
@@ -191,8 +195,8 @@ const useDepositOption = ({
           }
           amount={transaction.amount ?? 0}
           onPress={handleTransactionStatusPress}
-          icon={getTokenIcon({ tokenSymbol: outputToken })}
-          token={outputToken}
+          icon={getTokenIcon({ tokenSymbol: principalToken })}
+          token={principalToken}
         />
       );
     }
@@ -416,20 +420,20 @@ const useDepositOption = ({
     }
 
     if (value) {
-      const { chainId: defaultChainId, outputToken: defaultToken } =
+      const { chainId: defaultChainId, principalToken: defaultToken } =
         getDefaultDepositSelection();
       const supportedChains = depositConfig.supportedChains;
       // When srcChainId is 0 (unset), don't auto-sync so user sees options/networks to pick
       const nextChainId =
         srcChainId && supportedChains.includes(srcChainId) ? srcChainId : defaultChainId;
       const allowedTokens = getAllowedTokensForChain(nextChainId);
-      const nextToken = allowedTokens.includes(outputToken) ? outputToken : defaultToken;
+      const nextToken = allowedTokens.includes(principalToken) ? principalToken : defaultToken;
 
       if (srcChainId && nextChainId !== srcChainId) {
         setSrcChainId(nextChainId);
       }
-      if (nextToken !== outputToken) {
-        setOutputToken(nextToken);
+      if (nextToken !== principalToken) {
+        setPrincipalToken(nextToken);
       }
 
       const directChainId =

--- a/lib/vaults.ts
+++ b/lib/vaults.ts
@@ -43,7 +43,7 @@ export const getDefaultDepositSelection = (vault?: Vault) => {
     supportedChains.find(id => getAllowedTokensForChain(id, vault).length > 0) ??
     supportedChains[0];
   const allowedTokens = chainId ? getAllowedTokensForChain(chainId, vault) : [];
-  const outputToken = allowedTokens[0] ?? 'USDC';
+  const principalToken = allowedTokens[0] ?? 'USDC';
 
-  return { chainId, outputToken };
+  return { chainId, principalToken };
 };

--- a/store/useDepositStore.ts
+++ b/store/useDepositStore.ts
@@ -62,7 +62,7 @@ interface DepositState {
   previousModal: DepositModal;
   transaction: TransactionStatusModal;
   srcChainId: number;
-  outputToken: string;
+  principalToken: string;
   bankTransfer: BankTransferData;
   kyc: KycData;
   directDepositSession: DirectDepositSession;
@@ -76,7 +76,7 @@ interface DepositState {
   setKycData: (data: Partial<KycData>) => void;
   clearKycData: () => void;
   setSrcChainId: (srcChainId: number) => void;
-  setOutputToken: (token: string) => void;
+  setPrincipalToken: (token: string) => void;
   setDirectDepositSession: (data: Partial<DirectDepositSession>) => void;
   clearDirectDepositSession: () => void;
   setSessionStartTime: (time: number) => void;
@@ -91,7 +91,7 @@ export const useDepositStore = create<DepositState>()(
       previousModal: DEPOSIT_MODAL.CLOSE,
       transaction: {},
       srcChainId: mainnet.id,
-      outputToken: 'USDC',
+      principalToken: 'USDC',
       bankTransfer: {},
       kyc: {},
       directDepositSession: {},
@@ -112,7 +112,7 @@ export const useDepositStore = create<DepositState>()(
       setKycData: data => set({ kyc: { ...get().kyc, ...data } }),
       clearKycData: () => set({ kyc: {} }),
       setSrcChainId: srcChainId => set({ srcChainId }),
-      setOutputToken: outputToken => set({ outputToken }),
+      setPrincipalToken: principalToken => set({ principalToken }),
       setDirectDepositSession: data =>
         set({ directDepositSession: { ...get().directDepositSession, ...data } }),
       clearDirectDepositSession: () => set({ directDepositSession: {} }),
@@ -124,7 +124,7 @@ export const useDepositStore = create<DepositState>()(
           previousModal: DEPOSIT_MODAL.CLOSE,
           transaction: {},
           srcChainId: 0, // unset so next open shows options
-          outputToken: 'USDC',
+          principalToken: 'USDC',
           bankTransfer: {},
           kyc: {},
           directDepositSession: {},
@@ -139,14 +139,21 @@ export const useDepositStore = create<DepositState>()(
       partialize: state => ({
         transaction: state.transaction,
         srcChainId: state.srcChainId,
-        outputToken: state.outputToken,
+        principalToken: state.principalToken,
         bankTransfer: state.bankTransfer,
         kyc: state.kyc,
         directDepositSession: state.directDepositSession,
       }),
       // Ignore any legacy stored modal fields
       merge: (persisted, current) => {
-        const next = { ...current, ...(persisted as any) };
+        const persistedState = (persisted as any) || {};
+        const legacyPrincipalToken = persistedState.principalToken ?? persistedState.outputToken;
+        const { outputToken: _legacyOutputToken, ...restPersisted } = persistedState;
+        const next = {
+          ...current,
+          ...restPersisted,
+          principalToken: legacyPrincipalToken ?? current.principalToken,
+        };
         return {
           ...next,
           currentModal: current.currentModal,

--- a/store/useDepositStore.ts
+++ b/store/useDepositStore.ts
@@ -91,7 +91,7 @@ export const useDepositStore = create<DepositState>()(
       previousModal: DEPOSIT_MODAL.CLOSE,
       transaction: {},
       srcChainId: mainnet.id,
-      outputToken: 'soUSD',
+      outputToken: 'USDC',
       bankTransfer: {},
       kyc: {},
       directDepositSession: {},
@@ -124,7 +124,7 @@ export const useDepositStore = create<DepositState>()(
           previousModal: DEPOSIT_MODAL.CLOSE,
           transaction: {},
           srcChainId: 0, // unset so next open shows options
-          outputToken: 'soUSD',
+          outputToken: 'USDC',
           bankTransfer: {},
           kyc: {},
           directDepositSession: {},


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- normalize deposit form selection to a vault-compatible `(srcChainId, principalToken)` pair before rendering
- auto-correct persisted/stale token state when it doesn't belong to the selected vault, preventing invalid combinations like `soFUSE = soUSD`
- initialize and reset deposit flow principal token to `USDC` instead of vault token `soUSD`
- rename deposit store state from `outputToken` to `principalToken` across the deposit modal flow for semantic clarity
- add persisted-state backward compatibility so legacy `outputToken` values are migrated to `principalToken`

## Validation
- `npx prettier --write "store/useDepositStore.ts" "lib/vaults.ts" "components/DepositToVault/DepositToVaultForm.tsx" "components/DepositOption/AddFundsToWalletForm.tsx" "components/DepositNetwork/DepositNetworks.tsx" "components/DepositToVault/DepositTokenSelector/DepositTokenSelector.web.tsx" "components/DepositToVault/DepositTokenSelector/DepositTokenSelector.native.tsx" "components/DepositToVault/SavingsDepositTokenSelector.tsx" "hooks/useDepositOption.tsx"`
- `npx eslint "store/useDepositStore.ts" "lib/vaults.ts" "components/DepositToVault/DepositToVaultForm.tsx" "components/DepositOption/AddFundsToWalletForm.tsx" "components/DepositNetwork/DepositNetworks.tsx" "components/DepositToVault/DepositTokenSelector/DepositTokenSelector.web.tsx" "components/DepositToVault/DepositTokenSelector/DepositTokenSelector.native.tsx" "components/DepositToVault/SavingsDepositTokenSelector.tsx" "hooks/useDepositOption.tsx"`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5fa05309-2c9f-4747-aec8-41e5a5e7db12"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5fa05309-2c9f-4747-aec8-41e5a5e7db12"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

