### PR TITLE
Fix Didit widget blank screen when KYC completed on mobile

### DIFF
--- a/components/kyc/useDiditSession.ts
+++ b/components/kyc/useDiditSession.ts
@@ -137,6 +137,12 @@ export function useDiditSession() {
         } else if (status.status === 'Declined' || status.kycStatus === 'rejected') {
           clearInterval(interval);
           onVerificationError('Your identity verification was declined. Please try again.');
+        } else if (
+          status.status === 'In Review' ||
+          status.kycStatus === KycStatus.UNDER_REVIEW
+        ) {
+          clearInterval(interval);
+          onVerificationPending();
         }
       } catch {
         // silently retry on network errors
@@ -144,7 +150,7 @@ export function useDiditSession() {
     }, POLL_INTERVAL_MS);
 
     return () => clearInterval(interval);
-  }, [session.phase, onVerificationComplete, onVerificationError]);
+  }, [session.phase, onVerificationComplete, onVerificationError, onVerificationPending]);
 
   // Auto-init on mount
   useEffect(() => {


### PR DESCRIPTION
## Summary\n- Cherry-pick of a4447f2 from qa to master\n- Fixes the Didit KYC widget turning blank/white on desktop when user completes verification on mobile via QR code\n- The polling interval now detects `In Review` / `under_review` status and redirects to the pending page instead of leaving a blank iframe\n\n## Test plan\n- [ ] Start KYC on desktop, scan QR code on mobile, complete verification on mobile\n- [ ] Verify desktop redirects to the card pending page within ~5 seconds instead of showing a blank white widget\n- [ ] Verify normal desktop-only KYC flow still works (Approved → success, Declined → error)\n\nhttps://claude.ai/code/session_018nQC7baTuQivbNDAzXcTVP