### PR TITLE
feat(card-deposit): add external wallet option to internal form dropdown

### DIFF
--- a/components/Card/CardDepositInternalForm.tsx
+++ b/components/Card/CardDepositInternalForm.tsx
@@ -10,13 +10,21 @@ import {
 import { ActivityIndicator, Linking, Platform, Pressable, TextInput, View } from 'react-native';
 import Toast from 'react-native-toast-message';
 import { Image } from 'expo-image';
-import { ChevronDown, Fuel, Info, Leaf, Wallet as WalletIcon } from 'lucide-react-native';
+import {
+  ChevronDown,
+  ChevronRight,
+  Fuel,
+  Info,
+  Leaf,
+  Wallet as WalletIcon,
+} from 'lucide-react-native';
 import { Address, erc20Abi, formatUnits, parseUnits, TransactionReceipt } from 'viem';
 import { fuse, mainnet } from 'viem/chains';
 import { useReadContract } from 'wagmi';
 import { z } from 'zod';
 import { useShallow } from 'zustand/react/shallow';
 
+import DepositPublicAddress from '@/components/DepositOption/DepositPublicAddress';
 import Max from '@/components/Max';
 import TokenDetails from '@/components/TokenCard/TokenDetails';
 import { Button } from '@/components/ui/button';
@@ -76,6 +84,8 @@ import { CardDepositSource, useCardDepositStore } from '@/store/useCardDepositSt
 
 import { BorrowSlider } from './BorrowSlider';
 
+const BASE_USDC_TOKEN_URL = `https://basescan.org/token/${ADDRESSES.base.usdc}`;
+
 type FormData = { amount: string; from: CardDepositSource };
 
 type SourceSelectorProps = {
@@ -108,12 +118,14 @@ function SourceSelectorNative({
   const getDisplayText = useCallback(() => {
     if (value === CardDepositSource.WALLET) return 'Wallet';
     if (value === CardDepositSource.SAVINGS) return 'Savings';
+    if (value === CardDepositSource.EXTERNAL) return 'External Wallet';
     return 'Borrow against Savings';
   }, [value]);
 
   const getTokenSymbol = useCallback(() => {
     if (from === CardDepositSource.WALLET) return walletTokenSymbol;
     if (from === CardDepositSource.SAVINGS) return 'soUSD';
+    if (from === CardDepositSource.EXTERNAL) return 'USDC';
     return '';
   }, [from, walletTokenSymbol]);
 
@@ -124,7 +136,7 @@ function SourceSelectorNative({
         onPress={() => setIsOpen(!isOpen)}
       >
         <View className="flex-row items-center gap-2">
-          {value === CardDepositSource.WALLET ? (
+          {value === CardDepositSource.WALLET || value === CardDepositSource.EXTERNAL ? (
             <WalletIcon color="#A1A1A1" size={24} />
           ) : value === CardDepositSource.SAVINGS ? (
             <Leaf color="#A1A1A1" size={24} />
@@ -176,6 +188,16 @@ function SourceSelectorNative({
             <WalletIcon color="#A1A1A1" size={20} />
             <Text className="text-lg">Wallet</Text>
           </Pressable>
+          <Pressable
+            className="flex-row items-center gap-2 px-4 py-3"
+            onPress={() => {
+              onChange(CardDepositSource.EXTERNAL);
+              setIsOpen(false);
+            }}
+          >
+            <WalletIcon color="#A1A1A1" size={20} />
+            <Text className="text-lg">External Wallet</Text>
+          </Pressable>
         </View>
       )}
     </View>
@@ -200,12 +222,14 @@ function SourceSelectorWeb({
   const getDisplayText = useCallback(() => {
     if (value === CardDepositSource.WALLET) return 'Wallet';
     if (value === CardDepositSource.SAVINGS) return 'Savings';
+    if (value === CardDepositSource.EXTERNAL) return 'External Wallet';
     return 'Borrow against Savings';
   }, [value]);
 
   const getTokenSymbol = useCallback(() => {
     if (from === CardDepositSource.WALLET) return walletTokenSymbol;
     if (from === CardDepositSource.SAVINGS) return 'soUSD';
+    if (from === CardDepositSource.EXTERNAL) return 'USDC';
     return '';
   }, [from, walletTokenSymbol]);
 
@@ -214,7 +238,7 @@ function SourceSelectorWeb({
       <DropdownMenuTrigger asChild>
         <Pressable className="flex-row items-center justify-between rounded-2xl bg-accent p-4">
           <View className="flex-row items-center gap-2">
-            {value === CardDepositSource.WALLET ? (
+            {value === CardDepositSource.WALLET || value === CardDepositSource.EXTERNAL ? (
               <WalletIcon color="#A1A1A1" size={24} />
             ) : value === CardDepositSource.SAVINGS ? (
               <Leaf color="#A1A1A1" size={24} />
@@ -254,6 +278,13 @@ function SourceSelectorWeb({
         >
           <WalletIcon color="#A1A1A1" size={20} />
           <Text className="text-lg">Wallet</Text>
+        </DropdownMenuItem>
+        <DropdownMenuItem
+          onPress={() => onChange(CardDepositSource.EXTERNAL)}
+          className="flex-row items-center gap-2 px-4 py-3 web:cursor-pointer"
+        >
+          <WalletIcon color="#A1A1A1" size={20} />
+          <Text className="text-lg">External Wallet</Text>
         </DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>
@@ -1195,6 +1226,31 @@ export default function CardDepositInternalForm() {
     }
   }, [showBorrowOption, watchedFrom, setValue]);
 
+  const fundingAddress = useMemo(
+    () => getCardFundingAddress(cardDetails, provider, contracts ?? undefined),
+    [cardDetails, provider, contracts],
+  );
+
+  const externalWalletDescription = useMemo(
+    () => (
+      <View className="items-center gap-2">
+        <Text className="max-w-72 text-center text-sm text-muted-foreground">
+          Transfer USDC on Base chain.
+        </Text>
+        <Pressable
+          onPress={() => Linking.openURL(BASE_USDC_TOKEN_URL)}
+          className="web:hover:opacity-50"
+        >
+          <View className="flex-row flex-wrap items-center">
+            <Text className="text-sm font-medium text-white">See token address</Text>
+            <ChevronRight size={16} color="white" />
+          </View>
+        </Pressable>
+      </View>
+    ),
+    [],
+  );
+
   return (
     <View className="flex-1 gap-3">
       <SourceSelector
@@ -1205,7 +1261,20 @@ export default function CardDepositInternalForm() {
         walletTokenSymbol={walletTokenSymbol}
       />
 
-      {watchedFrom === CardDepositSource.BORROW ? (
+      {watchedFrom === CardDepositSource.EXTERNAL ? (
+        <View className="flex-1 gap-3">
+          {isFundingAddressLoading ? (
+            <View className="items-center py-8">
+              <ActivityIndicator color="white" />
+            </View>
+          ) : (
+            <DepositPublicAddress
+              address={fundingAddress}
+              description={externalWalletDescription}
+            />
+          )}
+        </View>
+      ) : watchedFrom === CardDepositSource.BORROW ? (
         <View className="gap-4 px-2">
           <BorrowSlider
             value={sliderValue}
@@ -1301,12 +1370,13 @@ export default function CardDepositInternalForm() {
 
       <View className="flex-1" />
 
-      {watchedFrom !== CardDepositSource.BORROW && (
-        <DestinationDisplay
-          fundingChainLabel={getChain(fundingChainId)?.name ?? 'Card'}
-          destinationTokenSymbol={getCardDepositTokenSymbol(provider)}
-        />
-      )}
+      {watchedFrom !== CardDepositSource.BORROW &&
+        watchedFrom !== CardDepositSource.EXTERNAL && (
+          <DestinationDisplay
+            fundingChainLabel={getChain(fundingChainId)?.name ?? 'Card'}
+            destinationTokenSymbol={getCardDepositTokenSymbol(provider)}
+          />
+        )}
 
       {isWalletSourceGaslessGated && (
         <View className="mt-2 flex-row items-start gap-2">
@@ -1319,17 +1389,22 @@ export default function CardDepositInternalForm() {
         </View>
       )}
 
-      <ErrorDisplay
-        error={
-          validationError ||
-          bridgeError ||
-          swapAndBridgeError ||
-          (!isProduction ? depositError : null) ||
-          (isProduction && watchedFrom === CardDepositSource.WALLET ? walletCardDepositError : null)
-        }
-      />
+      {watchedFrom !== CardDepositSource.EXTERNAL && (
+        <ErrorDisplay
+          error={
+            validationError ||
+            bridgeError ||
+            swapAndBridgeError ||
+            (!isProduction ? depositError : null) ||
+            (isProduction && watchedFrom === CardDepositSource.WALLET
+              ? walletCardDepositError
+              : null)
+          }
+        />
+      )}
 
-      {watchedFrom === CardDepositSource.BORROW ? (
+      {watchedFrom === CardDepositSource.EXTERNAL ? null : watchedFrom ===
+        CardDepositSource.BORROW ? (
         <BorrowAndDepositButton
           disabled={disabled || borrowAndDepositStatus === Status.PENDING}
           bridgeStatus={borrowAndDepositStatus}

--- a/components/DepositOption/DepositPublicAddress.tsx
+++ b/components/DepositOption/DepositPublicAddress.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { ReactNode, useMemo } from 'react';
 import { Linking, Pressable, View } from 'react-native';
 import QRCode from 'react-native-qrcode-svg';
 import { Image } from 'expo-image';
@@ -15,8 +15,16 @@ const solidLogo = require('@/assets/images/solid-white.png');
 const SUPPORTED_NETWORKS_URL =
   'https://support.solid.xyz/en/articles/14431132-supported-networks-and-tokens-on-solid';
 
-const DepositPublicAddress = () => {
+type DepositPublicAddressProps = {
+  /** Override address shown in copy row and QR. Defaults to user's safe address. */
+  address?: string;
+  /** Custom description rendered under the QR. Replaces default supported-networks section. */
+  description?: ReactNode;
+};
+
+const DepositPublicAddress = ({ address, description }: DepositPublicAddressProps = {}) => {
   const { user } = useUser();
+  const resolvedAddress = address ?? user?.safeAddress ?? '';
 
   const networks = useMemo(() => {
     const displayOrder: Record<string, number> = {
@@ -46,15 +54,15 @@ const DepositPublicAddress = () => {
       <View className="w-full max-w-md rounded-xl bg-card">
         <View className="flex-row items-center justify-center gap-1 pt-4">
           <Text className="text-lg font-medium text-white">
-            {user?.safeAddress ? eclipseAddress(user?.safeAddress, 6, 6) : ''}
+            {resolvedAddress ? eclipseAddress(resolvedAddress, 6, 6) : ''}
           </Text>
-          <CopyToClipboard text={user?.safeAddress || ''} className="text-primary" />
+          <CopyToClipboard text={resolvedAddress} className="text-primary" />
         </View>
 
         <View className="items-center justify-center px-4 py-4">
           <View className="overflow-hidden rounded-xl">
             <QRCode
-              value={user?.safeAddress || ''}
+              value={resolvedAddress}
               size={200}
               color="white"
               backgroundColor="#181A1A"
@@ -66,41 +74,47 @@ const DepositPublicAddress = () => {
         </View>
 
         <View className="items-center gap-2 px-4 pb-4">
-          <View className="flex-row items-center justify-center">
-            {networks.map((network, index) => (
-              <View
-                key={network.chainId}
-                className={index > 0 ? '-ml-2' : ''}
-                style={{ zIndex: networks.length - index }}
-              >
-                <Image
-                  source={network.icon}
-                  style={{
-                    width: 24,
-                    height: 24,
-                    borderRadius: 12,
-                    borderWidth: 1.5,
-                    borderColor: '#1C1C1C',
-                  }}
-                  contentFit="cover"
-                />
+          {description ? (
+            description
+          ) : (
+            <>
+              <View className="flex-row items-center justify-center">
+                {networks.map((network, index) => (
+                  <View
+                    key={network.chainId}
+                    className={index > 0 ? '-ml-2' : ''}
+                    style={{ zIndex: networks.length - index }}
+                  >
+                    <Image
+                      source={network.icon}
+                      style={{
+                        width: 24,
+                        height: 24,
+                        borderRadius: 12,
+                        borderWidth: 1.5,
+                        borderColor: '#1C1C1C',
+                      }}
+                      contentFit="cover"
+                    />
+                  </View>
+                ))}
               </View>
-            ))}
-          </View>
 
-          <Text className="max-w-72 text-center text-sm text-muted-foreground">
-            We support tokens on {networkNames} chain
-          </Text>
+              <Text className="max-w-72 text-center text-sm text-muted-foreground">
+                We support tokens on {networkNames} chain
+              </Text>
 
-          <Pressable
-            onPress={() => Linking.openURL(SUPPORTED_NETWORKS_URL)}
-            className="web:hover:opacity-50"
-          >
-            <View className="flex-row flex-wrap items-center">
-              <Text className="text-sm font-medium text-white">See supported networks</Text>
-              <ChevronRight size={16} color="white" />
-            </View>
-          </Pressable>
+              <Pressable
+                onPress={() => Linking.openURL(SUPPORTED_NETWORKS_URL)}
+                className="web:hover:opacity-50"
+              >
+                <View className="flex-row flex-wrap items-center">
+                  <Text className="text-sm font-medium text-white">See supported networks</Text>
+                  <ChevronRight size={16} color="white" />
+                </View>
+              </Pressable>
+            </>
+          )}
         </View>
       </View>
     </View>


### PR DESCRIPTION
## Summary
- Adds "External Wallet" as the last option in the card deposit dropdown (after Borrow against Savings, Savings, and Wallet)
- Renders the card funding address via the reusable `DepositPublicAddress` "Your Solid address" screen with a Base chain USDC description linking to Basescan
- Extends `DepositPublicAddress` with optional `address` and `description` props so it can be reused outside the Add funds flow (backwards compatible — defaults to `user.safeAddress` and the supported-networks section)

Cherry-picked from qa (#1970).

## Test plan
- [ ] Open Deposit to Card modal, select "External Wallet" from the dropdown — address + QR render and description shows "Transfer USDC on Base chain. See token address ›"
- [ ] Tap "See token address" — opens Basescan USDC token page
- [ ] Copy button copies the card funding address
- [ ] Verify Add funds → "Your Solid address" screen still renders the default supported-networks UI (regression check)

https://claude.ai/code/session_016b47CP58T3FaoHqVJtyQPW