### PR TITLE
Handle KYC "In Review" status in Didit session polling

### DIFF
--- a/components/kyc/useDiditSession.ts
+++ b/components/kyc/useDiditSession.ts
@@ -137,6 +137,12 @@ export function useDiditSession() {
         } else if (status.status === 'Declined' || status.kycStatus === 'rejected') {
           clearInterval(interval);
           onVerificationError('Your identity verification was declined. Please try again.');
+        } else if (
+          status.status === 'In Review' ||
+          status.kycStatus === KycStatus.UNDER_REVIEW
+        ) {
+          clearInterval(interval);
+          onVerificationPending();
         }
       } catch {
         // silently retry on network errors
@@ -144,7 +150,7 @@ export function useDiditSession() {
     }, POLL_INTERVAL_MS);
 
     return () => clearInterval(interval);
-  }, [session.phase, onVerificationComplete, onVerificationError]);
+  }, [session.phase, onVerificationComplete, onVerificationError, onVerificationPending]);
 
   // Auto-init on mount
   useEffect(() => {


### PR DESCRIPTION
## Summary
Added handling for the "In Review" KYC status in the Didit session verification polling logic to properly notify users when their identity verification is pending review.

## Key Changes
- Added a new conditional branch to detect when KYC status is "In Review" or `KycStatus.UNDER_REVIEW`
- Calls `onVerificationPending()` callback when the verification is in review state
- Clears the polling interval to stop further status checks once in review state is detected
- Updated the dependency array to include `onVerificationPending` callback

## Implementation Details
The change ensures that the verification flow properly handles the intermediate "In Review" state, which occurs after initial submission but before final approval/rejection. This prevents the polling from continuing indefinitely and allows the UI to display appropriate pending/review status messaging to the user.

https://claude.ai/code/session_018nQC7baTuQivbNDAzXcTVP