### PR TITLE
Wrap modal content with KeyboardAvoidingView for better keyboard handling

### DIFF
--- a/components/ResponsiveModal.tsx
+++ b/components/ResponsiveModal.tsx
@@ -1,5 +1,5 @@
 import React, { ReactNode, useCallback } from 'react';
-import { Platform, ScrollView, View } from 'react-native';
+import { KeyboardAvoidingView, Platform, ScrollView, View } from 'react-native';
 import Animated, {
   Easing,
   FadeInLeft,
@@ -215,40 +215,46 @@ const ResponsiveModal = ({
                 className="relative"
                 style={useNativeFlexLayout ? { flex: 1, minHeight: 0 } : undefined}
               >
-                <ScrollView
-                  className="web:max-h-[80vh]"
-                  contentContainerClassName="pb-4 md:pb-8"
-                  contentContainerStyle={useFixedHeightLayout ? { flexGrow: 1 } : undefined}
-                  style={useFixedHeightLayout ? { flex: 1 } : undefined}
-                  showsVerticalScrollIndicator={false}
-                  keyboardShouldPersistTaps="handled"
-                  nestedScrollEnabled
-                  onLayout={e => {
-                    containerHeightRef.current = e.nativeEvent.layout.height;
-                    setShowBottomFade(contentHeightRef.current > containerHeightRef.current + 4);
-                  }}
-                  onContentSizeChange={(_, h) => {
-                    contentHeightRef.current = h;
-                    if (containerHeightRef.current > 0) {
-                      setShowBottomFade(h > containerHeightRef.current + 4);
-                    }
-                  }}
-                  onScroll={e => {
-                    const { contentOffset, contentSize, layoutMeasurement } = e.nativeEvent;
-                    const atBottom =
-                      contentOffset.y + layoutMeasurement.height >= contentSize.height - 8;
-                    setShowBottomFade(!atBottom);
-                  }}
-                  scrollEventThrottle={16}
+                <KeyboardAvoidingView
+                  behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+                  enabled={Platform.OS !== 'web'}
+                  style={useNativeFlexLayout ? { flex: 1, minHeight: 0 } : undefined}
                 >
-                  <Animated.View
-                    entering={contentEntering}
-                    exiting={contentExiting}
-                    key={contentKey}
+                  <ScrollView
+                    className="web:max-h-[80vh]"
+                    contentContainerClassName="pb-4 md:pb-8"
+                    contentContainerStyle={useFixedHeightLayout ? { flexGrow: 1 } : undefined}
+                    style={useFixedHeightLayout ? { flex: 1 } : undefined}
+                    showsVerticalScrollIndicator={false}
+                    keyboardShouldPersistTaps="handled"
+                    nestedScrollEnabled
+                    onLayout={e => {
+                      containerHeightRef.current = e.nativeEvent.layout.height;
+                      setShowBottomFade(contentHeightRef.current > containerHeightRef.current + 4);
+                    }}
+                    onContentSizeChange={(_, h) => {
+                      contentHeightRef.current = h;
+                      if (containerHeightRef.current > 0) {
+                        setShowBottomFade(h > containerHeightRef.current + 4);
+                      }
+                    }}
+                    onScroll={e => {
+                      const { contentOffset, contentSize, layoutMeasurement } = e.nativeEvent;
+                      const atBottom =
+                        contentOffset.y + layoutMeasurement.height >= contentSize.height - 8;
+                      setShowBottomFade(!atBottom);
+                    }}
+                    scrollEventThrottle={16}
                   >
-                    {children}
-                  </Animated.View>
-                </ScrollView>
+                    <Animated.View
+                      entering={contentEntering}
+                      exiting={contentExiting}
+                      key={contentKey}
+                    >
+                      {children}
+                    </Animated.View>
+                  </ScrollView>
+                </KeyboardAvoidingView>
                 {showBottomFade && (
                   <View
                     pointerEvents="none"


### PR DESCRIPTION
## Summary
Added `KeyboardAvoidingView` wrapper around the `ScrollView` in `ResponsiveModal` to improve keyboard handling on mobile platforms, preventing the keyboard from covering modal content.

## Key Changes
- Imported `KeyboardAvoidingView` from `react-native`
- Wrapped the existing `ScrollView` component with `KeyboardAvoidingView`
- Configured `KeyboardAvoidingView` to use `padding` behavior on iOS and `height` behavior on Android
- Disabled the keyboard avoiding behavior on web platform where it's not needed

## Implementation Details
- The `KeyboardAvoidingView` is only enabled on native platforms (`Platform.OS !== 'web'`)
- Uses platform-specific behavior: `padding` for iOS (adjusts spacing) and `height` for Android (adjusts view height)
- Maintains the existing flex layout styling by passing `useNativeFlexLayout` styles to the `KeyboardAvoidingView`
- All existing `ScrollView` functionality and event handlers remain unchanged

https://claude.ai/code/session_01MGVdxsdT6kXH5nPgJJFLJo