### PR TITLE
fix: redirect to /card/activate when Rain KYC is not approved after Didit completion

### DIFF
--- a/components/kyc/useDiditSession.ts
+++ b/components/kyc/useDiditSession.ts
@@ -70,7 +70,9 @@ export function useDiditSession() {
       queryClient.invalidateQueries({ queryKey: [CARD_STATUS_QUERY_KEY] });
 
       if (kycStatus === KycStatus.APPROVED) {
-        // KYC approved: check Rain application status for correct redirect
+        // Didit KYC approved: only go to ready page when Rain is also approved.
+        // Otherwise redirect to activate page so the user sees the dynamic
+        // step-one button (e.g. "Provide more info" for Rain needsInformation).
         try {
           const cardStatusResponse = await withRefreshToken(() => getCardStatus());
           if (cardStatusResponse?.rainApplicationStatus === RainApplicationStatus.APPROVED) {
@@ -78,9 +80,9 @@ export function useDiditSession() {
             return;
           }
         } catch {
-          // Fall through to ready page on approved KYC
+          // On error fall through to activate page as a safe default
         }
-        router.replace(path.CARD_READY as any);
+        router.replace(path.CARD_ACTIVATE as any);
       } else if (kycStatus === KycStatus.UNDER_REVIEW) {
         router.replace(path.CARD_PENDING as any);
       } else {


### PR DESCRIPTION
## Summary

- **Fix incorrect redirect after Didit KYC completion**: Previously, completing Didit KYC always redirected to `/card/ready` even when Rain KYC was not yet approved (e.g. `needsInformation`, `needsVerification`, `pending`). Now only redirects to `/card/ready` when both Didit and Rain KYC are approved.
- **Redirect to `/card/activate` for non-approved Rain states**: The activate page already polls card status every 3s and renders a dynamic step-one button (e.g. "Provide more info" for `needsInformation`/`needsVerification`, or "Contact support" for `denied`/`locked`/`canceled`).
- **Safe fallback on API errors**: If the card status check fails, redirect to `/card/activate` instead of `/card/ready`.

## Test plan

- [ ] Complete Didit KYC where Rain approves immediately → should redirect to `/card/ready`
- [ ] Complete Didit KYC where Rain returns `needsInformation` or `needsVerification` → should redirect to `/card/activate` with dynamic button in step one
- [ ] Complete Didit KYC where Rain is still `pending` → should redirect to `/card/activate`
- [ ] Simulate card status API failure after Didit approval → should redirect to `/card/activate`
- [ ] Verify no regressions for `under_review` (→ `/card/pending`) and other statuses (→ `/card/activate?kycStatus=...`)

https://claude.ai/code/session_01LnsDaCsxy56ZcmsFaEZKJ7