### PR TITLE
Restore missing checkCardAccess API helper

### DIFF
--- a/lib/api.ts
+++ b/lib/api.ts
@@ -888,6 +888,24 @@ export const addToCardWaitlistToNotify = async (
   return response.json();
 };
 
+export const checkCardAccess = async (countryCode: string): Promise<CardAccessResponse> => {
+  const jwt = getJWTToken();
+  const url = new URL('/accounts/v1/cards/check-access', EXPO_PUBLIC_FLASH_API_BASE_URL);
+  url.searchParams.append('countryCode', countryCode.toUpperCase());
+
+  const response = await fetch(url.toString(), {
+    credentials: 'include',
+    headers: {
+      ...getPlatformHeaders(),
+      ...(jwt ? { Authorization: `Bearer ${jwt}` } : {}),
+    },
+  });
+
+  if (!response.ok) throw response;
+
+  return response.json();
+};
+
 export const checkCardWaitlistStatus = async (email: string): Promise<CardWaitlistResponse> => {
   const response = await fetch(
     `${EXPO_PUBLIC_FLASH_API_BASE_URL}/accounts/v1/card-waitlist/check?email=${encodeURIComponent(email)}`,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- restores `checkCardAccess(countryCode)` in `lib/api.ts`
- uses existing expected endpoint: `GET /accounts/v1/cards/check-access?countryCode=...`
- returns `CardAccessResponse` and includes platform/auth headers via existing helpers

## Why
- multiple screens/hooks import and call `checkCardAccess` (`card-onboard`, `card/activate`, `ReserveCardButton`, `useCountryCheck`, and KYC helpers)
- the helper was missing from `lib/api.ts`, creating a broken import/runtime path
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-03378508-4bf9-477d-8c69-5c654068fff4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-03378508-4bf9-477d-8c69-5c654068fff4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

