### PR TITLE
feat: add order physical card UI with shipping form

### DIFF
--- a/app/(protected)/(tabs)/card/details.tsx
+++ b/app/(protected)/(tabs)/card/details.tsx
@@ -13,13 +13,26 @@ import * as Clipboard from 'expo-clipboard';
 import { Image } from 'expo-image';
 import { LinearGradient } from 'expo-linear-gradient';
 import { useRouter } from 'expo-router';
-import { ChevronDown, ChevronRight, Copy, KeyRound, Plus, Settings } from 'lucide-react-native';
+import { useQuery } from '@tanstack/react-query';
+import {
+  ChevronDown,
+  ChevronRight,
+  Copy,
+  CreditCard,
+  KeyRound,
+  Plus,
+  Settings,
+} from 'lucide-react-native';
 
 import AddToWalletModal from '@/components/Card/AddToWalletModal';
 import { BorrowPositionCard } from '@/components/Card/BorrowPositionCard';
 import { CircularActionButton } from '@/components/Card/CircularActionButton';
 import DepositToCardModal from '@/components/Card/DepositToCardModal';
 import ManagePinModal from '@/components/Card/ManagePinModal';
+import CancelPhysicalCardModal from '@/components/Card/CancelPhysicalCardModal';
+import OrderPhysicalCardModal, {
+  PHYSICAL_CARD_STATUS_QUERY_KEY,
+} from '@/components/Card/OrderPhysicalCardModal';
 import WithdrawToCardModal from '@/components/Card/WithdrawToCardModal';
 import PageLayout from '@/components/PageLayout';
 import { Button } from '@/components/ui/button';
@@ -39,11 +52,11 @@ import { useCardProvider } from '@/hooks/useCardProvider';
 import { useCardWithdrawals } from '@/hooks/useCardWithdrawals';
 import { useCustomer } from '@/hooks/useCustomer';
 import { useDimension } from '@/hooks/useDimension';
-import { freezeCard, unfreezeCard } from '@/lib/api';
+import { freezeCard, getPhysicalCardStatus, unfreezeCard } from '@/lib/api';
 import { getAsset } from '@/lib/assets';
 import { EXPO_PUBLIC_ENVIRONMENT } from '@/lib/config';
 import { CardHolderName, CardProvider, CardStatus, FreezeInitiator, KycStatus } from '@/lib/types';
