### PR TITLE
Add mul53 to test features whitelist for Rain card

### DIFF
--- a/lib/utils/testFeatures.ts
+++ b/lib/utils/testFeatures.ts
@@ -6,6 +6,7 @@ export const TEST_FEATURES_ALLOW_LIST = [
   'LukaFuse',
   'Test',
   'InternSolid22',
+  'mul53',
 ];
 
 export const isUserAllowedToUseTestFeature = (username: string) => {


### PR DESCRIPTION
## Summary
- Adds username `mul53` to `TEST_FEATURES_ALLOW_LIST` in `lib/utils/testFeatures.ts` to enable Rain card testing

## Test plan
- [ ] Verify `mul53` user can access Rain card test features
- [ ] Verify existing whitelisted users are unaffected

https://claude.ai/code/session_01TRzaVGtJGWwykXz6ML3j6P