### PR TITLE
fix: remove Rain-specific cents division for card transactions

### DIFF
--- a/lib/utils/cardHelpers.ts
+++ b/lib/utils/cardHelpers.ts
@@ -49,17 +49,15 @@ export const getColorForTransaction = (
 };
 
 /**
- * Normalize amount for display: Rain returns cents, Bridge returns dollars.
+ * Normalize amount for display.
+ * Both Rain and Bridge amounts are returned as dollars from the backend.
  */
 function normalizeCardAmount(amount: string, provider?: CardProvider | null): number {
-  const num = parseFloat(amount);
-  if (provider === CardProvider.RAIN) return num / 100;
-  return num;
+  return parseFloat(amount);
 }
 
 /**
  * Format card transaction amount with proper sign and currency symbol.
- * Pass provider so Rain amounts (cents) are converted to dollars for display.
  */
 export const formatCardAmount = (
   amount: string,
@@ -72,7 +70,6 @@ export const formatCardAmount = (
 
 /**
  * Format card transaction amount with currency code and +/- sign.
- * Pass provider so Rain amounts (cents) are converted to dollars for display.
  */
 export const formatCardAmountWithCurrency = (
   amount: string,


### PR DESCRIPTION
## Summary
- Cherry-pick of qa merge (PR #1948) to master
- Removes the Rain-specific `/100` division from `normalizeCardAmount()` in `cardHelpers.ts`
- Backend now consistently returns dollar amounts for both Rain and Bridge providers, so the frontend no longer needs provider-specific conversion

## Context
The frontend was dividing all Rain card amounts by 100, assuming they were in cents. However, DB-stored transactions (from webhooks) were already converted to dollars by the backend, causing a double-division that displayed $0.13 instead of $13 on the card activity page.

**Companion PR:** solid-money/solid-backend#{backend_pr_number} (backend cents→dollars conversion)

## Test plan
- [ ] Verify Rain card transactions on activity page show correct dollar amounts
- [ ] Verify transaction detail page shows correct amounts
- [ ] Verify card balance display is unaffected (uses `formatCentsToDollars` in `useCardDetails` hook, not `normalizeCardAmount`)
- [ ] Verify card details transactions page shows correct amounts

https://claude.ai/code/session_016jQjBTDPvPYSqZrsDmouBs