### PR TITLE
fix: center merchant name/location and trim whitespace

### DIFF
--- a/app/(protected)/(tabs)/activity/[clientTxId].tsx
+++ b/app/(protected)/(tabs)/activity/[clientTxId].tsx
@@ -106,12 +106,14 @@ const Back = memo(function Back({ title, className }: BackProps) {
   }, [params.from, params.tab, router]);
 
   return (
-    <View className="flex-row items-center justify-between">
-      <Pressable onPress={handleBackPress} className="web:hover:opacity-70">
+    <View className="relative flex-row items-center justify-center">
+      <Pressable
+        onPress={handleBackPress}
+        className="absolute left-0 web:hover:opacity-70"
+      >
         <ChevronLeft color="white" />
       </Pressable>
       <Text className={cn('text-center text-lg font-semibold text-white', className)}>{title}</Text>
-      <View className="w-10" />
     </View>
   );
 });
@@ -162,7 +164,11 @@ const CardTransactionDetail = memo(function CardTransactionDetail({
   activity,
   cardProvider,
 }: CardTransactionDetailProps) {
-  const merchantName = transaction.merchant_name || transaction.description || 'Unknown';
+  const merchantName = (
+    transaction.merchant_name?.trim() ||
+    transaction.description?.trim() ||
+    'Unknown'
+  );
   const merchantLocation = [transaction.merchant_city, transaction.merchant_country]
     .filter(Boolean)
     .join(' ') || undefined;
@@ -253,7 +259,7 @@ const CardTransactionDetail = memo(function CardTransactionDetail({
         <View>
           <Back title={merchantName} className="text-xl md:text-3xl" />
           {merchantLocation && (
-            <Text className="ml-10 text-sm text-muted-foreground">{merchantLocation}</Text>
+            <Text className="text-center text-sm text-muted-foreground">{merchantLocation}</Text>
           )}
         </View>
 


### PR DESCRIPTION
## Summary
- Cherry-pick of the merchant header fix merged to `qa` in #1959, now targeting `master`.
- Absolutely position the back button in the card activity header so the merchant title truly centers regardless of chevron width, and center the merchant location text.
- Trim `merchant_name` / `description` so stray whitespace from upstream data doesn't misalign the header.

## Test plan
- [ ] Open a card purchase activity with a merchant name that has trailing/leading whitespace — name renders trimmed.
- [ ] Merchant name and city/country are horizontally centered under the back arrow on mobile and desktop widths.
- [ ] Back button still navigates correctly (activity tab / card details).

https://claude.ai/code/session_01T6zZc5Zr1FCcFV89aBkEJN