### PR TITLE
fix(card-deposit): prevent silent no-op and add minimum-amount UI

### DIFF
--- a/components/Card/CardDepositInternalForm.tsx
+++ b/components/Card/CardDepositInternalForm.tsx
@@ -10,9 +10,9 @@ import {
 import { ActivityIndicator, Linking, Platform, Pressable, TextInput, View } from 'react-native';
 import Toast from 'react-native-toast-message';
 import { Image } from 'expo-image';
-import { ChevronDown, Info, Leaf, Wallet as WalletIcon } from 'lucide-react-native';
+import { ChevronDown, Fuel, Info, Leaf, Wallet as WalletIcon } from 'lucide-react-native';
 import { Address, erc20Abi, formatUnits, parseUnits, TransactionReceipt } from 'viem';
-import { fuse, mainnet } from 'viem/chains';
+import { base, fuse, mainnet } from 'viem/chains';
 import { useReadContract } from 'wagmi';
 import { z } from 'zod';
 import { useShallow } from 'zustand/react/shallow';
@@ -677,6 +677,13 @@ export default function CardDepositInternalForm() {
     ADDRESSES.fuse.stargateOftUSDC,
   );
 
+  const isWalletSourceGaslessGated =
+    isProduction && watchedFrom === CardDepositSource.WALLET;
+  const cardDepositMinimumAmount = EXPO_PUBLIC_MINIMUM_SPONSOR_AMOUNT;
+  const isCardDepositSponsor = isWalletSourceGaslessGated
+    ? Number(watchedAmount || 0) >= Number(cardDepositMinimumAmount)
+    : true;
+
   const schema = useMemo(() => {
     return z.object({
       amount: z
@@ -696,9 +703,23 @@ export default function CardDepositInternalForm() {
                 ? `Maximum borrow amount is ${formatNumber(maxBorrowAmount)} USDC`
                 : `Available balance is ${formatNumber(balanceAmount)} ${tokenSymbol}`,
           },
+        )
+        .refine(
+          val => {
+            if (!isWalletSourceGaslessGated) return true;
+            return Number(val) >= Number(cardDepositMinimumAmount);
+          },
+          { error: `Minimum $${cardDepositMinimumAmount} USDC` },
         ),
     });
-  }, [balanceAmount, tokenSymbol, watchedFrom, maxBorrowAmount]);
+  }, [
+    balanceAmount,
+    tokenSymbol,
+    watchedFrom,
+    maxBorrowAmount,
+    isWalletSourceGaslessGated,
+    cardDepositMinimumAmount,
+  ]);
 
   const formattedBalance = balanceAmount.toString();
 
@@ -713,10 +734,21 @@ export default function CardDepositInternalForm() {
   const { borrowAndDeposit, bridgeStatus: borrowAndDepositStatus } = useBorrowAndDepositToCard();
   const { deposit, depositStatus, error: depositError } = useCardDeposit();
 
-  const cardDepositSrcChainId = useDepositStore(state => state.srcChainId);
-  const cardDepositTokenAddress =
-    (BRIDGE_TOKENS[cardDepositSrcChainId]?.tokens?.USDC?.address as Address | undefined) ||
-    ('' as Address);
+  const storedSrcChainId = useDepositStore(state => state.srcChainId);
+  const setSrcChainId = useDepositStore(state => state.setSrcChainId);
+  // Default to Base (the card funding chain) when no valid src chain is selected,
+  // so the useDepositFromSolidUsdc hook always has a chain to sign the approve on.
+  const cardDepositSrcChainId =
+    storedSrcChainId && BRIDGE_TOKENS[storedSrcChainId]?.tokens?.USDC
+      ? storedSrcChainId
+      : base.id;
+  useEffect(() => {
+    if (storedSrcChainId !== cardDepositSrcChainId) {
+      setSrcChainId(cardDepositSrcChainId);
+    }
+  }, [storedSrcChainId, cardDepositSrcChainId, setSrcChainId]);
+  const cardDepositTokenAddress = BRIDGE_TOKENS[cardDepositSrcChainId]?.tokens?.USDC
+    ?.address as Address;
   const {
     deposit: walletCardDeposit,
     depositStatus: walletCardDepositStatus,
@@ -1250,6 +1282,17 @@ export default function CardDepositInternalForm() {
           fundingChainLabel={getChain(fundingChainId)?.name ?? 'Card'}
           destinationTokenSymbol={getCardDepositTokenSymbol(provider)}
         />
+      )}
+
+      {isWalletSourceGaslessGated && (
+        <View className="mt-2 flex-row items-start gap-2">
+          <Fuel color="#A1A1A1" size={16} className="mt-0.5" />
+          <Text className="max-w-xs text-sm text-muted-foreground">
+            {isCardDepositSponsor
+              ? 'Gasless deposit'
+              : `Gasless deposit - Please deposit above $${cardDepositMinimumAmount} USDC so we can cover your fees`}
+          </Text>
+        </View>
       )}
 
       <ErrorDisplay

--- a/hooks/useDepositFromSolidUsdc.ts
+++ b/hooks/useDepositFromSolidUsdc.ts
@@ -88,7 +88,12 @@ const useDepositFromSolidUsdc = (
   };
 
   const deposit = async (amount: string) => {
-    if (!token || !srcChainId) return undefined;
+    if (!token) return undefined;
+    if (!srcChainId) {
+      throw new Error(
+        'Source chain is not selected. Please reopen the deposit flow and pick a chain.',
+      );
+    }
 
     const attributionData = useAttributionStore.getState().getAttributionForEvent();
     const attributionChannel = getAttributionChannel(attributionData);


### PR DESCRIPTION
Addresses two issues in the card deposit from Solid wallet flow:

1. When useDepositStore.srcChainId is 0/unset (e.g. after resetDepositFlow persisted an unset value), useDepositFromSolidUsdc silently returned undefined from deposit(), so the form opened the transaction-status screen with no approve UserOp ever submitted and no Turnkey passkey prompt. The hook now throws a clear error when srcChainId is falsy, and CardDepositInternalForm defaults srcChainId to Base (the card funding chain) whenever the stored value is missing or unsupported.

2. Card deposit form now enforces EXPO_PUBLIC_MINIMUM_SPONSOR_AMOUNT via a zod refine on the WALLET source (disables the submit button and surfaces a validation message) and shows a gasless deposit hint row under the destination mirroring DepositToVaultForm's Fuel-icon line.

https://claude.ai/code/session_01TDpHy9uTrVX3PTRp9xS9S5