### PR TITLE
Fix KYC redirect logic to show activate page when Rain not approved

### DIFF
--- a/components/kyc/useDiditSession.ts
+++ b/components/kyc/useDiditSession.ts
@@ -70,7 +70,9 @@ export function useDiditSession() {
       queryClient.invalidateQueries({ queryKey: [CARD_STATUS_QUERY_KEY] });
 
       if (kycStatus === KycStatus.APPROVED) {
-        // KYC approved: check Rain application status for correct redirect
+        // Didit KYC approved: only go to ready page when Rain is also approved.
+        // Otherwise redirect to activate page so the user sees the dynamic
+        // step-one button (e.g. "Provide more info" for Rain needsInformation).
         try {
           const cardStatusResponse = await withRefreshToken(() => getCardStatus());
           if (cardStatusResponse?.rainApplicationStatus === RainApplicationStatus.APPROVED) {
@@ -78,9 +80,9 @@ export function useDiditSession() {
             return;
           }
         } catch {
-          // Fall through to ready page on approved KYC
+          // On error fall through to activate page as a safe default
         }
-        router.replace(path.CARD_READY as any);
+        router.replace(path.CARD_ACTIVATE as any);
       } else if (kycStatus === KycStatus.UNDER_REVIEW) {
         router.replace(path.CARD_PENDING as any);
       } else {


### PR DESCRIPTION
## Summary
Updated the KYC session redirect logic to properly handle cases where Didit KYC is approved but the Rain application is not yet approved. Users are now redirected to the activate page instead of the ready page, allowing them to see dynamic step-one buttons (e.g., "Provide more info" for Rain needsInformation status).

## Key Changes
- Changed the fallback redirect from `CARD_READY` to `CARD_ACTIVATE` when Didit KYC is approved but Rain application status cannot be verified
- Updated comments to clarify the redirect logic: only proceed to ready page when both Didit KYC and Rain application are approved
- Improved error handling to safely default to the activate page instead of prematurely showing the ready page

## Implementation Details
- The activate page now serves as the safe default when Rain application status is unknown or not approved
- This ensures users see appropriate action items (like "Provide more info") rather than being shown a ready state prematurely
- The change maintains the existing flow when both KYC and Rain application are fully approved

https://claude.ai/code/session_01LnsDaCsxy56ZcmsFaEZKJ7