-import { cn } from '@/lib/utils/utils';
+import { cn, withRefreshToken } from '@/lib/utils/utils';
 import { CardDepositSource, useCardDepositStore } from '@/store/useCardDepositStore';
 
 export default function CardDetails() {
@@ -59,7 +72,17 @@ export default function CardDetails() {
   const [isLoadingCardDetails, setIsLoadingCardDetails] = useState(false);
   const [shouldRevealDetails, setShouldRevealDetails] = useState(false);
   const [isAddToWalletModalOpen, setIsAddToWalletModalOpen] = useState(false);
+  const [isOrderPhysicalCardModalOpen, setIsOrderPhysicalCardModalOpen] = useState(false);
+  const [isCancelPhysicalCardModalOpen, setIsCancelPhysicalCardModalOpen] = useState(false);
   const flipAnimation = useRef(new Animated.Value(0)).current;
+
+  const { data: physicalCardStatusData } = useQuery({
+    queryKey: [PHYSICAL_CARD_STATUS_QUERY_KEY],
+    queryFn: () => withRefreshToken(() => getPhysicalCardStatus()),
+    enabled: provider === CardProvider.RAIN,
+  });
+
+  const hasPhysicalCard = physicalCardStatusData?.hasPhysicalCard ?? false;
 
   const availableBalance = cardDetails?.balances.available;
   const availableAmount = Number(availableBalance?.amount || '0').toString();
@@ -135,6 +158,12 @@ export default function CardDetails() {
         onFreezeToggle={handleFreezeToggle}
         isWithdrawFromCardAllowed={isWithdrawFromCardAllowed}
         isRain={provider === CardProvider.RAIN}
+        hasPhysicalCard={hasPhysicalCard}
+        onPhysicalCardPress={() =>
+          hasPhysicalCard
+            ? setIsCancelPhysicalCardModalOpen(true)
+            : setIsOrderPhysicalCardModalOpen(true)
+        }
       />
     </View>
   ) : (
@@ -193,6 +222,16 @@ export default function CardDetails() {
           onOpenChange={setIsAddToWalletModalOpen}
           trigger={null}
         />
+        <OrderPhysicalCardModal
+          isOpen={isOrderPhysicalCardModalOpen}
+          onOpenChange={setIsOrderPhysicalCardModalOpen}
+          trigger={null}
+        />
+        <CancelPhysicalCardModal
+          isOpen={isCancelPhysicalCardModalOpen}
+          onOpenChange={setIsCancelPhysicalCardModalOpen}
+          trigger={null}
+        />
       </PageLayout>
     );
   }
@@ -223,6 +262,12 @@ export default function CardDetails() {
             onFreezeToggle={handleFreezeToggle}
             isWithdrawFromCardAllowed={isWithdrawFromCardAllowed}
             isRain={provider === CardProvider.RAIN}
+            hasPhysicalCard={hasPhysicalCard}
+            onPhysicalCardPress={() =>
+              hasPhysicalCard
+                ? setIsCancelPhysicalCardModalOpen(true)
+                : setIsOrderPhysicalCardModalOpen(true)
+            }
           />
           <BorrowPositionCard className="mb-4" />
           <DepositBonusBanner />
@@ -236,6 +281,16 @@ export default function CardDetails() {
       <AddToWalletModal
         isOpen={isAddToWalletModalOpen}
         onOpenChange={setIsAddToWalletModalOpen}
+        trigger={null}
+      />
+      <OrderPhysicalCardModal
+        isOpen={isOrderPhysicalCardModalOpen}
+        onOpenChange={setIsOrderPhysicalCardModalOpen}
+        trigger={null}
+      />
+      <CancelPhysicalCardModal
+        isOpen={isCancelPhysicalCardModalOpen}
+        onOpenChange={setIsCancelPhysicalCardModalOpen}
         trigger={null}
       />
     </PageLayout>
@@ -256,6 +311,8 @@ interface DesktopHeaderProps {
   onFreezeToggle: () => Promise<void>;
   isWithdrawFromCardAllowed: boolean;
   isRain: boolean;
+  hasPhysicalCard: boolean;
+  onPhysicalCardPress: () => void;
 }
 
 function DesktopHeader({
@@ -268,6 +325,8 @@ function DesktopHeader({
   onFreezeToggle,
   isWithdrawFromCardAllowed,
   isRain,
+  hasPhysicalCard,
+  onPhysicalCardPress,
 }: DesktopHeaderProps) {
   const [isManageOpen, setIsManageOpen] = useState(false);
   const manageRef = useRef<View>(null);
@@ -370,6 +429,22 @@ function DesktopHeader({
               </View>
             )}
           </View>
+        )}
+        {isRain && (
+          <Button
+            variant="secondary"
+            className={`h-12 rounded-xl border-0 px-6 ${hasPhysicalCard ? 'bg-red-500/20' : 'bg-[#303030]'}`}
+            onPress={onPhysicalCardPress}
+          >
+            <View className="flex-row items-center gap-2">
+              <CreditCard size={18} color={hasPhysicalCard ? '#ef4444' : 'white'} />
+              <Text
+                className={`text-base font-bold ${hasPhysicalCard ? 'text-red-400' : 'text-white'}`}
+              >
+                {hasPhysicalCard ? 'Cancel Physical Card' : 'Order Physical Card'}
+              </Text>
+            </View>
+          </Button>
         )}
         {isWithdrawFromCardAllowed && (
           <WithdrawToCardModal
@@ -780,6 +855,8 @@ interface CardActionsProps {
   onFreezeToggle: () => Promise<void>;
   isWithdrawFromCardAllowed: boolean;
   isRain: boolean;
+  hasPhysicalCard: boolean;
+  onPhysicalCardPress: () => void;
 }
 
 function CardActions({
@@ -792,6 +869,8 @@ function CardActions({
   onFreezeToggle,
   isWithdrawFromCardAllowed,
   isRain,
+  hasPhysicalCard,
+  onPhysicalCardPress,
 }: CardActionsProps) {
   const [isManageSheetOpen, setIsManageSheetOpen] = useState(false);
   const showManageButton = isRain || !isCardFrozen || canUnfreeze;
@@ -881,6 +960,20 @@ function CardActions({
               </View>
             </DialogContent>
           </Dialog>
+        </View>
+      )}
+      {isRain && (
+        <View className="flex-1 items-center">
+          <Pressable
+            onPress={onPhysicalCardPress}
+            className={`items-center justify-center rounded-full ${hasPhysicalCard ? 'bg-red-500/20' : 'bg-[#303030]'}`}
+            style={{ width: 50, height: 50 }}
+          >
+            <CreditCard size={24} color={hasPhysicalCard ? '#ef4444' : '#BFBFBF'} />
+          </Pressable>
+          <Text className={`mt-2 ${hasPhysicalCard ? 'text-red-400' : 'text-[#BFBFBF]'}`}>
+            {hasPhysicalCard ? 'Cancel' : 'Physical'}
+          </Text>
         </View>
       )}
       {isWithdrawFromCardAllowed && (

--- a/components/Card/CancelPhysicalCardModal.tsx
+++ b/components/Card/CancelPhysicalCardModal.tsx
@@ -1,0 +1,167 @@
+import React, { useState } from 'react';
+import { ActivityIndicator, View } from 'react-native';
+import Toast from 'react-native-toast-message';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { CreditCard } from 'lucide-react-native';
+
+import ResponsiveModal, { ModalState } from '@/components/ResponsiveModal';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Text } from '@/components/ui/text';
+import { cancelPhysicalCard, getPhysicalCardStatus } from '@/lib/api';
+import { PHYSICAL_CARD_STATUS_QUERY_KEY } from '@/components/Card/OrderPhysicalCardModal';
+import { withRefreshToken } from '@/lib/utils/utils';
+
+interface CancelPhysicalCardModalProps {
+  trigger: React.ReactNode;
+  isOpen: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+const MODAL_STATE: ModalState = { name: 'cancel-physical-card', number: 1 };
+const CLOSE_STATE: ModalState = { name: 'close', number: 0 };
+
+export default function CancelPhysicalCardModal({
+  trigger,
+  isOpen,
+  onOpenChange,
+}: CancelPhysicalCardModalProps) {
+  const queryClient = useQueryClient();
+  const [isConfirmOpen, setIsConfirmOpen] = useState(false);
+
+  const { data: statusData, isLoading: isLoadingStatus } = useQuery({
+    queryKey: [PHYSICAL_CARD_STATUS_QUERY_KEY],
+    queryFn: () => withRefreshToken(() => getPhysicalCardStatus()),
+    enabled: isOpen,
+  });
+
+  const physicalCardId = statusData?.cardId;
+
+  const cancelMutation = useMutation({
+    mutationFn: (cardId: string) => withRefreshToken(() => cancelPhysicalCard(cardId)),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [PHYSICAL_CARD_STATUS_QUERY_KEY] });
+      onOpenChange(false);
+      Toast.show({
+        type: 'success',
+        text1: 'Physical card canceled',
+        text2: 'Your physical card order has been canceled.',
+        props: { badgeText: '' },
+      });
+    },
+    onError: () => {
+      Toast.show({
+        type: 'error',
+        text1: 'Failed to cancel physical card',
+        text2: 'Please try again.',
+        props: { badgeText: '' },
+      });
+    },
+  });
+
+  return (
+    <ResponsiveModal
+      currentModal={MODAL_STATE}
+      previousModal={CLOSE_STATE}
+      isOpen={isOpen}
+      onOpenChange={onOpenChange}
+      trigger={trigger}
+      title="Physical Card Ordered"
+      contentKey="cancel-physical-card"
+      contentClassName="md:max-w-lg"
+      shouldAnimate={false}
+    >
+      {isLoadingStatus ? (
+        <View className="items-center justify-center p-12">
+          <ActivityIndicator size="large" color="white" />
+        </View>
+      ) : (
+        <View className="p-6">
+          <View className="mb-6 items-center">
+            <View className="mb-4 items-center justify-center rounded-full bg-[#303030] p-4">
+              <CreditCard size={32} color="#94F27F" />
+            </View>
+            <Text className="mb-2 text-center text-xl font-semibold text-white">
+              Physical card ordered
+            </Text>
+            <Text className="text-center text-base text-white/60">
+              Your physical card has been ordered and will be shipped to your address. You can cancel
+              the order if needed.
+            </Text>
+          </View>
+
+          <View className="gap-4">
+            <Button
+              className="h-14 rounded-xl bg-red-500"
+              onPress={() => setIsConfirmOpen(true)}
+              disabled={cancelMutation.isPending}
+            >
+              {cancelMutation.isPending ? (
+                <ActivityIndicator color="white" />
+              ) : (
+                <Text className="text-base font-bold text-white">Cancel Physical Card</Text>
+              )}
+            </Button>
+            <Button
+              variant="secondary"
+              className="h-14 rounded-xl border-0 bg-[#303030]"
+              onPress={() => onOpenChange(false)}
+              disabled={cancelMutation.isPending}
+            >
+              <Text className="text-base font-bold text-white">Close</Text>
+            </Button>
+          </View>
+
+          <Dialog open={isConfirmOpen} onOpenChange={open => !open && setIsConfirmOpen(false)}>
+            <DialogContent showCloseButton={false} className="max-w-sm">
+              <DialogHeader>
+                <DialogTitle className="text-xl font-bold">Cancel physical card?</DialogTitle>
+              </DialogHeader>
+
+              <DialogDescription className="text-base text-muted-foreground">
+                Are you sure you want to cancel your physical card order? This action cannot be
+                undone.
+              </DialogDescription>
+
+              <DialogFooter className="mt-4 flex-row gap-3">
+                <Button
+                  variant="secondary"
+                  className="flex-1 rounded-xl border-0"
+                  onPress={() => setIsConfirmOpen(false)}
+                  disabled={cancelMutation.isPending}
+                >
+                  <Text className="font-semibold">Keep order</Text>
+                </Button>
+                <Button
+                  variant="destructive"
+                  className="flex-1 rounded-xl border-0"
+                  onPress={() => {
+                    if (physicalCardId) {
+                      cancelMutation.mutate(physicalCardId, {
+                        onSettled: () => setIsConfirmOpen(false),
+                      });
+                    }
+                  }}
+                  disabled={cancelMutation.isPending}
+                >
+                  {cancelMutation.isPending ? (
+                    <ActivityIndicator color="white" size="small" />
+                  ) : (
+                    <Text className="font-semibold text-white">Cancel card</Text>
+                  )}
+                </Button>
+              </DialogFooter>
+            </DialogContent>
+          </Dialog>
+        </View>
+      )}
+    </ResponsiveModal>
+  );
+}

--- a/components/Card/OrderPhysicalCardModal.tsx
+++ b/components/Card/OrderPhysicalCardModal.tsx
@@ -1,0 +1,377 @@
+import React, { useCallback, useEffect } from 'react';
+import { ActivityIndicator, ScrollView, TextInput, View } from 'react-native';
+import Toast from 'react-native-toast-message';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { Controller, useForm } from 'react-hook-form';
+import { CreditCard } from 'lucide-react-native';
+import { z } from 'zod';
+
+import ResponsiveModal, { ModalState } from '@/components/ResponsiveModal';
+import { Button } from '@/components/ui/button';
+import { Text } from '@/components/ui/text';
+import { getPhysicalCardShippingData, orderPhysicalCard } from '@/lib/api';
+import { cn, withRefreshToken } from '@/lib/utils/utils';
+
+export const PHYSICAL_CARD_STATUS_QUERY_KEY = 'physicalCardStatus';
+const SHIPPING_DATA_QUERY_KEY = 'physicalCardShippingData';
+
+interface OrderPhysicalCardModalProps {
+  trigger: React.ReactNode;
+  isOpen: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+const MODAL_STATE: ModalState = { name: 'order-physical-card', number: 1 };
+const CLOSE_STATE: ModalState = { name: 'close', number: 0 };
+
+const shippingSchema = z.object({
+  firstName: z
+    .string()
+    .min(1, { message: 'First name is required' })
+    .max(50)
+    .regex(/^[a-zA-Z -]+$/, { message: 'Only Latin characters, spaces, and hyphens' }),
+  lastName: z
+    .string()
+    .min(1, { message: 'Last name is required' })
+    .max(50)
+    .regex(/^[a-zA-Z -]+$/, { message: 'Only Latin characters, spaces, and hyphens' }),
+  line1: z.string().min(1, { message: 'Address is required' }).max(100),
+  line2: z.string().max(100).optional().or(z.literal('')),
+  city: z.string().min(1, { message: 'City is required' }).max(50),
+  region: z.string().max(50).optional().or(z.literal('')),
+  postalCode: z.string().min(1, { message: 'Postal code is required' }).max(9),
+  countryCode: z
+    .string()
+    .length(2, { message: 'Must be 2-letter code' })
+    .regex(/^[A-Z]{2}$/, { message: 'Must be 2 uppercase letters' }),
+  phoneNumber: z.string().min(1, { message: 'Phone number is required' }),
+});
+
+type ShippingFormData = z.infer<typeof shippingSchema>;
+
+export default function OrderPhysicalCardModal({
+  trigger,
+  isOpen,
+  onOpenChange,
+}: OrderPhysicalCardModalProps) {
+  const queryClient = useQueryClient();
+
+  const { data: shippingData } = useQuery({
+    queryKey: [SHIPPING_DATA_QUERY_KEY],
+    queryFn: () => withRefreshToken(() => getPhysicalCardShippingData()),
+    enabled: isOpen,
+  });
+
+  const { control, handleSubmit, formState, reset } = useForm<ShippingFormData>({
+    resolver: zodResolver(shippingSchema) as any,
+    mode: 'onChange',
+    defaultValues: {
+      firstName: '',
+      lastName: '',
+      line1: '',
+      line2: '',
+      city: '',
+      region: '',
+      postalCode: '',
+      countryCode: '',
+      phoneNumber: '',
+    },
+  });
+
+  useEffect(() => {
+    if (shippingData) {
+      reset({
+        firstName: shippingData.firstName ?? '',
+        lastName: shippingData.lastName ?? '',
+        line1: shippingData.line1 ?? '',
+        line2: shippingData.line2 ?? '',
+        city: shippingData.city ?? '',
+        region: shippingData.region ?? '',
+        postalCode: shippingData.postalCode ?? '',
+        countryCode: shippingData.countryCode?.toUpperCase() ?? '',
+        phoneNumber: shippingData.phoneNumber ?? '',
+      });
+    }
+  }, [shippingData, reset]);
+
+  const orderMutation = useMutation({
+    mutationFn: (data: ShippingFormData) =>
+      withRefreshToken(() =>
+        orderPhysicalCard({
+          shipping: {
+            firstName: data.firstName,
+            lastName: data.lastName,
+            line1: data.line1,
+            ...(data.line2 ? { line2: data.line2 } : {}),
+            city: data.city,
+            ...(data.region ? { region: data.region } : {}),
+            postalCode: data.postalCode,
+            countryCode: data.countryCode,
+            phoneNumber: data.phoneNumber,
+          },
+        }),
+      ),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [PHYSICAL_CARD_STATUS_QUERY_KEY] });
+      onOpenChange(false);
+      Toast.show({
+        type: 'success',
+        text1: 'Physical card ordered',
+        text2: 'Your physical card has been ordered successfully.',
+        props: { badgeText: '' },
+      });
+    },
+    onError: () => {
+      Toast.show({
+        type: 'error',
+        text1: 'Failed to order physical card',
+        text2: 'Please try again.',
+        props: { badgeText: '' },
+      });
+    },
+  });
+
+  const onSubmit = useCallback(
+    (data: ShippingFormData) => {
+      orderMutation.mutate(data);
+    },
+    [orderMutation],
+  );
+
+  return (
+    <ResponsiveModal
+      currentModal={MODAL_STATE}
+      previousModal={CLOSE_STATE}
+      isOpen={isOpen}
+      onOpenChange={onOpenChange}
+      trigger={trigger}
+      title="Order Physical Card"
+      contentKey="order-physical-card"
+      contentClassName="md:max-w-lg"
+      shouldAnimate={false}
+      disableScroll
+    >
+      <ScrollView className="max-h-[70vh]" showsVerticalScrollIndicator={false}>
+        <View className="p-6">
+          <View className="mb-6 items-center">
+            <View className="mb-4 items-center justify-center rounded-full bg-[#303030] p-4">
+              <CreditCard size={32} color="#94F27F" />
+            </View>
+            <Text className="mb-2 text-center text-xl font-semibold text-white">
+              Shipping details
+            </Text>
+            <Text className="text-center text-base text-white/60">
+              Enter the address where your physical card should be shipped.
+            </Text>
+          </View>
+
+          <View className="gap-3">
+            <View className="flex-row gap-3">
+              <View className="flex-1 gap-1.5">
+                <Text className="font-medium opacity-50">First name *</Text>
+                <View
+                  className={cn(
+                    'rounded-2xl bg-accent px-5 py-3',
+                    formState.errors.firstName && 'border border-red-500',
+                  )}
+                >
+                  <Controller
+                    control={control}
+                    name="firstName"
+                    render={({ field: { onChange, onBlur, value } }) => (
+                      <TextInput
+                        className="text-lg font-semibold text-white web:focus:outline-none"
+                        value={value}
+                        onChangeText={onChange}
+                        onBlur={onBlur}
+                        placeholder="First name"
+                        placeholderTextColor="#666"
+                      />
+                    )}
+                  />
+                </View>
+                {formState.errors.firstName && (
+                  <Text className="text-sm text-red-500">
+                    {formState.errors.firstName.message}
+                  </Text>
+                )}
+              </View>
+              <View className="flex-1 gap-1.5">
+                <Text className="font-medium opacity-50">Last name *</Text>
+                <View
+                  className={cn(
+                    'rounded-2xl bg-accent px-5 py-3',
+                    formState.errors.lastName && 'border border-red-500',
+                  )}
+                >
+                  <Controller
+                    control={control}
+                    name="lastName"
+                    render={({ field: { onChange, onBlur, value } }) => (
+                      <TextInput
+                        className="text-lg font-semibold text-white web:focus:outline-none"
+                        value={value}
+                        onChangeText={onChange}
+                        onBlur={onBlur}
+                        placeholder="Last name"
+                        placeholderTextColor="#666"
+                      />
+                    )}
+                  />
+                </View>
+                {formState.errors.lastName && (
+                  <Text className="text-sm text-red-500">
+                    {formState.errors.lastName.message}
+                  </Text>
+                )}
+              </View>
+            </View>
+
+            <FormField
+              control={control}
+              name="line1"
+              label="Address line 1 *"
+              placeholder="Street address"
+              error={formState.errors.line1?.message}
+            />
+
+            <FormField
+              control={control}
+              name="line2"
+              label="Address line 2"
+              placeholder="Apt, suite, unit (optional)"
+              error={formState.errors.line2?.message}
+            />
+
+            <View className="flex-row gap-3">
+              <View className="flex-1">
+                <FormField
+                  control={control}
+                  name="city"
+                  label="City *"
+                  placeholder="City"
+                  error={formState.errors.city?.message}
+                />
+              </View>
+              <View className="flex-1">
+                <FormField
+                  control={control}
+                  name="region"
+                  label="Region"
+                  placeholder="State/Province"
+                  error={formState.errors.region?.message}
+                />
+              </View>
+            </View>
+
+            <View className="flex-row gap-3">
+              <View className="flex-1">
+                <FormField
+                  control={control}
+                  name="postalCode"
+                  label="Postal code *"
+                  placeholder="Postal code"
+                  error={formState.errors.postalCode?.message}
+                />
+              </View>
+              <View className="flex-1">
+                <FormField
+                  control={control}
+                  name="countryCode"
+                  label="Country code *"
+                  placeholder="US"
+                  error={formState.errors.countryCode?.message}
+                  maxLength={2}
+                  autoCapitalize="characters"
+                />
+              </View>
+            </View>
+
+            <FormField
+              control={control}
+              name="phoneNumber"
+              label="Phone number *"
+              placeholder="+1234567890"
+              error={formState.errors.phoneNumber?.message}
+              keyboardType="phone-pad"
+            />
+          </View>
+
+          <View className="mt-6 gap-4">
+            <Button
+              className="h-14 rounded-xl bg-[#94F27F]"
+              onPress={handleSubmit(onSubmit)}
+              disabled={orderMutation.isPending}
+            >
+              {orderMutation.isPending ? (
+                <ActivityIndicator color="black" />
+              ) : (
+                <Text className="text-base font-bold text-black">Place order</Text>
+              )}
+            </Button>
+            <Button
+              variant="secondary"
+              className="h-14 rounded-xl border-0 bg-[#303030]"
+              onPress={() => onOpenChange(false)}
+              disabled={orderMutation.isPending}
+            >
+              <Text className="text-base font-bold text-white">Cancel</Text>
+            </Button>
+          </View>
+        </View>
+      </ScrollView>
+    </ResponsiveModal>
+  );
+}
+
+function FormField({
+  control,
+  name,
+  label,
+  placeholder,
+  error,
+  keyboardType,
+  maxLength,
+  autoCapitalize,
+}: {
+  control: any;
+  name: string;
+  label: string;
+  placeholder: string;
+  error?: string;
+  keyboardType?: 'default' | 'phone-pad' | 'decimal-pad' | 'number-pad';
+  maxLength?: number;
+  autoCapitalize?: 'none' | 'sentences' | 'words' | 'characters';
+}) {
+  return (
+    <View className="gap-1.5">
+      <Text className="font-medium opacity-50">{label}</Text>
+      <View
+        className={cn(
+          'rounded-2xl bg-accent px-5 py-3',
+          error && 'border border-red-500',
+        )}
+      >
+        <Controller
+          control={control}
+          name={name}
+          render={({ field: { onChange, onBlur, value } }) => (
+            <TextInput
+              className="text-lg font-semibold text-white web:focus:outline-none"
+              value={value}
+              onChangeText={onChange}
+              onBlur={onBlur}
+              placeholder={placeholder}
+              placeholderTextColor="#666"
+              keyboardType={keyboardType}
+              maxLength={maxLength}
+              autoCapitalize={autoCapitalize}
+            />
+          )}
+        />
+      </View>
+      {error && <Text className="text-sm text-red-500">{error}</Text>}
+    </View>
+  );
+}

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -662,6 +662,113 @@ export const createCard = async (): Promise<CardResponse> => {
   return response.json();
 };
 
+export const orderPhysicalCard = async (options?: {
+  productId?: string;
+  virtualCardArt?: string;
+  shipping?: {
+    firstName?: string;
+    lastName?: string;
+    line1: string;
+    line2?: string;
+    city: string;
+    region?: string;
+    postalCode: string;
+    countryCode: string;
+    phoneNumber: string;
+  };
+}): Promise<CardResponse> => {
+  const jwt = getJWTToken();
+
+  const response = await fetch(`${EXPO_PUBLIC_FLASH_API_BASE_URL}/accounts/v1/cards/physical`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...getPlatformHeaders(),
+      ...(jwt ? { Authorization: `Bearer ${jwt}` } : {}),
+    },
+    credentials: 'include',
+    body: JSON.stringify(options ?? {}),
+  });
+
+  if (!response.ok) throw response;
+
+  return response.json();
+};
+
+export const getPhysicalCardStatus = async (): Promise<{
+  hasPhysicalCard: boolean;
+  cardId?: string;
+  status?: string;
+}> => {
+  const jwt = getJWTToken();
+
+  const response = await fetch(
+    `${EXPO_PUBLIC_FLASH_API_BASE_URL}/accounts/v1/cards/physical/status`,
+    {
+      credentials: 'include',
+      headers: {
+        ...getPlatformHeaders(),
+        ...(jwt ? { Authorization: `Bearer ${jwt}` } : {}),
+      },
+    },
+  );
+
+  if (!response.ok) throw response;
+
+  return response.json();
+};
+
+export const cancelPhysicalCard = async (cardId: string): Promise<{ message: string }> => {
+  const jwt = getJWTToken();
+
+  const response = await fetch(
+    `${EXPO_PUBLIC_FLASH_API_BASE_URL}/accounts/v1/cards/physical/cancel`,
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        ...getPlatformHeaders(),
+        ...(jwt ? { Authorization: `Bearer ${jwt}` } : {}),
+      },
+      credentials: 'include',
+      body: JSON.stringify({ cardId }),
+    },
+  );
+
+  if (!response.ok) throw response;
+
+  return response.json();
+};
+
+export const getPhysicalCardShippingData = async (): Promise<{
+  firstName?: string;
+  lastName?: string;
+  line1?: string;
+  line2?: string;
+  city?: string;
+  region?: string;
+  postalCode?: string;
+  countryCode?: string;
+  phoneNumber?: string;
+}> => {
+  const jwt = getJWTToken();
+
+  const response = await fetch(
+    `${EXPO_PUBLIC_FLASH_API_BASE_URL}/accounts/v1/cards/physical/shipping-data`,
+    {
+      credentials: 'include',
+      headers: {
+        ...getPlatformHeaders(),
+        ...(jwt ? { Authorization: `Bearer ${jwt}` } : {}),
+      },
+    },
+  );
+
+  if (!response.ok) throw response;
+
+  return response.json();
+};
+
 export const getCardStatus = async (): Promise<CardStatusResponse | null> => {
   const jwt = getJWTToken();
 


### PR DESCRIPTION
## Summary
- Add "Order Physical Card" / "Cancel Physical Card" button between Manage and Withdraw on card details page (desktop + mobile)
- Add `OrderPhysicalCardModal` with shipping form pre-filled from Didit KYC, validated with zod + react-hook-form
- Add `CancelPhysicalCardModal` with Dialog confirmation matching `DiscardChangesDialog` pattern
- Uses TanStack Query (`useQuery`/`useMutation`) for all data fetching and mutations
- Button toggles between order/cancel states based on physical card status query

Cherry-picked from qa merge: solid-money/solid-ui#1939

## Test plan
- [ ] Verify "Order Physical Card" button appears between Manage and Withdraw for Rain users
- [ ] Verify shipping form pre-fills from KYC data and validates required fields
- [ ] Verify placing order calls backend and shows success toast
- [ ] Verify button changes to "Cancel Physical Card" after ordering
- [ ] Verify cancel flow shows Dialog confirmation and cancels on confirm

https://claude.ai/code/session_012if81DYb8SeUEkniusLQfw