### PR TITLE
fix(card-deposit): hide flex spacer when external wallet is selected

### DIFF
--- a/components/Card/CardDepositInternalForm.tsx
+++ b/components/Card/CardDepositInternalForm.tsx
@@ -1368,7 +1368,7 @@ export default function CardDepositInternalForm() {
         </TokenDetails>
       )}
 
-      <View className="flex-1" />
+      {watchedFrom !== CardDepositSource.EXTERNAL && <View className="flex-1" />}
 
       {watchedFrom !== CardDepositSource.BORROW &&
         watchedFrom !== CardDepositSource.EXTERNAL && (


### PR DESCRIPTION
The unconditional <View className="flex-1" /> spacer was rendered as a sibling of the EXTERNAL branch's own flex-1 content wrapper, creating two stacked flex-1 children in the column. The empty sibling overlaid the address card and intercepted pointer events, making the "See token address" link unclickable. Restrict the spacer to non-external modes.