### PR TITLE
Fix AES-GCM decryption: authTagLength in bytes, not bits

### DIFF
--- a/lib/utils/rainCardSecrets.ts
+++ b/lib/utils/rainCardSecrets.ts
@@ -84,7 +84,7 @@ export async function decryptSecret(
       'aes-128-gcm',
       Buffer.from(keyBytes),
       Buffer.from(iv),
-      { authTagLength: authTagLength * 8 },
+      { authTagLength },
     );
     decipher.setAuthTag(Buffer.from(tag));
     const dec = decipher.update(Buffer.from(ciphertext)) as Buffer;


### PR DESCRIPTION
## Summary\n\n- **Fixes card details page stuck at loading on mobile** (Sentry issue 7413181910)\n- The `authTagLength` option passed to `createDecipheriv` was incorrectly multiplied by 8 (converting bytes to bits), but the Node.js/react-native-quick-crypto API expects the value in **bytes**\n- This caused `setAuthTag` to throw \"Invalid authentication tag length\" when the 16-byte GCM auth tag didn't match the expected 128-byte length, breaking card PAN/CVC decryption on native mobile\n\n## Test plan\n\n- [ ] Open card details page on iOS mobile app and verify card number/CVC reveal works\n- [ ] Verify card details page still works on web (web path uses SubtleCrypto, unaffected)\n- [ ] Verify PIN encryption/submission still works on mobile\n\nhttps://claude.ai/code/session_01QzA9vt9B6We2FhmSBxdgYH