### PR TITLE
Fix AES-GCM decryption: authTagLength should be in bytes, not bits

### DIFF
--- a/lib/utils/rainCardSecrets.ts
+++ b/lib/utils/rainCardSecrets.ts
@@ -84,7 +84,7 @@ export async function decryptSecret(
       'aes-128-gcm',
       Buffer.from(keyBytes),
       Buffer.from(iv),
-      { authTagLength: authTagLength * 8 },
+      { authTagLength },
     );
     decipher.setAuthTag(Buffer.from(tag));
     const dec = decipher.update(Buffer.from(ciphertext)) as Buffer;


### PR DESCRIPTION
The authTagLength option for Node.js createDecipheriv expects bytes, but was being multiplied by 8 (converting to bits), causing "Invalid authentication tag length" errors on mobile card details.

https://claude.ai/code/session_01QzA9vt9B6We2FhmSBxdgYH