### PR TITLE
Use platform-specific height overrides for toast close button

### DIFF
--- a/components/Toast.tsx
+++ b/components/Toast.tsx
@@ -62,7 +62,7 @@ const BaseToast = ({ text1, text2, classNames, props }: IBaseToast) => {
       <Button
         onPress={() => Toast.hide()}
         variant="ghost"
-        className="!h-full rounded-l-none rounded-r-2xl border-l border-primary/10 px-4 text-accent-foreground web:hover:border-accent"
+        className="native:!h-full web:!h-auto rounded-l-none rounded-r-2xl border-l border-primary/10 px-4 text-accent-foreground web:hover:border-accent"
       >
         <X color="white" />
       </Button>


### PR DESCRIPTION
h-auto works on web (lets flex stretch apply) but not native. h-full works on native but breaks web layout. Use native:!h-full and web:!h-auto to handle both platforms correctly.

https://claude.ai/code/session_01QhMD9PevR5HwX1uWbUqShv