### PR TITLE
feat: show cashback escrow status and time left in card activity

### DIFF
--- a/app/(protected)/(tabs)/activity/[clientTxId].tsx
+++ b/app/(protected)/(tabs)/activity/[clientTxId].tsx
@@ -3,7 +3,7 @@ import { Linking, Pressable, View } from 'react-native';
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import * as Sentry from '@sentry/react-native';
 import { useQuery } from '@tanstack/react-query';
-import { format, minutesToSeconds } from 'date-fns';
+import { format, formatDistanceStrict, minutesToSeconds } from 'date-fns';
 import { ArrowUpRight, ChevronLeft, X } from 'lucide-react-native';
 import { mainnet } from 'viem/chains';
 
@@ -90,6 +90,21 @@ const Label = memo(function Label({ children }: LabelProps) {
 
 const Value = memo(function Value({ children, className }: ValueProps) {
   return <Text className={cn('text-lg font-bold', className)}>{children}</Text>;
+});
+
+const EscrowTimeLeft = memo(function EscrowTimeLeft({ payoutAt }: { payoutAt: string }) {
+  const [now, setNow] = useState(() => Date.now());
+
+  useEffect(() => {
+    const interval = setInterval(() => setNow(Date.now()), 60_000);
+    return () => clearInterval(interval);
+  }, []);
+
+  const target = useMemo(() => new Date(payoutAt).getTime(), [payoutAt]);
+
+  if (target - now <= 0) return <Value>Releasing soon</Value>;
+
+  return <Value>{formatDistanceStrict(target, now)}</Value>;
 });
 
 const Back = memo(function Back({ title, className }: BackProps) {
@@ -217,12 +232,24 @@ const CardTransactionDetail = memo(function CardTransactionDetail({
           <Value
             className={cashbackInfo.amount === 'Pending' ? 'text-yellow-500' : 'text-[#34C759]'}
           >
-            {cashbackInfo.isPending && cashbackInfo.amount !== 'Pending'
-              ? `${cashbackInfo.amount} (Pending)`
-              : cashbackInfo.amount}
+            {cashbackInfo.amount === 'Pending'
+              ? cashbackInfo.isEscrowed
+                ? 'Escrowed'
+                : 'Pending'
+              : cashbackInfo.isEscrowed
+                ? `${cashbackInfo.amount} (Escrowed)`
+                : cashbackInfo.isPending
+                  ? `${cashbackInfo.amount} (Pending)`
+                  : cashbackInfo.amount}
           </Value>
         ),
       },
+      cashbackInfo?.isEscrowed &&
+        cashbackInfo.payoutAt && {
+          key: 'cashback-escrow-time-left',
+          label: <Label>Releases in</Label>,
+          value: <EscrowTimeLeft payoutAt={cashbackInfo.payoutAt} />,
+        },
       txHash && {
         key: 'explorer',
         label: <Label>Explorer</Label>,

--- a/components/Activity/CardTransactions.tsx
+++ b/components/Activity/CardTransactions.tsx
@@ -207,7 +207,11 @@ export default function CardTransactions() {
                 <View className="mt-0.5 flex-row items-center gap-1">
                   <Diamond />
                   <Text className="text-sm text-[#8E8E93]">
-                    {cashbackInfo.isPending ? 'Cashback (Pending)' : 'Cashback'}
+                    {cashbackInfo.isEscrowed
+                      ? 'Cashback (Escrowed)'
+                      : cashbackInfo.isPending
+                        ? 'Cashback (Pending)'
+                        : 'Cashback'}
                   </Text>
                 </View>
               )}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -923,12 +923,15 @@ export interface Cashback {
   fuseUsdPrice?: string;
   fiatAmount?: string;
   fiatCurrency?: string;
+  payoutAt?: string;
   createdAt: string;
 }
 
 export interface CashbackInfo {
   amount: string;
   isPending: boolean;
+  isEscrowed: boolean;
+  payoutAt?: string;
 }
 
 export interface SourceDepositInstructions {

--- a/lib/utils/cardHelpers.ts
+++ b/lib/utils/cardHelpers.ts
@@ -117,12 +117,15 @@ export const getCashbackAmount = (
   }
 
   const isPending = PENDING_CASHBACK_STATUSES.includes(cashback.status);
+  const isEscrowed = cashback.status === CashbackStatus.Escrowed;
 
   // For pending cashbacks without fuseAmount yet, show pending indicator without amount
   if (!cashback.fuseAmount) {
     return {
       amount: 'Pending',
       isPending: true,
+      isEscrowed,
+      payoutAt: cashback.payoutAt,
     };
   }
 
@@ -137,5 +140,7 @@ export const getCashbackAmount = (
   return {
     amount: `+$${amount.toFixed(2)}`,
     isPending,
+    isEscrowed,
+    payoutAt: cashback.payoutAt,
   };
 };


### PR DESCRIPTION
## Summary
- Cherry-pick of cashback escrow status + time-left changes from qa (#1958)
- Card activity list shows `Cashback (Escrowed)` when cashback is in escrow
- Activity detail cashback row shows `Escrowed` status and adds a `Releases in` row with live countdown based on `payoutAt`

## Test plan
- [ ] Verify escrowed card transactions show `Cashback (Escrowed)` in the card activity list
- [ ] Verify `/activity/card-[id]` detail page shows `Escrowed` for the cashback row
- [ ] Verify the new `Releases in` row renders below the cashback row with a time-left that updates every minute
- [ ] Verify paid/pending (non-escrowed) cashbacks still render as before

https://claude.ai/code/session_01JwEMS7D4Jcwkm2VqX4CRnd