### PR TITLE
Enable Rain card testing for all users

### DIFF
--- a/app/(protected)/(tabs)/card-onboard/country_selection.tsx
+++ b/app/(protected)/(tabs)/card-onboard/country_selection.tsx
@@ -29,7 +29,6 @@ import {
   getCountryFromIp,
 } from '@/lib/api';
 import { withRefreshToken } from '@/lib/utils';
-import { isUserAllowedToUseTestFeature } from '@/lib/utils/testFeatures';
 import { useCountryStore } from '@/store/useCountryStore';
 
 export default function CountrySelection() {
@@ -77,13 +76,10 @@ export default function CountrySelection() {
       // Check card access via backend
       const accessCheck = await withRefreshToken(() => checkCardAccess(countryCode));
       if (!accessCheck) throw new Error('Failed to check card access');
-      const canAccessCard =
-        accessCheck.hasAccess && isUserAllowedToUseTestFeature(user?.username ?? '');
-
       return {
         countryCode,
         countryName,
-        isAvailable: canAccessCard,
+        isAvailable: accessCheck.hasAccess,
       };
     } catch (error) {
       console.error('Error fetching country from IP:', error);
@@ -257,20 +253,18 @@ export default function CountrySelection() {
         const accessCheck = await withRefreshToken(() => checkCardAccess(selectedCountry.code));
 
         if (!accessCheck) throw new Error('Failed to check card access');
-        const canAccessCard =
-          accessCheck.hasAccess && isUserAllowedToUseTestFeature(user?.username ?? '');
 
         const updatedCountryInfo = {
           countryCode: selectedCountry.code,
           countryName: selectedCountry.name,
-          isAvailable: canAccessCard,
+          isAvailable: accessCheck.hasAccess,
           source: 'manual' as const,
         };
 
         setCountryInfo(updatedCountryInfo);
         setCountryDetectionFailed(false);
 
-        if (canAccessCard) {
+        if (accessCheck.hasAccess) {
           router.push({
             pathname: '/card/activate',
             params: { countryConfirmed: 'true' },

--- a/app/(protected)/(tabs)/card/activate/country_selection.tsx
+++ b/app/(protected)/(tabs)/card/activate/country_selection.tsx
@@ -14,7 +14,6 @@ import { TRACKING_EVENTS } from '@/constants/tracking-events';
 import { track } from '@/lib/analytics';
 import { checkCardAccess, getClientIp, getCountryFromIp } from '@/lib/api';
 import { withRefreshToken } from '@/lib/utils';
-import { isUserAllowedToUseTestFeature } from '@/lib/utils/testFeatures';
 import { useCountryStore } from '@/store/useCountryStore';
 import { useUserStore } from '@/store/useUserStore';
 
@@ -194,13 +193,10 @@ export default function ActivateCountrySelection() {
 
         if (!accessCheck) throw new Error('Failed to check card access');
 
-        const isUserAllowed = isUserAllowedToUseTestFeature(user?.username ?? '');
-        const canProceed = accessCheck.hasAccess && isUserAllowed;
-
         const updatedCountryInfo = {
           countryCode: selectedCountry.code,
           countryName: selectedCountry.name,
-          isAvailable: canProceed,
+          isAvailable: accessCheck.hasAccess,
         };
 
         setCountryInfo(updatedCountryInfo);
@@ -209,11 +205,11 @@ export default function ActivateCountrySelection() {
         track(TRACKING_EVENTS.CARD_COUNTRY_AVAILABILITY_CHECKED, {
           countryCode: selectedCountry.code,
           countryName: selectedCountry.name,
-          isAvailable: canProceed,
+          isAvailable: accessCheck.hasAccess,
           selectionMethod: selectionMethod === 'ip_detected' ? 'ip_detected' : 'manual',
         });
 
-        if (canProceed) {
+        if (accessCheck.hasAccess) {
           const ipCountry = await getCountryFromIp();
           if (ipCountry && ipCountry.countryCode === selectedCountry.code) {
             router.replace(path.CARD_ACTIVATE);

--- a/hooks/useCardWithdrawAllowed.ts
+++ b/hooks/useCardWithdrawAllowed.ts
@@ -1,7 +1,3 @@
-import useUser from '@/hooks/useUser';
-import { isUserAllowedToUseTestFeature } from '@/lib/utils/testFeatures';
-
 export const useCardWithdrawAllowed = (): boolean => {
-  const { user } = useUser();
-  return isUserAllowedToUseTestFeature(user?.username ?? '');
+  return true;
 };

--- a/hooks/useCardWithdrawAllowed.ts
+++ b/hooks/useCardWithdrawAllowed.ts
@@ -1,3 +1,0 @@
-export const useCardWithdrawAllowed = (): boolean => {
-  return true;
-};


### PR DESCRIPTION
## Summary
- Remove hardcoded username whitelist (`TEST_FEATURES_ALLOW_LIST`) gate from Rain card onboarding, activation, and withdraw flows
- Card access now relies solely on the backend `checkCardAccess` response instead of requiring both backend access AND whitelist membership
- Delete unused `useCardWithdrawAllowed` hook

Cherry-picked from qa merge commit (PR #1925).

## Test plan
- [ ] Verify a non-whitelisted user can proceed through card onboarding country selection
- [ ] Verify a non-whitelisted user can proceed through card activation country selection
- [ ] Verify backend `checkCardAccess` still correctly gates access by country

https://claude.ai/code/session_0175xemWqTv9ZPJdEqReBkYU