### PR TITLE
Restore missing card helpers and gate test users after country check

### DIFF
--- a/app/(protected)/(tabs)/card-onboard/country_selection.tsx
+++ b/app/(protected)/(tabs)/card-onboard/country_selection.tsx
@@ -1,5 +1,13 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import { ActivityIndicator, Linking, Modal, Pressable, ScrollView, TextInput, View } from 'react-native';
+import {
+  ActivityIndicator,
+  Linking,
+  Modal,
+  Pressable,
+  ScrollView,
+  TextInput,
+  View,
+} from 'react-native';
 import { useRouter } from 'expo-router';
 import { ArrowLeft, ChevronDown } from 'lucide-react-native';
 import { useShallow } from 'zustand/react/shallow';
@@ -21,6 +29,7 @@ import {
   getCountryFromIp,
 } from '@/lib/api';
 import { withRefreshToken } from '@/lib/utils';
+import { isUserAllowedToUseTestFeature } from '@/lib/utils/testFeatures';
 import { useCountryStore } from '@/store/useCountryStore';
 
 export default function CountrySelection() {
@@ -68,11 +77,13 @@ export default function CountrySelection() {
       // Check card access via backend
       const accessCheck = await withRefreshToken(() => checkCardAccess(countryCode));
       if (!accessCheck) throw new Error('Failed to check card access');
+      const canAccessCard =
+        accessCheck.hasAccess && isUserAllowedToUseTestFeature(user?.username ?? '');
 
       return {
         countryCode,
         countryName,
-        isAvailable: accessCheck.hasAccess,
+        isAvailable: canAccessCard,
       };
     } catch (error) {
       console.error('Error fetching country from IP:', error);
@@ -246,18 +257,20 @@ export default function CountrySelection() {
         const accessCheck = await withRefreshToken(() => checkCardAccess(selectedCountry.code));
 
         if (!accessCheck) throw new Error('Failed to check card access');
+        const canAccessCard =
+          accessCheck.hasAccess && isUserAllowedToUseTestFeature(user?.username ?? '');
 
         const updatedCountryInfo = {
           countryCode: selectedCountry.code,
           countryName: selectedCountry.name,
-          isAvailable: accessCheck.hasAccess,
+          isAvailable: canAccessCard,
           source: 'manual' as const,
         };
 
         setCountryInfo(updatedCountryInfo);
         setCountryDetectionFailed(false);
 
-        if (accessCheck.hasAccess) {
+        if (canAccessCard) {
           router.push({
             pathname: '/card/activate',
             params: { countryConfirmed: 'true' },
@@ -535,7 +548,7 @@ function CountryUnavailableView({
           className="font-bold leading-6 text-white"
           onPress={() =>
             Linking.openURL(
-              'https://www.solid.xyz/post/solid-partners-with-rain-to-power-the-next-era-of-global-crypto-cards'
+              'https://www.solid.xyz/post/solid-partners-with-rain-to-power-the-next-era-of-global-crypto-cards',
             )
           }
           accessibilityRole="link"

--- a/app/(protected)/(tabs)/card/activate/country_selection.tsx
+++ b/app/(protected)/(tabs)/card/activate/country_selection.tsx
@@ -14,10 +14,17 @@ import { TRACKING_EVENTS } from '@/constants/tracking-events';
 import { track } from '@/lib/analytics';
 import { checkCardAccess, getClientIp, getCountryFromIp } from '@/lib/api';
 import { withRefreshToken } from '@/lib/utils';
+import { isUserAllowedToUseTestFeature } from '@/lib/utils/testFeatures';
 import { useCountryStore } from '@/store/useCountryStore';
+import { useUserStore } from '@/store/useUserStore';
 
 export default function ActivateCountrySelection() {
   const router = useRouter();
+  const { user } = useUserStore(
+    useShallow(state => ({
+      user: state.users.find(user => user.selected),
+    })),
+  );
 
   const goBack = () => {
     router.replace(path.CARD);
@@ -187,10 +194,13 @@ export default function ActivateCountrySelection() {
 
         if (!accessCheck) throw new Error('Failed to check card access');
 
+        const isUserAllowed = isUserAllowedToUseTestFeature(user?.username ?? '');
+        const canProceed = accessCheck.hasAccess && isUserAllowed;
+
         const updatedCountryInfo = {
           countryCode: selectedCountry.code,
           countryName: selectedCountry.name,
-          isAvailable: accessCheck.hasAccess,
+          isAvailable: canProceed,
         };
 
         setCountryInfo(updatedCountryInfo);
@@ -199,11 +209,11 @@ export default function ActivateCountrySelection() {
         track(TRACKING_EVENTS.CARD_COUNTRY_AVAILABILITY_CHECKED, {
           countryCode: selectedCountry.code,
           countryName: selectedCountry.name,
-          isAvailable: accessCheck.hasAccess,
+          isAvailable: canProceed,
           selectionMethod: selectionMethod === 'ip_detected' ? 'ip_detected' : 'manual',
         });
 
-        if (accessCheck.hasAccess) {
+        if (canProceed) {
           const ipCountry = await getCountryFromIp();
           if (ipCountry && ipCountry.countryCode === selectedCountry.code) {
             router.replace(path.CARD_ACTIVATE);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- restore missing `checkCardAccess(countryCode)` helper in `lib/api.ts`
- restore missing `fetchLayerZeroBridgeTransactions(transactionHash)` helper in `lib/api.ts`
- add post-country-check gating so users must also pass `isUserAllowedToUseTestFeature(user.username)` to proceed

## Behavior change
After country selection, moving forward now requires **both**:
- `checkCardAccess(...).hasAccess === true`
- `isUserAllowedToUseTestFeature(user?.username ?? '') === true`

If either fails, the flow marks country as unavailable and keeps users on the existing "coming soon / notify" messaging path.

## Why
- both API helpers were dropped during merge history drift
- `checkCardAccess` is used by card country-selection/waitlist paths
- `fetchLayerZeroBridgeTransactions` is imported and used by `hooks/useAnalytics.ts`
- requirement: only allow listed test users to proceed beyond country selection

## Endpoints
- `GET /accounts/v1/cards/check-access?countryCode=...`
- `GET https://scan.layerzero-api.com/v1/messages/tx/{transactionHash}`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-03378508-4bf9-477d-8c69-5c654068fff4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-03378508-4bf9-477d-8c69-5c654068fff4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

