### PR TITLE
fix: remove unused isWithdrawAllowed prop

### DIFF
--- a/app/(protected)/(tabs)/card/details.tsx
+++ b/app/(protected)/(tabs)/card/details.tsx
@@ -221,7 +221,6 @@ export default function CardDetails() {
             isLoadingCardDetails={isLoadingCardDetails}
             onCardDetails={handleCardFlip}
             onFreezeToggle={handleFreezeToggle}
-            isWithdrawAllowed={isWithdrawAllowed}
             isWithdrawFromCardAllowed={isWithdrawFromCardAllowed}
             isRain={provider === CardProvider.RAIN}
           />


### PR DESCRIPTION
## Summary\n- Cherry-pick of #1933 from qa to master\n- Removes the undefined `isWithdrawAllowed` prop passed to `<CardActions>` in `card/details.tsx` that was causing the runtime error: *\"Property 'isWithdrawAllowed' doesn't exist\"*\n- The prop was never defined in the component, never in the `CardActionsProps` interface, and never existed in the backend. The actual withdraw logic uses `isWithdrawFromCardAllowed` instead.\n\n## Test plan\n- [ ] Verify the card details screen loads without the \"Property 'isWithdrawAllowed' doesn't exist\" error\n- [ ] Verify withdraw-from-card functionality still works correctly (controlled by `isWithdrawFromCardAllowed`)\n\nhttps://claude.ai/code/session_01UUYvaUWKzQgKCbRAdpQu7v