### PR TITLE
refactor(card-deposit): reuse savings wallet token selector screen

### DIFF
--- a/components/Card/CardDepositInternalForm.tsx
+++ b/components/Card/CardDepositInternalForm.tsx
@@ -12,7 +12,7 @@ import Toast from 'react-native-toast-message';
 import { Image } from 'expo-image';
 import { ChevronDown, Fuel, Info, Leaf, Wallet as WalletIcon } from 'lucide-react-native';
 import { Address, erc20Abi, formatUnits, parseUnits, TransactionReceipt } from 'viem';
-import { base, fuse, mainnet } from 'viem/chains';
+import { fuse, mainnet } from 'viem/chains';
 import { useReadContract } from 'wagmi';
 import { z } from 'zod';
 import { useShallow } from 'zustand/react/shallow';
@@ -44,6 +44,7 @@ import { useCardProvider } from '@/hooks/useCardProvider';
 import { usePreviewDepositToCard } from '@/hooks/usePreviewDepositToCard';
 import useSwapAndBridgeToCard from '@/hooks/useSwapAndBridgeToCard';
 import useUser from '@/hooks/useUser';
+import { WalletTokenButton } from '@/components/WalletTokenSelector';
 import { BRIDGE_TOKENS } from '@/constants/bridge';
 import { useDepositStore } from '@/store/useDepositStore';
 import { track } from '@/lib/analytics';
@@ -58,6 +59,8 @@ import {
   CardProvider,
   DepositCategory,
   Status,
+  TokenBalance,
+  TokenType,
   TransactionStatus,
   TransactionType,
 } from '@/lib/types';
