### PR TITLE
Replace custom back button with BackButton component

### DIFF
--- a/app/(protected)/(tabs)/settings/index.tsx
+++ b/app/(protected)/(tabs)/settings/index.tsx
@@ -3,11 +3,12 @@ import * as Application from 'expo-application';
 import { Image } from 'expo-image';
 import * as IntentLauncher from 'expo-intent-launcher';
 import { router } from 'expo-router';
-import { ArrowLeft, Bell, ChevronLeft } from 'lucide-react-native';
+import { ArrowLeft, Bell } from 'lucide-react-native';
 
 import Navbar from '@/components/Navbar';
 import PageLayout from '@/components/PageLayout';
 import { SettingsCard } from '@/components/Settings';
+import { BackButton } from '@/components/ui/back-button';
 import { useDimension } from '@/hooks/useDimension';
 import useNotificationPermissionStatus from '@/hooks/useNotificationPermissionStatus';
 import useUser from '@/hooks/useUser';
@@ -43,9 +44,7 @@ export default function Settings() {
 
   const mobileHeader = (
     <View className="flex-row items-center justify-between px-4 py-3">
-      <Pressable onPress={() => router.back()} className="p-2">
-        <ChevronLeft size={24} color="#ffffff" />
-      </Pressable>
+      <BackButton />
       <Text className="mr-10 flex-1 text-center text-xl font-bold text-white">Settings</Text>
     </View>
   );

--- a/components/ui/back-button.tsx
+++ b/components/ui/back-button.tsx
@@ -1,6 +1,6 @@
 import { Pressable } from 'react-native';
 import { useRouter } from 'expo-router';
-import { ArrowLeft } from 'lucide-react-native';
+import { ChevronLeft } from 'lucide-react-native';
 
 interface BackButtonProps {
   fallbackHref?: string;
@@ -14,7 +14,7 @@ export function BackButton({ fallbackHref = '/' }: BackButtonProps) {
       onPress={() => (router.canGoBack() ? router.back() : router.replace(fallbackHref as any))}
       className="flex h-10 w-10 items-center justify-center rounded-full border-0 bg-popover web:transition-colors web:hover:bg-muted"
     >
-      <ArrowLeft size={24} color="#FFFFFF" />
+      <ChevronLeft size={24} color="#FFFFFF" />
     </Pressable>
   );
 }

--- a/components/ui/back-button.tsx
+++ b/components/ui/back-button.tsx
@@ -1,6 +1,6 @@
 import { Pressable } from 'react-native';
 import { useRouter } from 'expo-router';
-import { ChevronLeft } from 'lucide-react-native';
+import { ArrowLeft } from 'lucide-react-native';
 
 interface BackButtonProps {
   fallbackHref?: string;
@@ -14,7 +14,7 @@ export function BackButton({ fallbackHref = '/' }: BackButtonProps) {
       onPress={() => (router.canGoBack() ? router.back() : router.replace(fallbackHref as any))}
       className="flex h-10 w-10 items-center justify-center rounded-full border-0 bg-popover web:transition-colors web:hover:bg-muted"
     >
-      <ChevronLeft size={24} color="#FFFFFF" />
+      <ArrowLeft size={24} color="#FFFFFF" />
     </Pressable>
   );
 }


### PR DESCRIPTION
## Summary
Refactored the settings page header to use a dedicated `BackButton` component instead of implementing the back button inline with raw icon and pressable elements.

## Key Changes
- Removed unused `ChevronLeft` icon import from lucide-react-native
- Imported the new `BackButton` component from `@/components/ui/back-button`
- Replaced inline back button implementation (Pressable + ChevronLeft icon) with `<BackButton />` component in the mobile header

## Implementation Details
This change improves code maintainability by centralizing back button styling and behavior in a reusable component, reducing duplication and making future updates to the back button design easier to manage across the application.

https://claude.ai/code/session_015abE3yneWZwkkzqAsvp7su