### PR TITLE
Remove unused isWithdrawAllowed prop from CardDetails

### DIFF
--- a/app/(protected)/(tabs)/card/details.tsx
+++ b/app/(protected)/(tabs)/card/details.tsx
@@ -221,7 +221,6 @@ export default function CardDetails() {
             isLoadingCardDetails={isLoadingCardDetails}
             onCardDetails={handleCardFlip}
             onFreezeToggle={handleFreezeToggle}
-            isWithdrawAllowed={isWithdrawAllowed}
             isWithdrawFromCardAllowed={isWithdrawFromCardAllowed}
             isRain={provider === CardProvider.RAIN}
           />


### PR DESCRIPTION
## Summary
Removed the unused `isWithdrawAllowed` prop that was being passed to a child component in the CardDetails screen.

## Changes
- Removed `isWithdrawAllowed={isWithdrawAllowed}` prop from the component rendering in `CardDetails.tsx`
- The prop was not being utilized by the receiving component, making this a cleanup of dead code

## Details
This change simplifies the component interface by removing an unnecessary prop that was being passed but not consumed. The related `isWithdrawFromCardAllowed` prop remains as it is actively used.

https://claude.ai/code/session_01UUYvaUWKzQgKCbRAdpQu7v