### PR TITLE
fix: recreate smart account client after Safe deployment

### DIFF
--- a/hooks/useWithdrawRainCollateral.ts
+++ b/hooks/useWithdrawRainCollateral.ts
@@ -98,7 +98,7 @@ const useWithdrawRainCollateral = (): WithdrawRainCollateralResult => {
         });
 
         // Step 3: Create Safe smart account client for transaction execution
-        const smartAccountClient = await safeAA(chain, user.suborgId, user.signWith);
+        let smartAccountClient = await safeAA(chain, user.suborgId, user.signWith);
 
         // Step 3a: Ensure Safe is deployed on this chain before signing.
         // Safe ERC-1271 signature verification requires the contract to exist on-chain;
@@ -110,6 +110,8 @@ const useWithdrawRainCollateral = (): WithdrawRainCollateralResult => {
             calls: [{ to: user.safeAddress as Address, data: '0x', value: 0n }],
           });
           await smartAccountClient.waitForUserOperationReceipt({ hash: deployHash });
+          // Recreate client so it no longer includes factory/initCode for the deployed Safe
+          smartAccountClient = await safeAA(chain, user.suborgId, user.signWith);
         }
 
         // Step 4: Generate admin EIP-712 signature via Safe smart account


### PR DESCRIPTION
## Summary
Cherry-pick from qa (merged PR #1943):

- Recreate the Safe smart account client after deploying the Safe on the card withdrawal chain. The permissionless library caches factory/initCode at client creation time, so the original client still includes deployment data in subsequent UserOps even after the Safe is deployed, causing `InvalidSignature` (0x8baa579f) reverts.

## Test plan
- [ ] Verify card withdrawal works for a user whose Safe was just deployed on Base
- [ ] Verify card withdrawal still works for users with an already-deployed Safe (deployment step is skipped)

https://claude.ai/code/session_01UdFXo6FkqQhCozNm7xXm7U