@@ -734,21 +737,26 @@ export default function CardDepositInternalForm() {
   const { borrowAndDeposit, bridgeStatus: borrowAndDepositStatus } = useBorrowAndDepositToCard();
   const { deposit, depositStatus, error: depositError } = useCardDeposit();
 
-  const storedSrcChainId = useDepositStore(state => state.srcChainId);
-  const setSrcChainId = useDepositStore(state => state.setSrcChainId);
-  // Default to Base (the card funding chain) when no valid src chain is selected,
-  // so the useDepositFromSolidUsdc hook always has a chain to sign the approve on.
-  const cardDepositSrcChainId =
-    storedSrcChainId && BRIDGE_TOKENS[storedSrcChainId]?.tokens?.USDC
-      ? storedSrcChainId
-      : base.id;
-  useEffect(() => {
-    if (storedSrcChainId !== cardDepositSrcChainId) {
-      setSrcChainId(cardDepositSrcChainId);
-    }
-  }, [storedSrcChainId, cardDepositSrcChainId, setSrcChainId]);
-  const cardDepositTokenAddress = BRIDGE_TOKENS[cardDepositSrcChainId]?.tokens?.USDC
-    ?.address as Address;
+  const cardDepositSrcChainId = useDepositStore(state => state.srcChainId);
+  const cardDepositTokenAddress = (BRIDGE_TOKENS[cardDepositSrcChainId]?.tokens?.USDC
+    ?.address ?? '') as Address;
+  const hasSelectedWalletToken =
+    watchedFrom === CardDepositSource.WALLET &&
+    isProduction &&
+    !!cardDepositSrcChainId &&
+    !!cardDepositTokenAddress;
+  const selectedCardWalletToken: TokenBalance | null = useMemo(() => {
+    if (!hasSelectedWalletToken) return null;
+    return {
+      contractTickerSymbol: 'USDC',
+      contractName: 'USD Coin',
+      contractAddress: cardDepositTokenAddress,
+      balance: '0',
+      contractDecimals: 6,
+      type: TokenType.ERC20,
+      chainId: cardDepositSrcChainId,
+    };
+  }, [hasSelectedWalletToken, cardDepositTokenAddress, cardDepositSrcChainId]);
   const {
     deposit: walletCardDeposit,
     depositStatus: walletCardDepositStatus,
@@ -1096,6 +1104,7 @@ export default function CardDepositInternalForm() {
     (watchedFrom !== CardDepositSource.BORROW && isEstimatedUSDCLoading) ||
     (watchedFrom === CardDepositSource.BORROW && isRateLoading) ||
     isFundingAddressLoading ||
+    (isWalletSourceGaslessGated && !hasSelectedWalletToken) ||
     !isValid ||
     !watchedAmount;
 
@@ -1188,6 +1197,16 @@ export default function CardDepositInternalForm() {
         showSavingsAndBorrowOptions={showSavingsAndBorrowOptions}
         walletTokenSymbol={walletTokenSymbol}
       />
+
+      {isWalletSourceGaslessGated && (
+        <View className="gap-2">
+          <Text className="font-medium opacity-50">Token</Text>
+          <WalletTokenButton
+            selectedToken={selectedCardWalletToken}
+            onPress={() => setModal(CARD_DEPOSIT_MODAL.OPEN_TOKEN_SELECTOR)}
+          />
+        </View>
+      )}
 
       {watchedFrom === CardDepositSource.BORROW ? (
         <View className="gap-4 px-2">

--- a/components/Card/CardDepositModalProvider.tsx
+++ b/components/Card/CardDepositModalProvider.tsx
@@ -14,6 +14,7 @@ import { useCardDepositStore } from '@/store/useCardDepositStore';
 import CardDepositExternal from './CardDepositExternal';
 import CardDepositInternalForm from './CardDepositInternalForm';
 import CardDepositOptions from './CardDepositOptions';
+import CardDepositTokenSelector from './CardDepositTokenSelector';
 
 /**
  * Global card deposit modal provider that renders a single ResponsiveModal instance.
@@ -39,6 +40,7 @@ const CardDepositModalProvider = () => {
   const isOptions = currentModal.name === CARD_DEPOSIT_MODAL.OPEN_OPTIONS.name;
   const isInternal = currentModal.name === CARD_DEPOSIT_MODAL.OPEN_INTERNAL_FORM.name;
   const isExternal = currentModal.name === CARD_DEPOSIT_MODAL.OPEN_EXTERNAL_FORM.name;
+  const isTokenSelector = currentModal.name === CARD_DEPOSIT_MODAL.OPEN_TOKEN_SELECTOR.name;
   const isTransactionStatus = currentModal.name === CARD_DEPOSIT_MODAL.OPEN_TRANSACTION_STATUS.name;
   const shouldAnimate = previousModal.name !== CARD_DEPOSIT_MODAL.CLOSE.name;
   const isForward = currentModal.number > previousModal.number;
@@ -90,16 +92,18 @@ const CardDepositModalProvider = () => {
 
   const getTitle = useCallback(() => {
     if (isTransactionStatus) return undefined;
+    if (isTokenSelector) return 'Select token';
     return 'Deposit to Card';
-  }, [isTransactionStatus]);
+  }, [isTransactionStatus, isTokenSelector]);
 
   const getContentKey = useCallback(() => {
     if (isTransactionStatus) return 'transaction-status';
     if (isOptions) return 'options';
     if (isInternal) return 'internal';
     if (isExternal) return 'external';
+    if (isTokenSelector) return 'token-selector';
     return 'options';
-  }, [isTransactionStatus, isOptions, isInternal, isExternal]);
+  }, [isTransactionStatus, isOptions, isInternal, isExternal, isTokenSelector]);
 
   const getContent = useCallback(() => {
     if (isTransactionStatus) {
@@ -118,12 +122,14 @@ const CardDepositModalProvider = () => {
     if (isOptions) return <CardDepositOptions />;
     if (isInternal) return <CardDepositInternalForm />;
     if (isExternal) return <CardDepositExternal />;
+    if (isTokenSelector) return <CardDepositTokenSelector />;
     return <CardDepositOptions />;
   }, [
     isTransactionStatus,
     isOptions,
     isInternal,
     isExternal,
+    isTokenSelector,
     transaction.amount,
     handleTransactionStatusPress,
   ]);
@@ -144,8 +150,12 @@ const CardDepositModalProvider = () => {
   );
 
   const handleBackPress = useCallback(() => {
+    if (isTokenSelector) {
+      setModal(CARD_DEPOSIT_MODAL.OPEN_INTERNAL_FORM);
+      return;
+    }
     setModal(CARD_DEPOSIT_MODAL.CLOSE);
-  }, [setModal]);
+  }, [isTokenSelector, setModal]);
 
   return (
     <ResponsiveModal
@@ -157,7 +167,7 @@ const CardDepositModalProvider = () => {
       title={getTitle()}
       containerClassName="min-h-[42rem] overflow-y-auto flex-1"
       contentKey={getContentKey()}
-      showBackButton={isInternal && !isTransactionStatus}
+      showBackButton={(isInternal || isTokenSelector) && !isTransactionStatus}
       onBackPress={handleBackPress}
       shouldAnimate={shouldAnimate}
       isForward={isForward}

--- a/components/Card/CardDepositTokenSelector.tsx
+++ b/components/Card/CardDepositTokenSelector.tsx
@@ -1,0 +1,51 @@
+import React, { useCallback, useMemo } from 'react';
+import { arbitrum, base, fuse, mainnet, polygon } from 'viem/chains';
+import { useShallow } from 'zustand/react/shallow';
+
+import { WalletTokenSelectorScreen } from '@/components/WalletTokenSelector';
+import { CARD_DEPOSIT_MODAL } from '@/constants/modals';
+import { TokenBalance } from '@/lib/types';
+import { useDepositStore } from '@/store/useDepositStore';
+
+const SUPPORTED_CHAIN_IDS = [mainnet.id, polygon.id, base.id, arbitrum.id, fuse.id];
+const SUPPORTED_TOKEN_SYMBOLS = ['USDC'];
+
+/**
+ * Token selector for the Card deposit "from wallet" flow. Reuses the
+ * generalized WalletTokenSelectorScreen (same screen as Savings) filtered
+ * to USDC across the five supported chains, and navigates back to the card
+ * deposit internal form on selection.
+ */
+const CardDepositTokenSelector: React.FC = () => {
+  const { setSrcChainId, setPrincipalToken, setModal } = useDepositStore(
+    useShallow(state => ({
+      setSrcChainId: state.setSrcChainId,
+      setPrincipalToken: state.setPrincipalToken,
+      setModal: state.setModal,
+    })),
+  );
+
+  const handleTokenSelect = useCallback(
+    (token: TokenBalance) => {
+      setSrcChainId(token.chainId);
+      setPrincipalToken(token.contractTickerSymbol?.toUpperCase() || 'USDC');
+      setModal(CARD_DEPOSIT_MODAL.OPEN_INTERNAL_FORM);
+    },
+    [setSrcChainId, setPrincipalToken, setModal],
+  );
+
+  const supportedChainIds = useMemo(() => SUPPORTED_CHAIN_IDS, []);
+  const supportedTokenSymbols = useMemo(() => SUPPORTED_TOKEN_SYMBOLS, []);
+
+  return (
+    <WalletTokenSelectorScreen
+      supportedChainIds={supportedChainIds}
+      supportedTokenSymbols={supportedTokenSymbols}
+      onSelect={handleTokenSelect}
+      emptyMessage="No USDC found in your Solid wallet"
+      emptyDescription="Add USDC to your Solid wallet on Ethereum, Polygon, Base, Arbitrum, or Fuse first, then come back to deposit to your card."
+    />
+  );
+};
+
+export default CardDepositTokenSelector;

--- a/components/DepositToVault/SavingsDepositTokenSelector.tsx
+++ b/components/DepositToVault/SavingsDepositTokenSelector.tsx
@@ -1,22 +1,17 @@
 import React, { useCallback, useMemo } from 'react';
-import { View } from 'react-native';
-import { formatUnits } from 'viem';
 import { useShallow } from 'zustand/react/shallow';
 
-import { Text } from '@/components/ui/text';
-import { WalletTokenList } from '@/components/WalletTokenSelector';
+import { WalletTokenSelectorScreen } from '@/components/WalletTokenSelector';
 import { BRIDGE_TOKENS } from '@/constants/bridge';
 import { DEPOSIT_MODAL } from '@/constants/modals';
 import useVaultDepositConfig from '@/hooks/useVaultDepositConfig';
-import { useWalletTokens } from '@/hooks/useWalletTokens';
 import { TokenBalance } from '@/lib/types';
 import { useDepositStore } from '@/store/useDepositStore';
 
 /**
  * Token selector for the Savings deposit flow (Step 2).
- * Shows tokens from the user's Solid wallet that can be deposited into vaults,
- * with chain names displayed. Selecting a token sets the srcChainId, principalToken,
- * and appropriate vault, then navigates to the deposit form.
+ * Thin wrapper around WalletTokenSelectorScreen that filters by the selected
+ * vault's supported chains/symbols and navigates back to the deposit form.
  */
 const SavingsDepositTokenSelector: React.FC = () => {
   const { setSrcChainId, setPrincipalToken, setModal } = useDepositStore(
@@ -27,38 +22,14 @@ const SavingsDepositTokenSelector: React.FC = () => {
     })),
   );
   const { vault } = useVaultDepositConfig();
-  const { ethereumTokens, fuseTokens, polygonTokens, baseTokens, arbitrumTokens } =
-    useWalletTokens();
 
-  // Build a list of depositable tokens that match the SELECTED vault's supported tokens
-  const depositableTokens = useMemo(() => {
-    const allTokens = [
-      ...ethereumTokens,
-      ...fuseTokens,
-      ...polygonTokens,
-      ...baseTokens,
-      ...arbitrumTokens,
-    ];
-
-    // Only include (chainId, symbol) pairs supported by the currently-selected vault
-    const supportedSet = new Set<string>();
+  const { supportedChainIds, supportedTokenSymbols } = useMemo(() => {
     const config = vault.depositConfig;
-    if (config) {
-      for (const chainId of config.supportedChains) {
-        for (const symbol of config.supportedTokens) {
-          supportedSet.add(`${chainId}:${symbol.toUpperCase()}`);
-        }
-      }
-    }
-
-    return allTokens.filter(token => {
-      const symbol = token.contractTickerSymbol?.toUpperCase();
-      const key = `${token.chainId}:${symbol}`;
-      if (!supportedSet.has(key)) return false;
-      const balance = Number(formatUnits(BigInt(token.balance || '0'), token.contractDecimals));
-      return balance > 0;
-    });
-  }, [ethereumTokens, fuseTokens, polygonTokens, baseTokens, arbitrumTokens, vault]);
+    return {
+      supportedChainIds: config?.supportedChains ?? [],
+      supportedTokenSymbols: config?.supportedTokens ?? [],
+    };
+  }, [vault]);
 
   const handleTokenSelect = useCallback(
     (token: TokenBalance) => {
@@ -72,24 +43,20 @@ const SavingsDepositTokenSelector: React.FC = () => {
         : undefined;
 
       setSrcChainId(chainId);
-      setPrincipalToken(tokenKey || symbol);
+      setPrincipalToken(tokenKey || symbol || '');
       setModal(DEPOSIT_MODAL.OPEN_FORM);
     },
     [setSrcChainId, setPrincipalToken, setModal],
   );
 
   return (
-    <View className="gap-4">
-      <Text className="text-base font-medium opacity-70">
-        Select a token from your wallet to deposit
-      </Text>
-      <WalletTokenList
-        tokens={depositableTokens}
-        onSelect={handleTokenSelect}
-        emptyMessage="No depositable tokens found"
-        emptyDescription="Add funds to your wallet first, then come back to deposit into Savings."
-      />
-    </View>
+    <WalletTokenSelectorScreen
+      supportedChainIds={supportedChainIds}
+      supportedTokenSymbols={supportedTokenSymbols}
+      onSelect={handleTokenSelect}
+      emptyMessage="No depositable tokens found"
+      emptyDescription="Add funds to your wallet first, then come back to deposit into Savings."
+    />
   );
 };
 

--- a/components/WalletTokenSelector/WalletTokenSelectorScreen.tsx
+++ b/components/WalletTokenSelector/WalletTokenSelectorScreen.tsx
@@ -1,0 +1,93 @@
+import React, { useMemo } from 'react';
+import { View } from 'react-native';
+import { formatUnits } from 'viem';
+
+import { Text } from '@/components/ui/text';
+import { WalletTokenList } from '@/components/WalletTokenSelector';
+import { useWalletTokens } from '@/hooks/useWalletTokens';
+import { TokenBalance } from '@/lib/types';
+
+export interface WalletTokenSelectorScreenProps {
+  /** Heading shown above the list. Defaults to "Select a token from your wallet to deposit". */
+  title?: string;
+  /** Whitelist of chain IDs to show tokens from. */
+  supportedChainIds: number[];
+  /** Whitelist of token symbols (case-insensitive). */
+  supportedTokenSymbols: string[];
+  /** Called with the selected token. */
+  onSelect: (token: TokenBalance) => void;
+  /** Empty-state title. */
+  emptyMessage?: string;
+  /** Empty-state description. */
+  emptyDescription?: string;
+  /** When true, include tokens with zero balance. Default: false. */
+  includeZeroBalance?: boolean;
+}
+
+/**
+ * Generic Solid-wallet token picker. Aggregates tokens across all chains the
+ * wallet hook exposes, filters by chain + symbol, sorts via WalletTokenList,
+ * and invokes onSelect when the user taps a row. Used by both the Savings
+ * deposit flow and the Card deposit flow (via thin wrappers that pass the
+ * vault- or card-specific filter + navigation callback).
+ */
+const WalletTokenSelectorScreen: React.FC<WalletTokenSelectorScreenProps> = ({
+  title = 'Select a token from your wallet to deposit',
+  supportedChainIds,
+  supportedTokenSymbols,
+  onSelect,
+  emptyMessage,
+  emptyDescription,
+  includeZeroBalance = false,
+}) => {
+  const { ethereumTokens, fuseTokens, polygonTokens, baseTokens, arbitrumTokens } =
+    useWalletTokens();
+
+  const depositableTokens = useMemo(() => {
+    const allTokens = [
+      ...ethereumTokens,
+      ...fuseTokens,
+      ...polygonTokens,
+      ...baseTokens,
+      ...arbitrumTokens,
+    ];
+    const chainSet = new Set(supportedChainIds);
+    const symbolSet = new Set(
+      supportedTokenSymbols.map(symbol => symbol.toUpperCase()),
+    );
+
+    return allTokens.filter(token => {
+      const symbol = token.contractTickerSymbol?.toUpperCase();
+      if (!symbol || !symbolSet.has(symbol)) return false;
+      if (!chainSet.has(token.chainId)) return false;
+      if (includeZeroBalance) return true;
+      const balance = Number(
+        formatUnits(BigInt(token.balance || '0'), token.contractDecimals),
+      );
+      return balance > 0;
+    });
+  }, [
+    ethereumTokens,
+    fuseTokens,
+    polygonTokens,
+    baseTokens,
+    arbitrumTokens,
+    supportedChainIds,
+    supportedTokenSymbols,
+    includeZeroBalance,
+  ]);
+
+  return (
+    <View className="gap-4">
+      <Text className="text-base font-medium opacity-70">{title}</Text>
+      <WalletTokenList
+        tokens={depositableTokens}
+        onSelect={onSelect}
+        emptyMessage={emptyMessage}
+        emptyDescription={emptyDescription}
+      />
+    </View>
+  );
+};
+
+export default WalletTokenSelectorScreen;

--- a/components/WalletTokenSelector/index.tsx
+++ b/components/WalletTokenSelector/index.tsx
@@ -1,2 +1,3 @@
 export { default as WalletTokenButton } from './WalletTokenButton';
 export { default as WalletTokenList } from './WalletTokenList';
+export { default as WalletTokenSelectorScreen } from './WalletTokenSelectorScreen';

--- a/constants/modals.ts
+++ b/constants/modals.ts
@@ -263,6 +263,11 @@ export const CARD_DEPOSIT_MODAL = {
     name: 'open_external_form',
     number: 2,
   },
+  OPEN_TOKEN_SELECTOR: {
+    // Step 2A.1: pick a USDC token from the Solid wallet (only from WALLET source)
+    name: 'open_token_selector',
+    number: 2.5,
+  },
   OPEN_TRANSACTION_STATUS: {
     name: 'open_transaction_status',
     number: 3,


### PR DESCRIPTION
Extract the reusable wallet-token picker from SavingsDepositTokenSelector into a shared WalletTokenSelectorScreen component that accepts filter props (supportedChainIds, supportedTokenSymbols, onSelect, empty text) so it can be reused unchanged by the card deposit flow.

- New components/WalletTokenSelector/WalletTokenSelectorScreen.tsx hosts the aggregation + filter + render logic previously inlined in the savings selector.
- SavingsDepositTokenSelector becomes a thin wrapper that passes the active vault's supportedChains / supportedTokens and navigates back to DEPOSIT_MODAL.OPEN_FORM on select. No behavioural change.
- New components/Card/CardDepositTokenSelector.tsx wraps the same screen with a USDC + 5-chains filter and navigates back to CARD_DEPOSIT_MODAL.OPEN_INTERNAL_FORM.
- constants/modals.ts adds CARD_DEPOSIT_MODAL.OPEN_TOKEN_SELECTOR.
- CardDepositModalProvider renders CardDepositTokenSelector when the new state is active and wires up the Select-token title + back-button routing to the internal form.
- CardDepositInternalForm replaces the earlier "default to Base" fallback with a WalletTokenButton that opens the selector. The deposit button is disabled until the user picks a token, and the selected token is shown in the button label (symbol + chain name).

https://claude.ai/code/session_01TDpHy9uTrVX3PTRp9xS9S5