### PR TITLE
Remove Rain-specific amount normalization logic

### DIFF
--- a/lib/utils/cardHelpers.ts
+++ b/lib/utils/cardHelpers.ts
@@ -49,17 +49,15 @@ export const getColorForTransaction = (
 };
 
 /**
- * Normalize amount for display: Rain returns cents, Bridge returns dollars.
+ * Normalize amount for display.
+ * Both Rain and Bridge amounts are returned as dollars from the backend.
  */
 function normalizeCardAmount(amount: string, provider?: CardProvider | null): number {
-  const num = parseFloat(amount);
-  if (provider === CardProvider.RAIN) return num / 100;
-  return num;
+  return parseFloat(amount);
 }
 
 /**
  * Format card transaction amount with proper sign and currency symbol.
- * Pass provider so Rain amounts (cents) are converted to dollars for display.
  */
 export const formatCardAmount = (
   amount: string,
@@ -72,7 +70,6 @@ export const formatCardAmount = (
 
 /**
  * Format card transaction amount with currency code and +/- sign.
- * Pass provider so Rain amounts (cents) are converted to dollars for display.
  */
 export const formatCardAmountWithCurrency = (
   amount: string,


### PR DESCRIPTION
## Summary
Updated card amount normalization to remove provider-specific handling, as both Rain and Bridge now return amounts in dollars from the backend.

## Key Changes
- Simplified `normalizeCardAmount()` to directly parse the amount string without provider-specific conversion logic
- Removed the conditional check that divided Rain provider amounts by 100 (cents to dollars conversion)
- Updated JSDoc comments to reflect that both providers now return amounts in the same format (dollars)
- Removed outdated references to "Rain amounts (cents)" from function documentation

## Implementation Details
The `normalizeCardAmount()` function previously contained provider-specific logic to handle Rain returning amounts in cents while Bridge returned dollars. This change removes that complexity since the backend now standardizes the response format across both providers, returning amounts as dollars directly.

https://claude.ai/code/session_016jQjBTDPvPYSqZrsDmouBs