### PR TITLE
feat: add Order Physical Card button and modal to card details page

### DIFF
--- a/app/(protected)/(tabs)/card/details.tsx
+++ b/app/(protected)/(tabs)/card/details.tsx
@@ -29,6 +29,7 @@ import { BorrowPositionCard } from '@/components/Card/BorrowPositionCard';
 import { CircularActionButton } from '@/components/Card/CircularActionButton';
 import DepositToCardModal from '@/components/Card/DepositToCardModal';
 import ManagePinModal from '@/components/Card/ManagePinModal';
+import CancelPhysicalCardModal from '@/components/Card/CancelPhysicalCardModal';
 import OrderPhysicalCardModal, {
   PHYSICAL_CARD_STATUS_QUERY_KEY,
 } from '@/components/Card/OrderPhysicalCardModal';
@@ -72,6 +73,7 @@ export default function CardDetails() {
   const [shouldRevealDetails, setShouldRevealDetails] = useState(false);
   const [isAddToWalletModalOpen, setIsAddToWalletModalOpen] = useState(false);
   const [isOrderPhysicalCardModalOpen, setIsOrderPhysicalCardModalOpen] = useState(false);
+  const [isCancelPhysicalCardModalOpen, setIsCancelPhysicalCardModalOpen] = useState(false);
   const flipAnimation = useRef(new Animated.Value(0)).current;
 
   const { data: physicalCardStatusData } = useQuery({
@@ -157,7 +159,11 @@ export default function CardDetails() {
         isWithdrawFromCardAllowed={isWithdrawFromCardAllowed}
         isRain={provider === CardProvider.RAIN}
         hasPhysicalCard={hasPhysicalCard}
-        onOrderPhysicalCardModalChange={setIsOrderPhysicalCardModalOpen}
+        onPhysicalCardPress={() =>
+          hasPhysicalCard
+            ? setIsCancelPhysicalCardModalOpen(true)
+            : setIsOrderPhysicalCardModalOpen(true)
+        }
       />
     </View>
   ) : (
@@ -221,6 +227,11 @@ export default function CardDetails() {
           onOpenChange={setIsOrderPhysicalCardModalOpen}
           trigger={null}
         />
+        <CancelPhysicalCardModal
+          isOpen={isCancelPhysicalCardModalOpen}
+          onOpenChange={setIsCancelPhysicalCardModalOpen}
+          trigger={null}
+        />
       </PageLayout>
     );
   }
@@ -253,7 +264,11 @@ export default function CardDetails() {
             isWithdrawFromCardAllowed={isWithdrawFromCardAllowed}
             isRain={provider === CardProvider.RAIN}
             hasPhysicalCard={hasPhysicalCard}
-            onOrderPhysicalCard={() => setIsOrderPhysicalCardModalOpen(true)}
+            onPhysicalCardPress={() =>
+              hasPhysicalCard
+                ? setIsCancelPhysicalCardModalOpen(true)
+                : setIsOrderPhysicalCardModalOpen(true)
+            }
           />
           <BorrowPositionCard className="mb-4" />
           <DepositBonusBanner />
@@ -272,6 +287,11 @@ export default function CardDetails() {
       <OrderPhysicalCardModal
         isOpen={isOrderPhysicalCardModalOpen}
         onOpenChange={setIsOrderPhysicalCardModalOpen}
+        trigger={null}
+      />
+      <CancelPhysicalCardModal
+        isOpen={isCancelPhysicalCardModalOpen}
+        onOpenChange={setIsCancelPhysicalCardModalOpen}
         trigger={null}
       />
     </PageLayout>
@@ -293,7 +313,7 @@ interface DesktopHeaderProps {
   isWithdrawFromCardAllowed: boolean;
   isRain: boolean;
   hasPhysicalCard: boolean;
-  onOrderPhysicalCardModalChange: (open: boolean) => void;
+  onPhysicalCardPress: () => void;
 }
 
 function DesktopHeader({
@@ -307,7 +327,7 @@ function DesktopHeader({
   isWithdrawFromCardAllowed,
   isRain,
   hasPhysicalCard,
-  onOrderPhysicalCardModalChange,
+  onPhysicalCardPress,
 }: DesktopHeaderProps) {
   const [isManageOpen, setIsManageOpen] = useState(false);
   const manageRef = useRef<View>(null);
@@ -415,7 +435,7 @@ function DesktopHeader({
           <Button
             variant="secondary"
             className={`h-12 rounded-xl border-0 px-6 ${hasPhysicalCard ? 'bg-red-500/20' : 'bg-[#303030]'}`}
-            onPress={() => onOrderPhysicalCardModalChange(true)}
+            onPress={onPhysicalCardPress}
           >
             <View className="flex-row items-center gap-2">
               <CreditCard size={18} color={hasPhysicalCard ? '#ef4444' : 'white'} />
@@ -837,7 +857,7 @@ interface CardActionsProps {
   isWithdrawFromCardAllowed: boolean;
   isRain: boolean;
   hasPhysicalCard: boolean;
-  onOrderPhysicalCard: () => void;
+  onPhysicalCardPress: () => void;
 }
 
 function CardActions({
@@ -851,7 +871,7 @@ function CardActions({
   isWithdrawFromCardAllowed,
   isRain,
   hasPhysicalCard,
-  onOrderPhysicalCard,
+  onPhysicalCardPress,
 }: CardActionsProps) {
   const [isManageSheetOpen, setIsManageSheetOpen] = useState(false);
   const showManageButton = isRain || !isCardFrozen || canUnfreeze;
@@ -946,7 +966,7 @@ function CardActions({
       {isRain && (
         <View className="flex-1 items-center">
           <Pressable
-            onPress={onOrderPhysicalCard}
+            onPress={onPhysicalCardPress}
             className={`items-center justify-center rounded-full ${hasPhysicalCard ? 'bg-red-500/20' : 'bg-[#303030]'}`}
             style={{ width: 50, height: 50 }}
           >

--- a/app/(protected)/(tabs)/card/details.tsx
+++ b/app/(protected)/(tabs)/card/details.tsx
@@ -157,7 +157,6 @@ export default function CardDetails() {
         isWithdrawFromCardAllowed={isWithdrawFromCardAllowed}
         isRain={provider === CardProvider.RAIN}
         hasPhysicalCard={hasPhysicalCard}
-        isOrderPhysicalCardModalOpen={isOrderPhysicalCardModalOpen}
         onOrderPhysicalCardModalChange={setIsOrderPhysicalCardModalOpen}
       />
     </View>
@@ -294,7 +293,6 @@ interface DesktopHeaderProps {
   isWithdrawFromCardAllowed: boolean;
   isRain: boolean;
   hasPhysicalCard: boolean;
-  isOrderPhysicalCardModalOpen: boolean;
   onOrderPhysicalCardModalChange: (open: boolean) => void;
 }
 
@@ -309,7 +307,6 @@ function DesktopHeader({
   isWithdrawFromCardAllowed,
   isRain,
   hasPhysicalCard,
-  isOrderPhysicalCardModalOpen,
   onOrderPhysicalCardModalChange,
 }: DesktopHeaderProps) {
   const [isManageOpen, setIsManageOpen] = useState(false);

--- a/app/(protected)/(tabs)/card/details.tsx
+++ b/app/(protected)/(tabs)/card/details.tsx
@@ -13,13 +13,22 @@ import * as Clipboard from 'expo-clipboard';
 import { Image } from 'expo-image';
 import { LinearGradient } from 'expo-linear-gradient';
 import { useRouter } from 'expo-router';
-import { ChevronDown, ChevronRight, Copy, KeyRound, Plus, Settings } from 'lucide-react-native';
+import {
+  ChevronDown,
+  ChevronRight,
+  Copy,
+  CreditCard,
+  KeyRound,
+  Plus,
+  Settings,
+} from 'lucide-react-native';
 
 import AddToWalletModal from '@/components/Card/AddToWalletModal';
 import { BorrowPositionCard } from '@/components/Card/BorrowPositionCard';
 import { CircularActionButton } from '@/components/Card/CircularActionButton';
 import DepositToCardModal from '@/components/Card/DepositToCardModal';
 import ManagePinModal from '@/components/Card/ManagePinModal';
+import OrderPhysicalCardModal from '@/components/Card/OrderPhysicalCardModal';
 import WithdrawToCardModal from '@/components/Card/WithdrawToCardModal';
 import PageLayout from '@/components/PageLayout';
 import { Button } from '@/components/ui/button';
@@ -59,6 +68,7 @@ export default function CardDetails() {
   const [isLoadingCardDetails, setIsLoadingCardDetails] = useState(false);
   const [shouldRevealDetails, setShouldRevealDetails] = useState(false);
   const [isAddToWalletModalOpen, setIsAddToWalletModalOpen] = useState(false);
+  const [isOrderPhysicalCardModalOpen, setIsOrderPhysicalCardModalOpen] = useState(false);
   const flipAnimation = useRef(new Animated.Value(0)).current;
 
   const availableBalance = cardDetails?.balances.available;
@@ -135,6 +145,8 @@ export default function CardDetails() {
         onFreezeToggle={handleFreezeToggle}
         isWithdrawFromCardAllowed={isWithdrawFromCardAllowed}
         isRain={provider === CardProvider.RAIN}
+        isOrderPhysicalCardModalOpen={isOrderPhysicalCardModalOpen}
+        onOrderPhysicalCardModalChange={setIsOrderPhysicalCardModalOpen}
       />
     </View>
   ) : (
@@ -193,6 +205,11 @@ export default function CardDetails() {
           onOpenChange={setIsAddToWalletModalOpen}
           trigger={null}
         />
+        <OrderPhysicalCardModal
+          isOpen={isOrderPhysicalCardModalOpen}
+          onOpenChange={setIsOrderPhysicalCardModalOpen}
+          trigger={null}
+        />
       </PageLayout>
     );
   }
@@ -224,6 +241,7 @@ export default function CardDetails() {
             isWithdrawAllowed={isWithdrawAllowed}
             isWithdrawFromCardAllowed={isWithdrawFromCardAllowed}
             isRain={provider === CardProvider.RAIN}
+            onOrderPhysicalCard={() => setIsOrderPhysicalCardModalOpen(true)}
           />
           <BorrowPositionCard className="mb-4" />
           <DepositBonusBanner />
@@ -237,6 +255,11 @@ export default function CardDetails() {
       <AddToWalletModal
         isOpen={isAddToWalletModalOpen}
         onOpenChange={setIsAddToWalletModalOpen}
+        trigger={null}
+      />
+      <OrderPhysicalCardModal
+        isOpen={isOrderPhysicalCardModalOpen}
+        onOpenChange={setIsOrderPhysicalCardModalOpen}
         trigger={null}
       />
     </PageLayout>
@@ -257,6 +280,8 @@ interface DesktopHeaderProps {
   onFreezeToggle: () => Promise<void>;
   isWithdrawFromCardAllowed: boolean;
   isRain: boolean;
+  isOrderPhysicalCardModalOpen: boolean;
+  onOrderPhysicalCardModalChange: (open: boolean) => void;
 }
 
 function DesktopHeader({
@@ -269,6 +294,8 @@ function DesktopHeader({
   onFreezeToggle,
   isWithdrawFromCardAllowed,
   isRain,
+  isOrderPhysicalCardModalOpen,
+  onOrderPhysicalCardModalChange,
 }: DesktopHeaderProps) {
   const [isManageOpen, setIsManageOpen] = useState(false);
   const manageRef = useRef<View>(null);
@@ -371,6 +398,18 @@ function DesktopHeader({
               </View>
             )}
           </View>
+        )}
+        {isRain && (
+          <Button
+            variant="secondary"
+            className="h-12 rounded-xl border-0 bg-[#303030] px-6"
+            onPress={() => onOrderPhysicalCardModalChange(true)}
+          >
+            <View className="flex-row items-center gap-2">
+              <CreditCard size={18} color="white" />
+              <Text className="text-base font-bold text-white">Order Physical Card</Text>
+            </View>
+          </Button>
         )}
         {isWithdrawFromCardAllowed && (
           <WithdrawToCardModal
@@ -781,6 +820,7 @@ interface CardActionsProps {
   onFreezeToggle: () => Promise<void>;
   isWithdrawFromCardAllowed: boolean;
   isRain: boolean;
+  onOrderPhysicalCard: () => void;
 }
 
 function CardActions({
@@ -793,6 +833,7 @@ function CardActions({
   onFreezeToggle,
   isWithdrawFromCardAllowed,
   isRain,
+  onOrderPhysicalCard,
 }: CardActionsProps) {
   const [isManageSheetOpen, setIsManageSheetOpen] = useState(false);
   const showManageButton = isRain || !isCardFrozen || canUnfreeze;
@@ -882,6 +923,18 @@ function CardActions({
               </View>
             </DialogContent>
           </Dialog>
+        </View>
+      )}
+      {isRain && (
+        <View className="flex-1 items-center">
+          <Pressable
+            onPress={onOrderPhysicalCard}
+            className="items-center justify-center rounded-full bg-[#303030]"
+            style={{ width: 50, height: 50 }}
+          >
+            <CreditCard size={24} color="#BFBFBF" />
+          </Pressable>
+          <Text className="mt-2 text-[#BFBFBF]">Physical</Text>
         </View>
       )}
       {isWithdrawFromCardAllowed && (

--- a/app/(protected)/(tabs)/card/details.tsx
+++ b/app/(protected)/(tabs)/card/details.tsx
@@ -13,6 +13,7 @@ import * as Clipboard from 'expo-clipboard';
 import { Image } from 'expo-image';
 import { LinearGradient } from 'expo-linear-gradient';
 import { useRouter } from 'expo-router';
+import { useQuery } from '@tanstack/react-query';
 import {
   ChevronDown,
   ChevronRight,
@@ -28,7 +29,9 @@ import { BorrowPositionCard } from '@/components/Card/BorrowPositionCard';
 import { CircularActionButton } from '@/components/Card/CircularActionButton';
 import DepositToCardModal from '@/components/Card/DepositToCardModal';
 import ManagePinModal from '@/components/Card/ManagePinModal';
-import OrderPhysicalCardModal from '@/components/Card/OrderPhysicalCardModal';
+import OrderPhysicalCardModal, {
+  PHYSICAL_CARD_STATUS_QUERY_KEY,
+} from '@/components/Card/OrderPhysicalCardModal';
 import WithdrawToCardModal from '@/components/Card/WithdrawToCardModal';
 import PageLayout from '@/components/PageLayout';
 import { Button } from '@/components/ui/button';
@@ -52,7 +55,7 @@ import { freezeCard, getPhysicalCardStatus, unfreezeCard } from '@/lib/api';
 import { getAsset } from '@/lib/assets';
 import { EXPO_PUBLIC_ENVIRONMENT } from '@/lib/config';
 import { CardHolderName, CardProvider, CardStatus, FreezeInitiator, KycStatus } from '@/lib/types';
-import { cn } from '@/lib/utils/utils';
+import { cn, withRefreshToken } from '@/lib/utils/utils';
 import { CardDepositSource, useCardDepositStore } from '@/store/useCardDepositStore';
 
 export default function CardDetails() {
@@ -69,33 +72,15 @@ export default function CardDetails() {
   const [shouldRevealDetails, setShouldRevealDetails] = useState(false);
   const [isAddToWalletModalOpen, setIsAddToWalletModalOpen] = useState(false);
   const [isOrderPhysicalCardModalOpen, setIsOrderPhysicalCardModalOpen] = useState(false);
-  const [hasPhysicalCard, setHasPhysicalCard] = useState(false);
   const flipAnimation = useRef(new Animated.Value(0)).current;
 
-  const checkPhysicalCardStatus = useCallback(async () => {
-    if (provider !== CardProvider.RAIN) return;
-    try {
-      const result = await getPhysicalCardStatus();
-      setHasPhysicalCard(result.hasPhysicalCard);
-    } catch {
-      // ignore
-    }
-  }, [provider]);
+  const { data: physicalCardStatusData } = useQuery({
+    queryKey: [PHYSICAL_CARD_STATUS_QUERY_KEY],
+    queryFn: () => withRefreshToken(() => getPhysicalCardStatus()),
+    enabled: provider === CardProvider.RAIN,
+  });
 
-  useEffect(() => {
-    checkPhysicalCardStatus();
-  }, [checkPhysicalCardStatus]);
-
-  const handlePhysicalCardModalChange = useCallback(
-    (open: boolean) => {
-      setIsOrderPhysicalCardModalOpen(open);
-      if (!open) {
-        // Re-check physical card status when modal closes
-        checkPhysicalCardStatus();
-      }
-    },
-    [checkPhysicalCardStatus],
-  );
+  const hasPhysicalCard = physicalCardStatusData?.hasPhysicalCard ?? false;
 
   const availableBalance = cardDetails?.balances.available;
   const availableAmount = Number(availableBalance?.amount || '0').toString();
@@ -173,7 +158,7 @@ export default function CardDetails() {
         isRain={provider === CardProvider.RAIN}
         hasPhysicalCard={hasPhysicalCard}
         isOrderPhysicalCardModalOpen={isOrderPhysicalCardModalOpen}
-        onOrderPhysicalCardModalChange={handlePhysicalCardModalChange}
+        onOrderPhysicalCardModalChange={setIsOrderPhysicalCardModalOpen}
       />
     </View>
   ) : (
@@ -234,7 +219,7 @@ export default function CardDetails() {
         />
         <OrderPhysicalCardModal
           isOpen={isOrderPhysicalCardModalOpen}
-          onOpenChange={handlePhysicalCardModalChange}
+          onOpenChange={setIsOrderPhysicalCardModalOpen}
           trigger={null}
         />
       </PageLayout>

--- a/app/(protected)/(tabs)/card/details.tsx
+++ b/app/(protected)/(tabs)/card/details.tsx
@@ -48,7 +48,7 @@ import { useCardProvider } from '@/hooks/useCardProvider';
 import { useCardWithdrawals } from '@/hooks/useCardWithdrawals';
 import { useCustomer } from '@/hooks/useCustomer';
 import { useDimension } from '@/hooks/useDimension';
-import { freezeCard, unfreezeCard } from '@/lib/api';
+import { freezeCard, getPhysicalCardStatus, unfreezeCard } from '@/lib/api';
 import { getAsset } from '@/lib/assets';
 import { EXPO_PUBLIC_ENVIRONMENT } from '@/lib/config';
 import { CardHolderName, CardProvider, CardStatus, FreezeInitiator, KycStatus } from '@/lib/types';
@@ -69,7 +69,33 @@ export default function CardDetails() {
   const [shouldRevealDetails, setShouldRevealDetails] = useState(false);
   const [isAddToWalletModalOpen, setIsAddToWalletModalOpen] = useState(false);
   const [isOrderPhysicalCardModalOpen, setIsOrderPhysicalCardModalOpen] = useState(false);
+  const [hasPhysicalCard, setHasPhysicalCard] = useState(false);
   const flipAnimation = useRef(new Animated.Value(0)).current;
+
+  const checkPhysicalCardStatus = useCallback(async () => {
+    if (provider !== CardProvider.RAIN) return;
+    try {
+      const result = await getPhysicalCardStatus();
+      setHasPhysicalCard(result.hasPhysicalCard);
+    } catch {
+      // ignore
+    }
+  }, [provider]);
+
+  useEffect(() => {
+    checkPhysicalCardStatus();
+  }, [checkPhysicalCardStatus]);
+
+  const handlePhysicalCardModalChange = useCallback(
+    (open: boolean) => {
+      setIsOrderPhysicalCardModalOpen(open);
+      if (!open) {
+        // Re-check physical card status when modal closes
+        checkPhysicalCardStatus();
+      }
+    },
+    [checkPhysicalCardStatus],
+  );
 
   const availableBalance = cardDetails?.balances.available;
   const availableAmount = Number(availableBalance?.amount || '0').toString();
@@ -145,8 +171,9 @@ export default function CardDetails() {
         onFreezeToggle={handleFreezeToggle}
         isWithdrawFromCardAllowed={isWithdrawFromCardAllowed}
         isRain={provider === CardProvider.RAIN}
+        hasPhysicalCard={hasPhysicalCard}
         isOrderPhysicalCardModalOpen={isOrderPhysicalCardModalOpen}
-        onOrderPhysicalCardModalChange={setIsOrderPhysicalCardModalOpen}
+        onOrderPhysicalCardModalChange={handlePhysicalCardModalChange}
       />
     </View>
   ) : (
@@ -207,7 +234,7 @@ export default function CardDetails() {
         />
         <OrderPhysicalCardModal
           isOpen={isOrderPhysicalCardModalOpen}
-          onOpenChange={setIsOrderPhysicalCardModalOpen}
+          onOpenChange={handlePhysicalCardModalChange}
           trigger={null}
         />
       </PageLayout>
@@ -241,6 +268,7 @@ export default function CardDetails() {
             isWithdrawAllowed={isWithdrawAllowed}
             isWithdrawFromCardAllowed={isWithdrawFromCardAllowed}
             isRain={provider === CardProvider.RAIN}
+            hasPhysicalCard={hasPhysicalCard}
             onOrderPhysicalCard={() => setIsOrderPhysicalCardModalOpen(true)}
           />
           <BorrowPositionCard className="mb-4" />
@@ -280,6 +308,7 @@ interface DesktopHeaderProps {
   onFreezeToggle: () => Promise<void>;
   isWithdrawFromCardAllowed: boolean;
   isRain: boolean;
+  hasPhysicalCard: boolean;
   isOrderPhysicalCardModalOpen: boolean;
   onOrderPhysicalCardModalChange: (open: boolean) => void;
 }
@@ -294,6 +323,7 @@ function DesktopHeader({
   onFreezeToggle,
   isWithdrawFromCardAllowed,
   isRain,
+  hasPhysicalCard,
   isOrderPhysicalCardModalOpen,
   onOrderPhysicalCardModalChange,
 }: DesktopHeaderProps) {
@@ -402,12 +432,16 @@ function DesktopHeader({
         {isRain && (
           <Button
             variant="secondary"
-            className="h-12 rounded-xl border-0 bg-[#303030] px-6"
+            className={`h-12 rounded-xl border-0 px-6 ${hasPhysicalCard ? 'bg-red-500/20' : 'bg-[#303030]'}`}
             onPress={() => onOrderPhysicalCardModalChange(true)}
           >
             <View className="flex-row items-center gap-2">
-              <CreditCard size={18} color="white" />
-              <Text className="text-base font-bold text-white">Order Physical Card</Text>
+              <CreditCard size={18} color={hasPhysicalCard ? '#ef4444' : 'white'} />
+              <Text
+                className={`text-base font-bold ${hasPhysicalCard ? 'text-red-400' : 'text-white'}`}
+              >
+                {hasPhysicalCard ? 'Cancel Physical Card' : 'Order Physical Card'}
+              </Text>
             </View>
           </Button>
         )}
@@ -820,6 +854,7 @@ interface CardActionsProps {
   onFreezeToggle: () => Promise<void>;
   isWithdrawFromCardAllowed: boolean;
   isRain: boolean;
+  hasPhysicalCard: boolean;
   onOrderPhysicalCard: () => void;
 }
 
@@ -833,6 +868,7 @@ function CardActions({
   onFreezeToggle,
   isWithdrawFromCardAllowed,
   isRain,
+  hasPhysicalCard,
   onOrderPhysicalCard,
 }: CardActionsProps) {
   const [isManageSheetOpen, setIsManageSheetOpen] = useState(false);
@@ -929,12 +965,14 @@ function CardActions({
         <View className="flex-1 items-center">
           <Pressable
             onPress={onOrderPhysicalCard}
-            className="items-center justify-center rounded-full bg-[#303030]"
+            className={`items-center justify-center rounded-full ${hasPhysicalCard ? 'bg-red-500/20' : 'bg-[#303030]'}`}
             style={{ width: 50, height: 50 }}
           >
-            <CreditCard size={24} color="#BFBFBF" />
+            <CreditCard size={24} color={hasPhysicalCard ? '#ef4444' : '#BFBFBF'} />
           </Pressable>
-          <Text className="mt-2 text-[#BFBFBF]">Physical</Text>
+          <Text className={`mt-2 ${hasPhysicalCard ? 'text-red-400' : 'text-[#BFBFBF]'}`}>
+            {hasPhysicalCard ? 'Cancel' : 'Physical'}
+          </Text>
         </View>
       )}
       {isWithdrawFromCardAllowed && (

--- a/components/Card/CancelPhysicalCardModal.tsx
+++ b/components/Card/CancelPhysicalCardModal.tsx
@@ -1,0 +1,167 @@
+import React, { useState } from 'react';
+import { ActivityIndicator, View } from 'react-native';
+import Toast from 'react-native-toast-message';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { CreditCard } from 'lucide-react-native';
+
+import ResponsiveModal, { ModalState } from '@/components/ResponsiveModal';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Text } from '@/components/ui/text';
+import { cancelPhysicalCard, getPhysicalCardStatus } from '@/lib/api';
+import { PHYSICAL_CARD_STATUS_QUERY_KEY } from '@/components/Card/OrderPhysicalCardModal';
+import { withRefreshToken } from '@/lib/utils/utils';
+
+interface CancelPhysicalCardModalProps {
+  trigger: React.ReactNode;
+  isOpen: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+const MODAL_STATE: ModalState = { name: 'cancel-physical-card', number: 1 };
+const CLOSE_STATE: ModalState = { name: 'close', number: 0 };
+
+export default function CancelPhysicalCardModal({
+  trigger,
+  isOpen,
+  onOpenChange,
+}: CancelPhysicalCardModalProps) {
+  const queryClient = useQueryClient();
+  const [isConfirmOpen, setIsConfirmOpen] = useState(false);
+
+  const { data: statusData, isLoading: isLoadingStatus } = useQuery({
+    queryKey: [PHYSICAL_CARD_STATUS_QUERY_KEY],
+    queryFn: () => withRefreshToken(() => getPhysicalCardStatus()),
+    enabled: isOpen,
+  });
+
+  const physicalCardId = statusData?.cardId;
+
+  const cancelMutation = useMutation({
+    mutationFn: (cardId: string) => withRefreshToken(() => cancelPhysicalCard(cardId)),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [PHYSICAL_CARD_STATUS_QUERY_KEY] });
+      onOpenChange(false);
+      Toast.show({
+        type: 'success',
+        text1: 'Physical card canceled',
+        text2: 'Your physical card order has been canceled.',
+        props: { badgeText: '' },
+      });
+    },
+    onError: () => {
+      Toast.show({
+        type: 'error',
+        text1: 'Failed to cancel physical card',
+        text2: 'Please try again.',
+        props: { badgeText: '' },
+      });
+    },
+  });
+
+  return (
+    <ResponsiveModal
+      currentModal={MODAL_STATE}
+      previousModal={CLOSE_STATE}
+      isOpen={isOpen}
+      onOpenChange={onOpenChange}
+      trigger={trigger}
+      title="Physical Card Ordered"
+      contentKey="cancel-physical-card"
+      contentClassName="md:max-w-lg"
+      shouldAnimate={false}
+    >
+      {isLoadingStatus ? (
+        <View className="items-center justify-center p-12">
+          <ActivityIndicator size="large" color="white" />
+        </View>
+      ) : (
+        <View className="p-6">
+          <View className="mb-6 items-center">
+            <View className="mb-4 items-center justify-center rounded-full bg-[#303030] p-4">
+              <CreditCard size={32} color="#94F27F" />
+            </View>
+            <Text className="mb-2 text-center text-xl font-semibold text-white">
+              Physical card ordered
+            </Text>
+            <Text className="text-center text-base text-white/60">
+              Your physical card has been ordered and will be shipped to your address. You can cancel
+              the order if needed.
+            </Text>
+          </View>
+
+          <View className="gap-4">
+            <Button
+              className="h-14 rounded-xl bg-red-500"
+              onPress={() => setIsConfirmOpen(true)}
+              disabled={cancelMutation.isPending}
+            >
+              {cancelMutation.isPending ? (
+                <ActivityIndicator color="white" />
+              ) : (
+                <Text className="text-base font-bold text-white">Cancel Physical Card</Text>
+              )}
+            </Button>
+            <Button
+              variant="secondary"
+              className="h-14 rounded-xl border-0 bg-[#303030]"
+              onPress={() => onOpenChange(false)}
+              disabled={cancelMutation.isPending}
+            >
+              <Text className="text-base font-bold text-white">Close</Text>
+            </Button>
+          </View>
+
+          <Dialog open={isConfirmOpen} onOpenChange={open => !open && setIsConfirmOpen(false)}>
+            <DialogContent showCloseButton={false} className="max-w-sm">
+              <DialogHeader>
+                <DialogTitle className="text-xl font-bold">Cancel physical card?</DialogTitle>
+              </DialogHeader>
+
+              <DialogDescription className="text-base text-muted-foreground">
+                Are you sure you want to cancel your physical card order? This action cannot be
+                undone.
+              </DialogDescription>
+
+              <DialogFooter className="mt-4 flex-row gap-3">
+                <Button
+                  variant="secondary"
+                  className="flex-1 rounded-xl border-0"
+                  onPress={() => setIsConfirmOpen(false)}
+                  disabled={cancelMutation.isPending}
+                >
+                  <Text className="font-semibold">Keep order</Text>
+                </Button>
+                <Button
+                  variant="destructive"
+                  className="flex-1 rounded-xl border-0"
+                  onPress={() => {
+                    if (physicalCardId) {
+                      cancelMutation.mutate(physicalCardId, {
+                        onSettled: () => setIsConfirmOpen(false),
+                      });
+                    }
+                  }}
+                  disabled={cancelMutation.isPending}
+                >
+                  {cancelMutation.isPending ? (
+                    <ActivityIndicator color="white" size="small" />
+                  ) : (
+                    <Text className="font-semibold text-white">Cancel card</Text>
+                  )}
+                </Button>
+              </DialogFooter>
+            </DialogContent>
+          </Dialog>
+        </View>
+      )}
+    </ResponsiveModal>
+  );
+}

--- a/components/Card/OrderPhysicalCardModal.tsx
+++ b/components/Card/OrderPhysicalCardModal.tsx
@@ -1,11 +1,14 @@
-import React, { useCallback, useEffect, useState } from 'react';
-import { ActivityIndicator, Alert, ScrollView, View } from 'react-native';
+import React, { useCallback, useEffect } from 'react';
+import { ActivityIndicator, Alert, ScrollView, TextInput, View } from 'react-native';
 import Toast from 'react-native-toast-message';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { Controller, useForm } from 'react-hook-form';
 import { CreditCard } from 'lucide-react-native';
+import { z } from 'zod';
 
 import ResponsiveModal, { ModalState } from '@/components/ResponsiveModal';
 import { Button } from '@/components/ui/button';
-import Input from '@/components/ui/input';
 import { Text } from '@/components/ui/text';
 import {
   cancelPhysicalCard,
@@ -13,6 +16,8 @@ import {
   getPhysicalCardStatus,
   orderPhysicalCard,
 } from '@/lib/api';
+import { withRefreshToken } from '@/lib/utils/utils';
+import { cn } from '@/lib/utils/utils';
 
 interface OrderPhysicalCardModalProps {
   trigger: React.ReactNode;
@@ -23,124 +28,155 @@ interface OrderPhysicalCardModalProps {
 const MODAL_STATE: ModalState = { name: 'order-physical-card', number: 1 };
 const CLOSE_STATE: ModalState = { name: 'close', number: 0 };
 
-interface ShippingForm {
-  firstName: string;
-  lastName: string;
-  line1: string;
-  line2: string;
-  city: string;
-  region: string;
-  postalCode: string;
-  countryCode: string;
-  phoneNumber: string;
-}
+export const PHYSICAL_CARD_STATUS_QUERY_KEY = 'physicalCardStatus';
+const SHIPPING_DATA_QUERY_KEY = 'physicalCardShippingData';
 
-const EMPTY_FORM: ShippingForm = {
-  firstName: '',
-  lastName: '',
-  line1: '',
-  line2: '',
-  city: '',
-  region: '',
-  postalCode: '',
-  countryCode: '',
-  phoneNumber: '',
-};
+const shippingSchema = z.object({
+  firstName: z
+    .string()
+    .min(1, { message: 'First name is required' })
+    .max(50)
+    .regex(/^[a-zA-Z -]+$/, { message: 'Only Latin characters, spaces, and hyphens' }),
+  lastName: z
+    .string()
+    .min(1, { message: 'Last name is required' })
+    .max(50)
+    .regex(/^[a-zA-Z -]+$/, { message: 'Only Latin characters, spaces, and hyphens' }),
+  line1: z.string().min(1, { message: 'Address is required' }).max(100),
+  line2: z.string().max(100).optional().or(z.literal('')),
+  city: z.string().min(1, { message: 'City is required' }).max(50),
+  region: z.string().max(50).optional().or(z.literal('')),
+  postalCode: z.string().min(1, { message: 'Postal code is required' }).max(9),
+  countryCode: z
+    .string()
+    .length(2, { message: 'Must be 2-letter code' })
+    .regex(/^[A-Z]{2}$/, { message: 'Must be 2 uppercase letters' }),
+  phoneNumber: z.string().min(1, { message: 'Phone number is required' }),
+});
+
+type ShippingFormData = z.infer<typeof shippingSchema>;
 
 export default function OrderPhysicalCardModal({
   trigger,
   isOpen,
   onOpenChange,
 }: OrderPhysicalCardModalProps) {
-  const [isSubmitting, setIsSubmitting] = useState(false);
-  const [isCanceling, setIsCanceling] = useState(false);
-  const [isLoadingData, setIsLoadingData] = useState(false);
-  const [form, setForm] = useState<ShippingForm>(EMPTY_FORM);
-  const [physicalCardId, setPhysicalCardId] = useState<string | null>(null);
-  const [hasPhysicalCard, setHasPhysicalCard] = useState(false);
+  const queryClient = useQueryClient();
 
-  const loadData = useCallback(async () => {
-    setIsLoadingData(true);
-    try {
-      const [statusResult, shippingResult] = await Promise.all([
-        getPhysicalCardStatus(),
-        getPhysicalCardShippingData(),
-      ]);
+  const { data: statusData, isLoading: isLoadingStatus } = useQuery({
+    queryKey: [PHYSICAL_CARD_STATUS_QUERY_KEY],
+    queryFn: () => withRefreshToken(() => getPhysicalCardStatus()),
+    enabled: isOpen,
+  });
 
-      if (statusResult.hasPhysicalCard && statusResult.cardId) {
-        setHasPhysicalCard(true);
-        setPhysicalCardId(statusResult.cardId);
-      } else {
-        setHasPhysicalCard(false);
-        setPhysicalCardId(null);
-      }
+  const { data: shippingData } = useQuery({
+    queryKey: [SHIPPING_DATA_QUERY_KEY],
+    queryFn: () => withRefreshToken(() => getPhysicalCardShippingData()),
+    enabled: isOpen && !statusData?.hasPhysicalCard,
+  });
 
-      setForm({
-        firstName: shippingResult.firstName ?? '',
-        lastName: shippingResult.lastName ?? '',
-        line1: shippingResult.line1 ?? '',
-        line2: shippingResult.line2 ?? '',
-        city: shippingResult.city ?? '',
-        region: shippingResult.region ?? '',
-        postalCode: shippingResult.postalCode ?? '',
-        countryCode: shippingResult.countryCode ?? '',
-        phoneNumber: shippingResult.phoneNumber ?? '',
-      });
-    } catch (_error) {
-      // Shipping data may not be available, continue with empty form
-    } finally {
-      setIsLoadingData(false);
-    }
-  }, []);
+  const hasPhysicalCard = statusData?.hasPhysicalCard ?? false;
+  const physicalCardId = statusData?.cardId;
+
+  const { control, handleSubmit, formState, reset } = useForm<ShippingFormData>({
+    resolver: zodResolver(shippingSchema) as any,
+    mode: 'onChange',
+    defaultValues: {
+      firstName: '',
+      lastName: '',
+      line1: '',
+      line2: '',
+      city: '',
+      region: '',
+      postalCode: '',
+      countryCode: '',
+      phoneNumber: '',
+    },
+  });
 
   useEffect(() => {
-    if (isOpen) {
-      loadData();
-    }
-  }, [isOpen, loadData]);
-
-  const updateField = (field: keyof ShippingForm) => (value: string) => {
-    setForm(prev => ({ ...prev, [field]: value }));
-  };
-
-  const handlePlaceOrder = async () => {
-    if (!form.firstName || !form.lastName || !form.line1 || !form.city || !form.postalCode || !form.countryCode || !form.phoneNumber) {
-      Alert.alert('Missing fields', 'Please fill in all required fields.');
-      return;
-    }
-
-    try {
-      setIsSubmitting(true);
-      const result = await orderPhysicalCard({
-        shipping: {
-          firstName: form.firstName,
-          lastName: form.lastName,
-          line1: form.line1,
-          ...(form.line2 ? { line2: form.line2 } : {}),
-          city: form.city,
-          ...(form.region ? { region: form.region } : {}),
-          postalCode: form.postalCode,
-          countryCode: form.countryCode,
-          phoneNumber: form.phoneNumber,
-        },
+    if (shippingData) {
+      reset({
+        firstName: shippingData.firstName ?? '',
+        lastName: shippingData.lastName ?? '',
+        line1: shippingData.line1 ?? '',
+        line2: shippingData.line2 ?? '',
+        city: shippingData.city ?? '',
+        region: shippingData.region ?? '',
+        postalCode: shippingData.postalCode ?? '',
+        countryCode: shippingData.countryCode?.toUpperCase() ?? '',
+        phoneNumber: shippingData.phoneNumber ?? '',
       });
-      setHasPhysicalCard(true);
-      setPhysicalCardId(result.id);
+    }
+  }, [shippingData, reset]);
+
+  const orderMutation = useMutation({
+    mutationFn: (data: ShippingFormData) =>
+      withRefreshToken(() =>
+        orderPhysicalCard({
+          shipping: {
+            firstName: data.firstName,
+            lastName: data.lastName,
+            line1: data.line1,
+            ...(data.line2 ? { line2: data.line2 } : {}),
+            city: data.city,
+            ...(data.region ? { region: data.region } : {}),
+            postalCode: data.postalCode,
+            countryCode: data.countryCode,
+            phoneNumber: data.phoneNumber,
+          },
+        }),
+      ),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [PHYSICAL_CARD_STATUS_QUERY_KEY] });
       Toast.show({
         type: 'success',
         text1: 'Physical card ordered',
         text2: 'Your physical card has been ordered successfully.',
+        props: { badgeText: '' },
       });
-    } catch (_error) {
-      Alert.alert('Error', 'Failed to order physical card. Please try again.');
-    } finally {
-      setIsSubmitting(false);
-    }
-  };
+    },
+    onError: () => {
+      Toast.show({
+        type: 'error',
+        text1: 'Failed to order physical card',
+        text2: 'Please try again.',
+        props: { badgeText: '' },
+      });
+    },
+  });
 
-  const handleCancel = async () => {
+  const cancelMutation = useMutation({
+    mutationFn: (cardId: string) => withRefreshToken(() => cancelPhysicalCard(cardId)),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [PHYSICAL_CARD_STATUS_QUERY_KEY] });
+      onOpenChange(false);
+      Toast.show({
+        type: 'success',
+        text1: 'Physical card canceled',
+        text2: 'Your physical card order has been canceled.',
+        props: { badgeText: '' },
+      });
+    },
+    onError: () => {
+      Toast.show({
+        type: 'error',
+        text1: 'Failed to cancel physical card',
+        text2: 'Please try again.',
+        props: { badgeText: '' },
+      });
+    },
+  });
+
+  const onSubmit = useCallback(
+    (data: ShippingFormData) => {
+      orderMutation.mutate(data);
+    },
+    [orderMutation],
+  );
+
+  const handleCancel = useCallback(() => {
     if (!physicalCardId) return;
-
     Alert.alert(
       'Cancel Physical Card',
       'Are you sure you want to cancel your physical card order? This action cannot be undone.',
@@ -149,28 +185,11 @@ export default function OrderPhysicalCardModal({
         {
           text: 'Yes, Cancel',
           style: 'destructive',
-          onPress: async () => {
-            try {
-              setIsCanceling(true);
-              await cancelPhysicalCard(physicalCardId);
-              setHasPhysicalCard(false);
-              setPhysicalCardId(null);
-              onOpenChange(false);
-              Toast.show({
-                type: 'success',
-                text1: 'Physical card canceled',
-                text2: 'Your physical card order has been canceled.',
-              });
-            } catch (_error) {
-              Alert.alert('Error', 'Failed to cancel physical card. Please try again.');
-            } finally {
-              setIsCanceling(false);
-            }
-          },
+          onPress: () => cancelMutation.mutate(physicalCardId),
         },
       ],
     );
-  };
+  }, [physicalCardId, cancelMutation]);
 
   return (
     <ResponsiveModal
@@ -185,7 +204,7 @@ export default function OrderPhysicalCardModal({
       shouldAnimate={false}
       disableScroll
     >
-      {isLoadingData ? (
+      {isLoadingStatus ? (
         <View className="items-center justify-center p-12">
           <ActivityIndicator size="large" color="white" />
         </View>
@@ -208,9 +227,9 @@ export default function OrderPhysicalCardModal({
             <Button
               className="h-14 rounded-xl bg-red-500"
               onPress={handleCancel}
-              disabled={isCanceling}
+              disabled={cancelMutation.isPending}
             >
-              {isCanceling ? (
+              {cancelMutation.isPending ? (
                 <ActivityIndicator color="white" />
               ) : (
                 <Text className="text-base font-bold text-white">Cancel Physical Card</Text>
@@ -220,7 +239,7 @@ export default function OrderPhysicalCardModal({
               variant="secondary"
               className="h-14 rounded-xl border-0 bg-[#303030]"
               onPress={() => onOpenChange(false)}
-              disabled={isCanceling}
+              disabled={cancelMutation.isPending}
             >
               <Text className="text-base font-bold text-white">Close</Text>
             </Button>
@@ -243,109 +262,143 @@ export default function OrderPhysicalCardModal({
 
             <View className="gap-3">
               <View className="flex-row gap-3">
-                <View className="flex-1">
-                  <Text className="mb-1.5 text-sm font-medium text-white/50">First name *</Text>
-                  <Input
-                    value={form.firstName}
-                    onChangeText={updateField('firstName')}
-                    placeholder="First name"
-                    placeholderTextColor="#666"
-                  />
+                <View className="flex-1 gap-1.5">
+                  <Text className="font-medium opacity-50">First name *</Text>
+                  <View
+                    className={cn(
+                      'rounded-2xl bg-accent px-5 py-3',
+                      formState.errors.firstName && 'border border-red-500',
+                    )}
+                  >
+                    <Controller
+                      control={control}
+                      name="firstName"
+                      render={({ field: { onChange, onBlur, value } }) => (
+                        <TextInput
+                          className="text-lg font-semibold text-white web:focus:outline-none"
+                          value={value}
+                          onChangeText={onChange}
+                          onBlur={onBlur}
+                          placeholder="First name"
+                          placeholderTextColor="#666"
+                        />
+                      )}
+                    />
+                  </View>
+                  {formState.errors.firstName && (
+                    <Text className="text-sm text-red-500">
+                      {formState.errors.firstName.message}
+                    </Text>
+                  )}
                 </View>
-                <View className="flex-1">
-                  <Text className="mb-1.5 text-sm font-medium text-white/50">Last name *</Text>
-                  <Input
-                    value={form.lastName}
-                    onChangeText={updateField('lastName')}
-                    placeholder="Last name"
-                    placeholderTextColor="#666"
-                  />
+                <View className="flex-1 gap-1.5">
+                  <Text className="font-medium opacity-50">Last name *</Text>
+                  <View
+                    className={cn(
+                      'rounded-2xl bg-accent px-5 py-3',
+                      formState.errors.lastName && 'border border-red-500',
+                    )}
+                  >
+                    <Controller
+                      control={control}
+                      name="lastName"
+                      render={({ field: { onChange, onBlur, value } }) => (
+                        <TextInput
+                          className="text-lg font-semibold text-white web:focus:outline-none"
+                          value={value}
+                          onChangeText={onChange}
+                          onBlur={onBlur}
+                          placeholder="Last name"
+                          placeholderTextColor="#666"
+                        />
+                      )}
+                    />
+                  </View>
+                  {formState.errors.lastName && (
+                    <Text className="text-sm text-red-500">
+                      {formState.errors.lastName.message}
+                    </Text>
+                  )}
                 </View>
               </View>
 
-              <View>
-                <Text className="mb-1.5 text-sm font-medium text-white/50">Address line 1 *</Text>
-                <Input
-                  value={form.line1}
-                  onChangeText={updateField('line1')}
-                  placeholder="Street address"
-                  placeholderTextColor="#666"
-                />
-              </View>
+              <FormField
+                control={control}
+                name="line1"
+                label="Address line 1 *"
+                placeholder="Street address"
+                error={formState.errors.line1?.message}
+              />
 
-              <View>
-                <Text className="mb-1.5 text-sm font-medium text-white/50">Address line 2</Text>
-                <Input
-                  value={form.line2}
-                  onChangeText={updateField('line2')}
-                  placeholder="Apt, suite, unit (optional)"
-                  placeholderTextColor="#666"
-                />
-              </View>
+              <FormField
+                control={control}
+                name="line2"
+                label="Address line 2"
+                placeholder="Apt, suite, unit (optional)"
+                error={formState.errors.line2?.message}
+              />
 
               <View className="flex-row gap-3">
                 <View className="flex-1">
-                  <Text className="mb-1.5 text-sm font-medium text-white/50">City *</Text>
-                  <Input
-                    value={form.city}
-                    onChangeText={updateField('city')}
+                  <FormField
+                    control={control}
+                    name="city"
+                    label="City *"
                     placeholder="City"
-                    placeholderTextColor="#666"
+                    error={formState.errors.city?.message}
                   />
                 </View>
                 <View className="flex-1">
-                  <Text className="mb-1.5 text-sm font-medium text-white/50">Region</Text>
-                  <Input
-                    value={form.region}
-                    onChangeText={updateField('region')}
+                  <FormField
+                    control={control}
+                    name="region"
+                    label="Region"
                     placeholder="State/Province"
-                    placeholderTextColor="#666"
+                    error={formState.errors.region?.message}
                   />
                 </View>
               </View>
 
               <View className="flex-row gap-3">
                 <View className="flex-1">
-                  <Text className="mb-1.5 text-sm font-medium text-white/50">Postal code *</Text>
-                  <Input
-                    value={form.postalCode}
-                    onChangeText={updateField('postalCode')}
+                  <FormField
+                    control={control}
+                    name="postalCode"
+                    label="Postal code *"
                     placeholder="Postal code"
-                    placeholderTextColor="#666"
+                    error={formState.errors.postalCode?.message}
                   />
                 </View>
                 <View className="flex-1">
-                  <Text className="mb-1.5 text-sm font-medium text-white/50">Country code *</Text>
-                  <Input
-                    value={form.countryCode}
-                    onChangeText={updateField('countryCode')}
+                  <FormField
+                    control={control}
+                    name="countryCode"
+                    label="Country code *"
                     placeholder="US"
-                    placeholderTextColor="#666"
+                    error={formState.errors.countryCode?.message}
                     maxLength={2}
                     autoCapitalize="characters"
                   />
                 </View>
               </View>
 
-              <View>
-                <Text className="mb-1.5 text-sm font-medium text-white/50">Phone number *</Text>
-                <Input
-                  value={form.phoneNumber}
-                  onChangeText={updateField('phoneNumber')}
-                  placeholder="+1234567890"
-                  placeholderTextColor="#666"
-                  keyboardType="phone-pad"
-                />
-              </View>
+              <FormField
+                control={control}
+                name="phoneNumber"
+                label="Phone number *"
+                placeholder="+1234567890"
+                error={formState.errors.phoneNumber?.message}
+                keyboardType="phone-pad"
+              />
             </View>
 
             <View className="mt-6 gap-4">
               <Button
                 className="h-14 rounded-xl bg-[#94F27F]"
-                onPress={handlePlaceOrder}
-                disabled={isSubmitting}
+                onPress={handleSubmit(onSubmit)}
+                disabled={orderMutation.isPending}
               >
-                {isSubmitting ? (
+                {orderMutation.isPending ? (
                   <ActivityIndicator color="black" />
                 ) : (
                   <Text className="text-base font-bold text-black">Place order</Text>
@@ -355,7 +408,7 @@ export default function OrderPhysicalCardModal({
                 variant="secondary"
                 className="h-14 rounded-xl border-0 bg-[#303030]"
                 onPress={() => onOpenChange(false)}
-                disabled={isSubmitting}
+                disabled={orderMutation.isPending}
               >
                 <Text className="text-base font-bold text-white">Cancel</Text>
               </Button>
@@ -364,5 +417,56 @@ export default function OrderPhysicalCardModal({
         </ScrollView>
       )}
     </ResponsiveModal>
+  );
+}
+
+function FormField({
+  control,
+  name,
+  label,
+  placeholder,
+  error,
+  keyboardType,
+  maxLength,
+  autoCapitalize,
+}: {
+  control: any;
+  name: string;
+  label: string;
+  placeholder: string;
+  error?: string;
+  keyboardType?: 'default' | 'phone-pad' | 'decimal-pad' | 'number-pad';
+  maxLength?: number;
+  autoCapitalize?: 'none' | 'sentences' | 'words' | 'characters';
+}) {
+  return (
+    <View className="gap-1.5">
+      <Text className="font-medium opacity-50">{label}</Text>
+      <View
+        className={cn(
+          'rounded-2xl bg-accent px-5 py-3',
+          error && 'border border-red-500',
+        )}
+      >
+        <Controller
+          control={control}
+          name={name}
+          render={({ field: { onChange, onBlur, value } }) => (
+            <TextInput
+              className="text-lg font-semibold text-white web:focus:outline-none"
+              value={value}
+              onChangeText={onChange}
+              onBlur={onBlur}
+              placeholder={placeholder}
+              placeholderTextColor="#666"
+              keyboardType={keyboardType}
+              maxLength={maxLength}
+              autoCapitalize={autoCapitalize}
+            />
+          )}
+        />
+      </View>
+      {error && <Text className="text-sm text-red-500">{error}</Text>}
+    </View>
   );
 }

--- a/components/Card/OrderPhysicalCardModal.tsx
+++ b/components/Card/OrderPhysicalCardModal.tsx
@@ -1,5 +1,5 @@
-import React, { useCallback, useEffect } from 'react';
-import { ActivityIndicator, Alert, ScrollView, TextInput, View } from 'react-native';
+import React, { useCallback, useEffect, useState } from 'react';
+import { ActivityIndicator, ScrollView, TextInput, View } from 'react-native';
 import Toast from 'react-native-toast-message';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { zodResolver } from '@hookform/resolvers/zod';
@@ -9,6 +9,14 @@ import { z } from 'zod';
 
 import ResponsiveModal, { ModalState } from '@/components/ResponsiveModal';
 import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
 import { Text } from '@/components/ui/text';
 import {
   cancelPhysicalCard,
@@ -175,21 +183,7 @@ export default function OrderPhysicalCardModal({
     [orderMutation],
   );
 
-  const handleCancel = useCallback(() => {
-    if (!physicalCardId) return;
-    Alert.alert(
-      'Cancel Physical Card',
-      'Are you sure you want to cancel your physical card order? This action cannot be undone.',
-      [
-        { text: 'No', style: 'cancel' },
-        {
-          text: 'Yes, Cancel',
-          style: 'destructive',
-          onPress: () => cancelMutation.mutate(physicalCardId),
-        },
-      ],
-    );
-  }, [physicalCardId, cancelMutation]);
+  const [isCancelConfirmOpen, setIsCancelConfirmOpen] = useState(false);
 
   return (
     <ResponsiveModal
@@ -226,7 +220,7 @@ export default function OrderPhysicalCardModal({
           <View className="gap-4">
             <Button
               className="h-14 rounded-xl bg-red-500"
-              onPress={handleCancel}
+              onPress={() => setIsCancelConfirmOpen(true)}
               disabled={cancelMutation.isPending}
             >
               {cancelMutation.isPending ? (
@@ -244,6 +238,19 @@ export default function OrderPhysicalCardModal({
               <Text className="text-base font-bold text-white">Close</Text>
             </Button>
           </View>
+
+          <CancelConfirmDialog
+            visible={isCancelConfirmOpen}
+            isPending={cancelMutation.isPending}
+            onConfirm={() => {
+              if (physicalCardId) {
+                cancelMutation.mutate(physicalCardId, {
+                  onSettled: () => setIsCancelConfirmOpen(false),
+                });
+              }
+            }}
+            onCancel={() => setIsCancelConfirmOpen(false)}
+          />
         </View>
       ) : (
         <ScrollView className="max-h-[70vh]" showsVerticalScrollIndicator={false}>
@@ -417,6 +424,55 @@ export default function OrderPhysicalCardModal({
         </ScrollView>
       )}
     </ResponsiveModal>
+  );
+}
+
+function CancelConfirmDialog({
+  visible,
+  isPending,
+  onConfirm,
+  onCancel,
+}: {
+  visible: boolean;
+  isPending: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+}) {
+  return (
+    <Dialog open={visible} onOpenChange={open => !open && onCancel()}>
+      <DialogContent showCloseButton={false} className="max-w-sm">
+        <DialogHeader>
+          <DialogTitle className="text-xl font-bold">Cancel physical card?</DialogTitle>
+        </DialogHeader>
+
+        <DialogDescription className="text-base text-muted-foreground">
+          Are you sure you want to cancel your physical card order? This action cannot be undone.
+        </DialogDescription>
+
+        <DialogFooter className="mt-4 flex-row gap-3">
+          <Button
+            variant="secondary"
+            className="flex-1 rounded-xl border-0"
+            onPress={onCancel}
+            disabled={isPending}
+          >
+            <Text className="font-semibold">Keep order</Text>
+          </Button>
+          <Button
+            variant="destructive"
+            className="flex-1 rounded-xl border-0"
+            onPress={onConfirm}
+            disabled={isPending}
+          >
+            {isPending ? (
+              <ActivityIndicator color="white" size="small" />
+            ) : (
+              <Text className="font-semibold text-white">Cancel card</Text>
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
   );
 }
 

--- a/components/Card/OrderPhysicalCardModal.tsx
+++ b/components/Card/OrderPhysicalCardModal.tsx
@@ -1,12 +1,18 @@
-import React, { useState } from 'react';
-import { ActivityIndicator, Alert, View } from 'react-native';
+import React, { useCallback, useEffect, useState } from 'react';
+import { ActivityIndicator, Alert, ScrollView, View } from 'react-native';
 import Toast from 'react-native-toast-message';
 import { CreditCard } from 'lucide-react-native';
 
 import ResponsiveModal, { ModalState } from '@/components/ResponsiveModal';
 import { Button } from '@/components/ui/button';
+import Input from '@/components/ui/input';
 import { Text } from '@/components/ui/text';
-import { orderPhysicalCard } from '@/lib/api';
+import {
+  cancelPhysicalCard,
+  getPhysicalCardShippingData,
+  getPhysicalCardStatus,
+  orderPhysicalCard,
+} from '@/lib/api';
 
 interface OrderPhysicalCardModalProps {
   trigger: React.ReactNode;
@@ -17,32 +23,153 @@ interface OrderPhysicalCardModalProps {
 const MODAL_STATE: ModalState = { name: 'order-physical-card', number: 1 };
 const CLOSE_STATE: ModalState = { name: 'close', number: 0 };
 
+interface ShippingForm {
+  firstName: string;
+  lastName: string;
+  line1: string;
+  line2: string;
+  city: string;
+  region: string;
+  postalCode: string;
+  countryCode: string;
+  phoneNumber: string;
+}
+
+const EMPTY_FORM: ShippingForm = {
+  firstName: '',
+  lastName: '',
+  line1: '',
+  line2: '',
+  city: '',
+  region: '',
+  postalCode: '',
+  countryCode: '',
+  phoneNumber: '',
+};
+
 export default function OrderPhysicalCardModal({
   trigger,
   isOpen,
   onOpenChange,
 }: OrderPhysicalCardModalProps) {
-  const [isChecking, setIsChecking] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isCanceling, setIsCanceling] = useState(false);
+  const [isLoadingData, setIsLoadingData] = useState(false);
+  const [form, setForm] = useState<ShippingForm>(EMPTY_FORM);
+  const [physicalCardId, setPhysicalCardId] = useState<string | null>(null);
+  const [hasPhysicalCard, setHasPhysicalCard] = useState(false);
 
-  const handleCheck = async () => {
+  const loadData = useCallback(async () => {
+    setIsLoadingData(true);
     try {
-      setIsChecking(true);
-      await orderPhysicalCard();
-      onOpenChange(false);
-      Toast.show({
-        type: 'success',
-        text1: 'Physical cards supported',
-        text2: 'Your Rain program supports physical card creation.',
+      const [statusResult, shippingResult] = await Promise.all([
+        getPhysicalCardStatus(),
+        getPhysicalCardShippingData(),
+      ]);
+
+      if (statusResult.hasPhysicalCard && statusResult.cardId) {
+        setHasPhysicalCard(true);
+        setPhysicalCardId(statusResult.cardId);
+      } else {
+        setHasPhysicalCard(false);
+        setPhysicalCardId(null);
+      }
+
+      setForm({
+        firstName: shippingResult.firstName ?? '',
+        lastName: shippingResult.lastName ?? '',
+        line1: shippingResult.line1 ?? '',
+        line2: shippingResult.line2 ?? '',
+        city: shippingResult.city ?? '',
+        region: shippingResult.region ?? '',
+        postalCode: shippingResult.postalCode ?? '',
+        countryCode: shippingResult.countryCode ?? '',
+        phoneNumber: shippingResult.phoneNumber ?? '',
       });
     } catch (_error) {
-      onOpenChange(false);
-      Alert.alert(
-        'Not supported',
-        'Physical card creation is not supported by your Rain program. Only virtual cards are available.',
-      );
+      // Shipping data may not be available, continue with empty form
     } finally {
-      setIsChecking(false);
+      setIsLoadingData(false);
     }
+  }, []);
+
+  useEffect(() => {
+    if (isOpen) {
+      loadData();
+    }
+  }, [isOpen, loadData]);
+
+  const updateField = (field: keyof ShippingForm) => (value: string) => {
+    setForm(prev => ({ ...prev, [field]: value }));
+  };
+
+  const handlePlaceOrder = async () => {
+    if (!form.firstName || !form.lastName || !form.line1 || !form.city || !form.postalCode || !form.countryCode || !form.phoneNumber) {
+      Alert.alert('Missing fields', 'Please fill in all required fields.');
+      return;
+    }
+
+    try {
+      setIsSubmitting(true);
+      const result = await orderPhysicalCard({
+        shipping: {
+          firstName: form.firstName,
+          lastName: form.lastName,
+          line1: form.line1,
+          ...(form.line2 ? { line2: form.line2 } : {}),
+          city: form.city,
+          ...(form.region ? { region: form.region } : {}),
+          postalCode: form.postalCode,
+          countryCode: form.countryCode,
+          phoneNumber: form.phoneNumber,
+        },
+      });
+      setHasPhysicalCard(true);
+      setPhysicalCardId(result.id);
+      Toast.show({
+        type: 'success',
+        text1: 'Physical card ordered',
+        text2: 'Your physical card has been ordered successfully.',
+      });
+    } catch (_error) {
+      Alert.alert('Error', 'Failed to order physical card. Please try again.');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleCancel = async () => {
+    if (!physicalCardId) return;
+
+    Alert.alert(
+      'Cancel Physical Card',
+      'Are you sure you want to cancel your physical card order? This action cannot be undone.',
+      [
+        { text: 'No', style: 'cancel' },
+        {
+          text: 'Yes, Cancel',
+          style: 'destructive',
+          onPress: async () => {
+            try {
+              setIsCanceling(true);
+              await cancelPhysicalCard(physicalCardId);
+              setHasPhysicalCard(false);
+              setPhysicalCardId(null);
+              onOpenChange(false);
+              Toast.show({
+                type: 'success',
+                text1: 'Physical card canceled',
+                text2: 'Your physical card order has been canceled.',
+              });
+            } catch (_error) {
+              Alert.alert('Error', 'Failed to cancel physical card. Please try again.');
+            } finally {
+              setIsCanceling(false);
+            }
+          },
+        },
+      ],
+    );
   };
 
   return (
@@ -52,47 +179,190 @@ export default function OrderPhysicalCardModal({
       isOpen={isOpen}
       onOpenChange={onOpenChange}
       trigger={trigger}
-      title="Order Physical Card"
+      title={hasPhysicalCard ? 'Physical Card Ordered' : 'Order Physical Card'}
       contentKey="order-physical-card"
       contentClassName="md:max-w-lg"
       shouldAnimate={false}
+      disableScroll
     >
-      <View className="p-6">
-        <View className="mb-6 items-center">
-          <View className="mb-4 items-center justify-center rounded-full bg-[#303030] p-4">
-            <CreditCard size={32} color="#94F27F" />
+      {isLoadingData ? (
+        <View className="items-center justify-center p-12">
+          <ActivityIndicator size="large" color="white" />
+        </View>
+      ) : hasPhysicalCard ? (
+        <View className="p-6">
+          <View className="mb-6 items-center">
+            <View className="mb-4 items-center justify-center rounded-full bg-[#303030] p-4">
+              <CreditCard size={32} color="#94F27F" />
+            </View>
+            <Text className="mb-2 text-center text-xl font-semibold text-white">
+              Physical card ordered
+            </Text>
+            <Text className="text-center text-base text-white/60">
+              Your physical card has been ordered and will be shipped to your address. You can cancel
+              the order if needed.
+            </Text>
           </View>
-          <Text className="mb-2 text-center text-xl font-semibold text-white">
-            Order Physical Card
-          </Text>
-          <Text className="text-center text-base text-white/60">
-            Check if your account supports physical card issuance. A test card will be created and
-            immediately canceled to verify eligibility.
-          </Text>
-        </View>
 
-        <View className="gap-4">
-          <Button
-            className="h-14 rounded-xl bg-[#94F27F]"
-            onPress={handleCheck}
-            disabled={isChecking}
-          >
-            {isChecking ? (
-              <ActivityIndicator color="black" />
-            ) : (
-              <Text className="text-base font-bold text-black">Check Eligibility</Text>
-            )}
-          </Button>
-          <Button
-            variant="secondary"
-            className="h-14 rounded-xl border-0 bg-[#303030]"
-            onPress={() => onOpenChange(false)}
-            disabled={isChecking}
-          >
-            <Text className="text-base font-bold text-white">Cancel</Text>
-          </Button>
+          <View className="gap-4">
+            <Button
+              className="h-14 rounded-xl bg-red-500"
+              onPress={handleCancel}
+              disabled={isCanceling}
+            >
+              {isCanceling ? (
+                <ActivityIndicator color="white" />
+              ) : (
+                <Text className="text-base font-bold text-white">Cancel Physical Card</Text>
+              )}
+            </Button>
+            <Button
+              variant="secondary"
+              className="h-14 rounded-xl border-0 bg-[#303030]"
+              onPress={() => onOpenChange(false)}
+              disabled={isCanceling}
+            >
+              <Text className="text-base font-bold text-white">Close</Text>
+            </Button>
+          </View>
         </View>
-      </View>
+      ) : (
+        <ScrollView className="max-h-[70vh]" showsVerticalScrollIndicator={false}>
+          <View className="p-6">
+            <View className="mb-6 items-center">
+              <View className="mb-4 items-center justify-center rounded-full bg-[#303030] p-4">
+                <CreditCard size={32} color="#94F27F" />
+              </View>
+              <Text className="mb-2 text-center text-xl font-semibold text-white">
+                Shipping details
+              </Text>
+              <Text className="text-center text-base text-white/60">
+                Enter the address where your physical card should be shipped.
+              </Text>
+            </View>
+
+            <View className="gap-3">
+              <View className="flex-row gap-3">
+                <View className="flex-1">
+                  <Text className="mb-1.5 text-sm font-medium text-white/50">First name *</Text>
+                  <Input
+                    value={form.firstName}
+                    onChangeText={updateField('firstName')}
+                    placeholder="First name"
+                    placeholderTextColor="#666"
+                  />
+                </View>
+                <View className="flex-1">
+                  <Text className="mb-1.5 text-sm font-medium text-white/50">Last name *</Text>
+                  <Input
+                    value={form.lastName}
+                    onChangeText={updateField('lastName')}
+                    placeholder="Last name"
+                    placeholderTextColor="#666"
+                  />
+                </View>
+              </View>
+
+              <View>
+                <Text className="mb-1.5 text-sm font-medium text-white/50">Address line 1 *</Text>
+                <Input
+                  value={form.line1}
+                  onChangeText={updateField('line1')}
+                  placeholder="Street address"
+                  placeholderTextColor="#666"
+                />
+              </View>
+
+              <View>
+                <Text className="mb-1.5 text-sm font-medium text-white/50">Address line 2</Text>
+                <Input
+                  value={form.line2}
+                  onChangeText={updateField('line2')}
+                  placeholder="Apt, suite, unit (optional)"
+                  placeholderTextColor="#666"
+                />
+              </View>
+
+              <View className="flex-row gap-3">
+                <View className="flex-1">
+                  <Text className="mb-1.5 text-sm font-medium text-white/50">City *</Text>
+                  <Input
+                    value={form.city}
+                    onChangeText={updateField('city')}
+                    placeholder="City"
+                    placeholderTextColor="#666"
+                  />
+                </View>
+                <View className="flex-1">
+                  <Text className="mb-1.5 text-sm font-medium text-white/50">Region</Text>
+                  <Input
+                    value={form.region}
+                    onChangeText={updateField('region')}
+                    placeholder="State/Province"
+                    placeholderTextColor="#666"
+                  />
+                </View>
+              </View>
+
+              <View className="flex-row gap-3">
+                <View className="flex-1">
+                  <Text className="mb-1.5 text-sm font-medium text-white/50">Postal code *</Text>
+                  <Input
+                    value={form.postalCode}
+                    onChangeText={updateField('postalCode')}
+                    placeholder="Postal code"
+                    placeholderTextColor="#666"
+                  />
+                </View>
+                <View className="flex-1">
+                  <Text className="mb-1.5 text-sm font-medium text-white/50">Country code *</Text>
+                  <Input
+                    value={form.countryCode}
+                    onChangeText={updateField('countryCode')}
+                    placeholder="US"
+                    placeholderTextColor="#666"
+                    maxLength={2}
+                    autoCapitalize="characters"
+                  />
+                </View>
+              </View>
+
+              <View>
+                <Text className="mb-1.5 text-sm font-medium text-white/50">Phone number *</Text>
+                <Input
+                  value={form.phoneNumber}
+                  onChangeText={updateField('phoneNumber')}
+                  placeholder="+1234567890"
+                  placeholderTextColor="#666"
+                  keyboardType="phone-pad"
+                />
+              </View>
+            </View>
+
+            <View className="mt-6 gap-4">
+              <Button
+                className="h-14 rounded-xl bg-[#94F27F]"
+                onPress={handlePlaceOrder}
+                disabled={isSubmitting}
+              >
+                {isSubmitting ? (
+                  <ActivityIndicator color="black" />
+                ) : (
+                  <Text className="text-base font-bold text-black">Place order</Text>
+                )}
+              </Button>
+              <Button
+                variant="secondary"
+                className="h-14 rounded-xl border-0 bg-[#303030]"
+                onPress={() => onOpenChange(false)}
+                disabled={isSubmitting}
+              >
+                <Text className="text-base font-bold text-white">Cancel</Text>
+              </Button>
+            </View>
+          </View>
+        </ScrollView>
+      )}
     </ResponsiveModal>
   );
 }

--- a/components/Card/OrderPhysicalCardModal.tsx
+++ b/components/Card/OrderPhysicalCardModal.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect } from 'react';
 import { ActivityIndicator, ScrollView, TextInput, View } from 'react-native';
 import Toast from 'react-native-toast-message';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
@@ -9,23 +9,12 @@ import { z } from 'zod';
 
 import ResponsiveModal, { ModalState } from '@/components/ResponsiveModal';
 import { Button } from '@/components/ui/button';
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from '@/components/ui/dialog';
 import { Text } from '@/components/ui/text';
-import {
-  cancelPhysicalCard,
-  getPhysicalCardShippingData,
-  getPhysicalCardStatus,
-  orderPhysicalCard,
-} from '@/lib/api';
-import { withRefreshToken } from '@/lib/utils/utils';
-import { cn } from '@/lib/utils/utils';
+import { getPhysicalCardShippingData, orderPhysicalCard } from '@/lib/api';
+import { cn, withRefreshToken } from '@/lib/utils/utils';
+
+export const PHYSICAL_CARD_STATUS_QUERY_KEY = 'physicalCardStatus';
+const SHIPPING_DATA_QUERY_KEY = 'physicalCardShippingData';
 
 interface OrderPhysicalCardModalProps {
   trigger: React.ReactNode;
@@ -35,9 +24,6 @@ interface OrderPhysicalCardModalProps {
 
 const MODAL_STATE: ModalState = { name: 'order-physical-card', number: 1 };
 const CLOSE_STATE: ModalState = { name: 'close', number: 0 };
-
-export const PHYSICAL_CARD_STATUS_QUERY_KEY = 'physicalCardStatus';
-const SHIPPING_DATA_QUERY_KEY = 'physicalCardShippingData';
 
 const shippingSchema = z.object({
   firstName: z
@@ -71,20 +57,11 @@ export default function OrderPhysicalCardModal({
 }: OrderPhysicalCardModalProps) {
   const queryClient = useQueryClient();
 
-  const { data: statusData, isLoading: isLoadingStatus } = useQuery({
-    queryKey: [PHYSICAL_CARD_STATUS_QUERY_KEY],
-    queryFn: () => withRefreshToken(() => getPhysicalCardStatus()),
-    enabled: isOpen,
-  });
-
   const { data: shippingData } = useQuery({
     queryKey: [SHIPPING_DATA_QUERY_KEY],
     queryFn: () => withRefreshToken(() => getPhysicalCardShippingData()),
-    enabled: isOpen && !statusData?.hasPhysicalCard,
+    enabled: isOpen,
   });
-
-  const hasPhysicalCard = statusData?.hasPhysicalCard ?? false;
-  const physicalCardId = statusData?.cardId;
 
   const { control, handleSubmit, formState, reset } = useForm<ShippingFormData>({
     resolver: zodResolver(shippingSchema) as any,
@@ -137,6 +114,7 @@ export default function OrderPhysicalCardModal({
       ),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: [PHYSICAL_CARD_STATUS_QUERY_KEY] });
+      onOpenChange(false);
       Toast.show({
         type: 'success',
         text1: 'Physical card ordered',
@@ -154,36 +132,12 @@ export default function OrderPhysicalCardModal({
     },
   });
 
-  const cancelMutation = useMutation({
-    mutationFn: (cardId: string) => withRefreshToken(() => cancelPhysicalCard(cardId)),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: [PHYSICAL_CARD_STATUS_QUERY_KEY] });
-      onOpenChange(false);
-      Toast.show({
-        type: 'success',
-        text1: 'Physical card canceled',
-        text2: 'Your physical card order has been canceled.',
-        props: { badgeText: '' },
-      });
-    },
-    onError: () => {
-      Toast.show({
-        type: 'error',
-        text1: 'Failed to cancel physical card',
-        text2: 'Please try again.',
-        props: { badgeText: '' },
-      });
-    },
-  });
-
   const onSubmit = useCallback(
     (data: ShippingFormData) => {
       orderMutation.mutate(data);
     },
     [orderMutation],
   );
-
-  const [isCancelConfirmOpen, setIsCancelConfirmOpen] = useState(false);
 
   return (
     <ResponsiveModal
@@ -192,287 +146,182 @@ export default function OrderPhysicalCardModal({
       isOpen={isOpen}
       onOpenChange={onOpenChange}
       trigger={trigger}
-      title={hasPhysicalCard ? 'Physical Card Ordered' : 'Order Physical Card'}
+      title="Order Physical Card"
       contentKey="order-physical-card"
       contentClassName="md:max-w-lg"
       shouldAnimate={false}
       disableScroll
     >
-      {isLoadingStatus ? (
-        <View className="items-center justify-center p-12">
-          <ActivityIndicator size="large" color="white" />
-        </View>
-      ) : hasPhysicalCard ? (
+      <ScrollView className="max-h-[70vh]" showsVerticalScrollIndicator={false}>
         <View className="p-6">
           <View className="mb-6 items-center">
             <View className="mb-4 items-center justify-center rounded-full bg-[#303030] p-4">
               <CreditCard size={32} color="#94F27F" />
             </View>
             <Text className="mb-2 text-center text-xl font-semibold text-white">
-              Physical card ordered
+              Shipping details
             </Text>
             <Text className="text-center text-base text-white/60">
-              Your physical card has been ordered and will be shipped to your address. You can cancel
-              the order if needed.
+              Enter the address where your physical card should be shipped.
             </Text>
           </View>
 
-          <View className="gap-4">
+          <View className="gap-3">
+            <View className="flex-row gap-3">
+              <View className="flex-1 gap-1.5">
+                <Text className="font-medium opacity-50">First name *</Text>
+                <View
+                  className={cn(
+                    'rounded-2xl bg-accent px-5 py-3',
+                    formState.errors.firstName && 'border border-red-500',
+                  )}
+                >
+                  <Controller
+                    control={control}
+                    name="firstName"
+                    render={({ field: { onChange, onBlur, value } }) => (
+                      <TextInput
+                        className="text-lg font-semibold text-white web:focus:outline-none"
+                        value={value}
+                        onChangeText={onChange}
+                        onBlur={onBlur}
+                        placeholder="First name"
+                        placeholderTextColor="#666"
+                      />
+                    )}
+                  />
+                </View>
+                {formState.errors.firstName && (
+                  <Text className="text-sm text-red-500">
+                    {formState.errors.firstName.message}
+                  </Text>
+                )}
+              </View>
+              <View className="flex-1 gap-1.5">
+                <Text className="font-medium opacity-50">Last name *</Text>
+                <View
+                  className={cn(
+                    'rounded-2xl bg-accent px-5 py-3',
+                    formState.errors.lastName && 'border border-red-500',
+                  )}
+                >
+                  <Controller
+                    control={control}
+                    name="lastName"
+                    render={({ field: { onChange, onBlur, value } }) => (
+                      <TextInput
+                        className="text-lg font-semibold text-white web:focus:outline-none"
+                        value={value}
+                        onChangeText={onChange}
+                        onBlur={onBlur}
+                        placeholder="Last name"
+                        placeholderTextColor="#666"
+                      />
+                    )}
+                  />
+                </View>
+                {formState.errors.lastName && (
+                  <Text className="text-sm text-red-500">
+                    {formState.errors.lastName.message}
+                  </Text>
+                )}
+              </View>
+            </View>
+
+            <FormField
+              control={control}
+              name="line1"
+              label="Address line 1 *"
+              placeholder="Street address"
+              error={formState.errors.line1?.message}
+            />
+
+            <FormField
+              control={control}
+              name="line2"
+              label="Address line 2"
+              placeholder="Apt, suite, unit (optional)"
+              error={formState.errors.line2?.message}
+            />
+
+            <View className="flex-row gap-3">
+              <View className="flex-1">
+                <FormField
+                  control={control}
+                  name="city"
+                  label="City *"
+                  placeholder="City"
+                  error={formState.errors.city?.message}
+                />
+              </View>
+              <View className="flex-1">
+                <FormField
+                  control={control}
+                  name="region"
+                  label="Region"
+                  placeholder="State/Province"
+                  error={formState.errors.region?.message}
+                />
+              </View>
+            </View>
+
+            <View className="flex-row gap-3">
+              <View className="flex-1">
+                <FormField
+                  control={control}
+                  name="postalCode"
+                  label="Postal code *"
+                  placeholder="Postal code"
+                  error={formState.errors.postalCode?.message}
+                />
+              </View>
+              <View className="flex-1">
+                <FormField
+                  control={control}
+                  name="countryCode"
+                  label="Country code *"
+                  placeholder="US"
+                  error={formState.errors.countryCode?.message}
+                  maxLength={2}
+                  autoCapitalize="characters"
+                />
+              </View>
+            </View>
+
+            <FormField
+              control={control}
+              name="phoneNumber"
+              label="Phone number *"
+              placeholder="+1234567890"
+              error={formState.errors.phoneNumber?.message}
+              keyboardType="phone-pad"
+            />
+          </View>
+
+          <View className="mt-6 gap-4">
             <Button
-              className="h-14 rounded-xl bg-red-500"
-              onPress={() => setIsCancelConfirmOpen(true)}
-              disabled={cancelMutation.isPending}
+              className="h-14 rounded-xl bg-[#94F27F]"
+              onPress={handleSubmit(onSubmit)}
+              disabled={orderMutation.isPending}
             >
-              {cancelMutation.isPending ? (
-                <ActivityIndicator color="white" />
+              {orderMutation.isPending ? (
+                <ActivityIndicator color="black" />
               ) : (
-                <Text className="text-base font-bold text-white">Cancel Physical Card</Text>
+                <Text className="text-base font-bold text-black">Place order</Text>
               )}
             </Button>
             <Button
               variant="secondary"
               className="h-14 rounded-xl border-0 bg-[#303030]"
               onPress={() => onOpenChange(false)}
-              disabled={cancelMutation.isPending}
+              disabled={orderMutation.isPending}
             >
-              <Text className="text-base font-bold text-white">Close</Text>
+              <Text className="text-base font-bold text-white">Cancel</Text>
             </Button>
           </View>
-
-          <CancelConfirmDialog
-            visible={isCancelConfirmOpen}
-            isPending={cancelMutation.isPending}
-            onConfirm={() => {
-              if (physicalCardId) {
-                cancelMutation.mutate(physicalCardId, {
-                  onSettled: () => setIsCancelConfirmOpen(false),
-                });
-              }
-            }}
-            onCancel={() => setIsCancelConfirmOpen(false)}
-          />
         </View>
-      ) : (
-        <ScrollView className="max-h-[70vh]" showsVerticalScrollIndicator={false}>
-          <View className="p-6">
-            <View className="mb-6 items-center">
-              <View className="mb-4 items-center justify-center rounded-full bg-[#303030] p-4">
-                <CreditCard size={32} color="#94F27F" />
-              </View>
-              <Text className="mb-2 text-center text-xl font-semibold text-white">
-                Shipping details
-              </Text>
-              <Text className="text-center text-base text-white/60">
-                Enter the address where your physical card should be shipped.
-              </Text>
-            </View>
-
-            <View className="gap-3">
-              <View className="flex-row gap-3">
-                <View className="flex-1 gap-1.5">
-                  <Text className="font-medium opacity-50">First name *</Text>
-                  <View
-                    className={cn(
-                      'rounded-2xl bg-accent px-5 py-3',
-                      formState.errors.firstName && 'border border-red-500',
-                    )}
-                  >
-                    <Controller
-                      control={control}
-                      name="firstName"
-                      render={({ field: { onChange, onBlur, value } }) => (
-                        <TextInput
-                          className="text-lg font-semibold text-white web:focus:outline-none"
-                          value={value}
-                          onChangeText={onChange}
-                          onBlur={onBlur}
-                          placeholder="First name"
-                          placeholderTextColor="#666"
-                        />
-                      )}
-                    />
-                  </View>
-                  {formState.errors.firstName && (
-                    <Text className="text-sm text-red-500">
-                      {formState.errors.firstName.message}
-                    </Text>
-                  )}
-                </View>
-                <View className="flex-1 gap-1.5">
-                  <Text className="font-medium opacity-50">Last name *</Text>
-                  <View
-                    className={cn(
-                      'rounded-2xl bg-accent px-5 py-3',
-                      formState.errors.lastName && 'border border-red-500',
-                    )}
-                  >
-                    <Controller
-                      control={control}
-                      name="lastName"
-                      render={({ field: { onChange, onBlur, value } }) => (
-                        <TextInput
-                          className="text-lg font-semibold text-white web:focus:outline-none"
-                          value={value}
-                          onChangeText={onChange}
-                          onBlur={onBlur}
-                          placeholder="Last name"
-                          placeholderTextColor="#666"
-                        />
-                      )}
-                    />
-                  </View>
-                  {formState.errors.lastName && (
-                    <Text className="text-sm text-red-500">
-                      {formState.errors.lastName.message}
-                    </Text>
-                  )}
-                </View>
-              </View>
-
-              <FormField
-                control={control}
-                name="line1"
-                label="Address line 1 *"
-                placeholder="Street address"
-                error={formState.errors.line1?.message}
-              />
-
-              <FormField
-                control={control}
-                name="line2"
-                label="Address line 2"
-                placeholder="Apt, suite, unit (optional)"
-                error={formState.errors.line2?.message}
-              />
-
-              <View className="flex-row gap-3">
-                <View className="flex-1">
-                  <FormField
-                    control={control}
-                    name="city"
-                    label="City *"
-                    placeholder="City"
-                    error={formState.errors.city?.message}
-                  />
-                </View>
-                <View className="flex-1">
-                  <FormField
-                    control={control}
-                    name="region"
-                    label="Region"
-                    placeholder="State/Province"
-                    error={formState.errors.region?.message}
-                  />
-                </View>
-              </View>
-
-              <View className="flex-row gap-3">
-                <View className="flex-1">
-                  <FormField
-                    control={control}
-                    name="postalCode"
-                    label="Postal code *"
-                    placeholder="Postal code"
-                    error={formState.errors.postalCode?.message}
-                  />
-                </View>
-                <View className="flex-1">
-                  <FormField
-                    control={control}
-                    name="countryCode"
-                    label="Country code *"
-                    placeholder="US"
-                    error={formState.errors.countryCode?.message}
-                    maxLength={2}
-                    autoCapitalize="characters"
-                  />
-                </View>
-              </View>
-
-              <FormField
-                control={control}
-                name="phoneNumber"
-                label="Phone number *"
-                placeholder="+1234567890"
-                error={formState.errors.phoneNumber?.message}
-                keyboardType="phone-pad"
-              />
-            </View>
-
-            <View className="mt-6 gap-4">
-              <Button
-                className="h-14 rounded-xl bg-[#94F27F]"
-                onPress={handleSubmit(onSubmit)}
-                disabled={orderMutation.isPending}
-              >
-                {orderMutation.isPending ? (
-                  <ActivityIndicator color="black" />
-                ) : (
-                  <Text className="text-base font-bold text-black">Place order</Text>
-                )}
-              </Button>
-              <Button
-                variant="secondary"
-                className="h-14 rounded-xl border-0 bg-[#303030]"
-                onPress={() => onOpenChange(false)}
-                disabled={orderMutation.isPending}
-              >
-                <Text className="text-base font-bold text-white">Cancel</Text>
-              </Button>
-            </View>
-          </View>
-        </ScrollView>
-      )}
+      </ScrollView>
     </ResponsiveModal>
-  );
-}
-
-function CancelConfirmDialog({
-  visible,
-  isPending,
-  onConfirm,
-  onCancel,
-}: {
-  visible: boolean;
-  isPending: boolean;
-  onConfirm: () => void;
-  onCancel: () => void;
-}) {
-  return (
-    <Dialog open={visible} onOpenChange={open => !open && onCancel()}>
-      <DialogContent showCloseButton={false} className="max-w-sm">
-        <DialogHeader>
-          <DialogTitle className="text-xl font-bold">Cancel physical card?</DialogTitle>
-        </DialogHeader>
-
-        <DialogDescription className="text-base text-muted-foreground">
-          Are you sure you want to cancel your physical card order? This action cannot be undone.
-        </DialogDescription>
-
-        <DialogFooter className="mt-4 flex-row gap-3">
-          <Button
-            variant="secondary"
-            className="flex-1 rounded-xl border-0"
-            onPress={onCancel}
-            disabled={isPending}
-          >
-            <Text className="font-semibold">Keep order</Text>
-          </Button>
-          <Button
-            variant="destructive"
-            className="flex-1 rounded-xl border-0"
-            onPress={onConfirm}
-            disabled={isPending}
-          >
-            {isPending ? (
-              <ActivityIndicator color="white" size="small" />
-            ) : (
-              <Text className="font-semibold text-white">Cancel card</Text>
-            )}
-          </Button>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
   );
 }
 

--- a/components/Card/OrderPhysicalCardModal.tsx
+++ b/components/Card/OrderPhysicalCardModal.tsx
@@ -22,22 +22,26 @@ export default function OrderPhysicalCardModal({
   isOpen,
   onOpenChange,
 }: OrderPhysicalCardModalProps) {
-  const [isOrdering, setIsOrdering] = useState(false);
+  const [isChecking, setIsChecking] = useState(false);
 
-  const handleOrder = async () => {
+  const handleCheck = async () => {
     try {
-      setIsOrdering(true);
+      setIsChecking(true);
       await orderPhysicalCard();
       onOpenChange(false);
       Toast.show({
         type: 'success',
-        text1: 'Physical card ordered',
-        text2: 'Your physical card has been ordered successfully.',
+        text1: 'Physical cards supported',
+        text2: 'Your Rain program supports physical card creation.',
       });
     } catch (_error) {
-      Alert.alert('Error', 'Failed to order physical card. Please try again.');
+      onOpenChange(false);
+      Alert.alert(
+        'Not supported',
+        'Physical card creation is not supported by your Rain program. Only virtual cards are available.',
+      );
     } finally {
-      setIsOrdering(false);
+      setIsChecking(false);
     }
   };
 
@@ -59,31 +63,31 @@ export default function OrderPhysicalCardModal({
             <CreditCard size={32} color="#94F27F" />
           </View>
           <Text className="mb-2 text-center text-xl font-semibold text-white">
-            Get your physical card
+            Order Physical Card
           </Text>
           <Text className="text-center text-base text-white/60">
-            Order a physical Solid card delivered to your address. The card will need to be activated
-            once received.
+            Check if your account supports physical card issuance. A test card will be created and
+            immediately canceled to verify eligibility.
           </Text>
         </View>
 
         <View className="gap-4">
           <Button
             className="h-14 rounded-xl bg-[#94F27F]"
-            onPress={handleOrder}
-            disabled={isOrdering}
+            onPress={handleCheck}
+            disabled={isChecking}
           >
-            {isOrdering ? (
+            {isChecking ? (
               <ActivityIndicator color="black" />
             ) : (
-              <Text className="text-base font-bold text-black">Order Physical Card</Text>
+              <Text className="text-base font-bold text-black">Check Eligibility</Text>
             )}
           </Button>
           <Button
             variant="secondary"
             className="h-14 rounded-xl border-0 bg-[#303030]"
             onPress={() => onOpenChange(false)}
-            disabled={isOrdering}
+            disabled={isChecking}
           >
             <Text className="text-base font-bold text-white">Cancel</Text>
           </Button>

--- a/components/Card/OrderPhysicalCardModal.tsx
+++ b/components/Card/OrderPhysicalCardModal.tsx
@@ -1,0 +1,94 @@
+import React, { useState } from 'react';
+import { ActivityIndicator, Alert, View } from 'react-native';
+import Toast from 'react-native-toast-message';
+import { CreditCard } from 'lucide-react-native';
+
+import ResponsiveModal, { ModalState } from '@/components/ResponsiveModal';
+import { Button } from '@/components/ui/button';
+import { Text } from '@/components/ui/text';
+import { orderPhysicalCard } from '@/lib/api';
+
+interface OrderPhysicalCardModalProps {
+  trigger: React.ReactNode;
+  isOpen: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+const MODAL_STATE: ModalState = { name: 'order-physical-card', number: 1 };
+const CLOSE_STATE: ModalState = { name: 'close', number: 0 };
+
+export default function OrderPhysicalCardModal({
+  trigger,
+  isOpen,
+  onOpenChange,
+}: OrderPhysicalCardModalProps) {
+  const [isOrdering, setIsOrdering] = useState(false);
+
+  const handleOrder = async () => {
+    try {
+      setIsOrdering(true);
+      await orderPhysicalCard();
+      onOpenChange(false);
+      Toast.show({
+        type: 'success',
+        text1: 'Physical card ordered',
+        text2: 'Your physical card has been ordered successfully.',
+      });
+    } catch (_error) {
+      Alert.alert('Error', 'Failed to order physical card. Please try again.');
+    } finally {
+      setIsOrdering(false);
+    }
+  };
+
+  return (
+    <ResponsiveModal
+      currentModal={MODAL_STATE}
+      previousModal={CLOSE_STATE}
+      isOpen={isOpen}
+      onOpenChange={onOpenChange}
+      trigger={trigger}
+      title="Order Physical Card"
+      contentKey="order-physical-card"
+      contentClassName="md:max-w-lg"
+      shouldAnimate={false}
+    >
+      <View className="p-6">
+        <View className="mb-6 items-center">
+          <View className="mb-4 items-center justify-center rounded-full bg-[#303030] p-4">
+            <CreditCard size={32} color="#94F27F" />
+          </View>
+          <Text className="mb-2 text-center text-xl font-semibold text-white">
+            Get your physical card
+          </Text>
+          <Text className="text-center text-base text-white/60">
+            Order a physical Solid card delivered to your address. The card will need to be activated
+            once received.
+          </Text>
+        </View>
+
+        <View className="gap-4">
+          <Button
+            className="h-14 rounded-xl bg-[#94F27F]"
+            onPress={handleOrder}
+            disabled={isOrdering}
+          >
+            {isOrdering ? (
+              <ActivityIndicator color="black" />
+            ) : (
+              <Text className="text-base font-bold text-black">Order Physical Card</Text>
+            )}
+          </Button>
+          <Button
+            variant="secondary"
+            className="h-14 rounded-xl border-0 bg-[#303030]"
+            onPress={() => onOpenChange(false)}
+            disabled={isOrdering}
+          >
+            <Text className="text-base font-bold text-white">Cancel</Text>
+          </Button>
+        </View>
+      </View>
+    </ResponsiveModal>
+  );
+}

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -662,6 +662,28 @@ export const createCard = async (): Promise<CardResponse> => {
   return response.json();
 };
 
+export const orderPhysicalCard = async (options?: {
+  productId?: string;
+  virtualCardArt?: string;
+}): Promise<CardResponse> => {
+  const jwt = getJWTToken();
+
+  const response = await fetch(`${EXPO_PUBLIC_FLASH_API_BASE_URL}/accounts/v1/cards/physical`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...getPlatformHeaders(),
+      ...(jwt ? { Authorization: `Bearer ${jwt}` } : {}),
+    },
+    credentials: 'include',
+    body: JSON.stringify(options ?? {}),
+  });
+
+  if (!response.ok) throw response;
+
+  return response.json();
+};
+
 export const getCardStatus = async (): Promise<CardStatusResponse | null> => {
   const jwt = getJWTToken();
 

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -665,6 +665,17 @@ export const createCard = async (): Promise<CardResponse> => {
 export const orderPhysicalCard = async (options?: {
   productId?: string;
   virtualCardArt?: string;
+  shipping?: {
+    firstName?: string;
+    lastName?: string;
+    line1: string;
+    line2?: string;
+    city: string;
+    region?: string;
+    postalCode: string;
+    countryCode: string;
+    phoneNumber: string;
+  };
 }): Promise<CardResponse> => {
   const jwt = getJWTToken();
 
@@ -678,6 +689,80 @@ export const orderPhysicalCard = async (options?: {
     credentials: 'include',
     body: JSON.stringify(options ?? {}),
   });
+
+  if (!response.ok) throw response;
+
+  return response.json();
+};
+
+export const getPhysicalCardStatus = async (): Promise<{
+  hasPhysicalCard: boolean;
+  cardId?: string;
+  status?: string;
+}> => {
+  const jwt = getJWTToken();
+
+  const response = await fetch(
+    `${EXPO_PUBLIC_FLASH_API_BASE_URL}/accounts/v1/cards/physical/status`,
+    {
+      credentials: 'include',
+      headers: {
+        ...getPlatformHeaders(),
+        ...(jwt ? { Authorization: `Bearer ${jwt}` } : {}),
+      },
+    },
+  );
+
+  if (!response.ok) throw response;
+
+  return response.json();
+};
+
+export const cancelPhysicalCard = async (cardId: string): Promise<{ message: string }> => {
+  const jwt = getJWTToken();
+
+  const response = await fetch(
+    `${EXPO_PUBLIC_FLASH_API_BASE_URL}/accounts/v1/cards/physical/cancel`,
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        ...getPlatformHeaders(),
+        ...(jwt ? { Authorization: `Bearer ${jwt}` } : {}),
+      },
+      credentials: 'include',
+      body: JSON.stringify({ cardId }),
+    },
+  );
+
+  if (!response.ok) throw response;
+
+  return response.json();
+};
+
+export const getPhysicalCardShippingData = async (): Promise<{
+  firstName?: string;
+  lastName?: string;
+  line1?: string;
+  line2?: string;
+  city?: string;
+  region?: string;
+  postalCode?: string;
+  countryCode?: string;
+  phoneNumber?: string;
+}> => {
+  const jwt = getJWTToken();
+
+  const response = await fetch(
+    `${EXPO_PUBLIC_FLASH_API_BASE_URL}/accounts/v1/cards/physical/shipping-data`,
+    {
+      credentials: 'include',
+      headers: {
+        ...getPlatformHeaders(),
+        ...(jwt ? { Authorization: `Bearer ${jwt}` } : {}),
+      },
+    },
+  );
 
   if (!response.ok) throw response;
 


### PR DESCRIPTION
Add "Order Physical Card" button between Manage and Withdraw on both desktop and mobile layouts. Desktop shows a header button, mobile shows a circular action button. Includes OrderPhysicalCardModal with confirmation flow and orderPhysicalCard API function. Only visible for Rain card provider.

https://claude.ai/code/session_012if81DYb8SeUEkniusLQfw