### PR TITLE
Refactor passkey auth flow to decouple user selection from authentication

### DIFF
--- a/app/welcome.tsx
+++ b/app/welcome.tsx
@@ -1,9 +1,10 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import { View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import Toast from 'react-native-toast-message';
 import { Image } from 'expo-image';
 import { useLocalSearchParams, useRouter } from 'expo-router';
+import { useTurnkey } from '@turnkey/react-native-wallet-kit';
 import { useShallow } from 'zustand/react/shallow';
 
 import LoginKeyIcon from '@/assets/images/login_key_icon';
@@ -19,17 +20,24 @@ import { useUserStore } from '@/store/useUserStore';
 
 export default function Welcome() {
   const { handleRemoveUsers, handleSelectUserById } = useUser();
-  const { users, _hasHydrated } = useUserStore(
-    useShallow(state => ({
-      users: state.users,
-      _hasHydrated: state._hasHydrated,
-    })),
-  );
+  const { users, _hasHydrated, pendingAuthUserId, selectUserById, unselectUser, setPendingAuthUserId } =
+    useUserStore(
+      useShallow(state => ({
+        users: state.users,
+        _hasHydrated: state._hasHydrated,
+        pendingAuthUserId: state.pendingAuthUserId,
+        selectUserById: state.selectUserById,
+        unselectUser: state.unselectUser,
+        setPendingAuthUserId: state.setPendingAuthUserId,
+      })),
+    );
+  const { httpClient } = useTurnkey();
   const router = useRouter();
   const { isDesktop } = useDimension();
-  const [loadingUserId, setLoadingUserId] = useState<string | null>(null);
   const { session } = useLocalSearchParams<{ session: string }>();
   const passkeyUsers = users.filter(user => user.hasPasskey !== false);
+  const selectedUserId = users.find(u => u.selected)?.userId;
+  const isAuthInFlight = useRef(false);
 
   // Redirect to onboarding if no users exist (e.g., after session expired with empty user list)
   useEffect(() => {
@@ -51,13 +59,26 @@ export default function Welcome() {
     }
   }, [session]);
 
-  const handleSelectUser = useCallback(
-    async (userId: string) => {
-      setLoadingUserId(userId);
-      try {
-        await handleSelectUserById(userId);
-      } catch (error: any) {
-        // Show error toast if passkey authentication fails
+  // After a user is clicked, the store's selected user changes which causes
+  // TurnkeyProvider to re-mount with that user's credentialId in
+  // `passkeyConfig.allowCredentials`. This effect waits for the new
+  // httpClient to be ready and only then triggers the passkey prompt — so the
+  // authenticator sees the filtered credential list and only the selected
+  // user's passkey is offered.
+  useEffect(() => {
+    if (!pendingAuthUserId) return;
+    if (!httpClient) return;
+    if (selectedUserId !== pendingAuthUserId) return;
+    if (isAuthInFlight.current) return;
+
+    const userId = pendingAuthUserId;
+    isAuthInFlight.current = true;
+
+    handleSelectUserById(userId)
+      .catch((error: any) => {
+        // Revert the pre-selection so the welcome screen reflects the
+        // un-authenticated state and TurnkeyProvider drops the filter.
+        unselectUser();
         Toast.show({
           type: 'error',
           text1: 'Authentication failed',
@@ -66,11 +87,34 @@ export default function Welcome() {
             badgeText: '',
           },
         });
-      } finally {
-        setLoadingUserId(null);
-      }
+      })
+      .finally(() => {
+        // Keep `pendingAuthUserId` set while auth is in flight so every
+        // button stays disabled, then clear it once we settle.
+        setPendingAuthUserId(null);
+        isAuthInFlight.current = false;
+      });
+  }, [
+    pendingAuthUserId,
+    httpClient,
+    selectedUserId,
+    handleSelectUserById,
+    unselectUser,
+    setPendingAuthUserId,
+  ]);
+
+  const handleSelectUser = useCallback(
+    (userId: string) => {
+      if (pendingAuthUserId || isAuthInFlight.current) return;
+
+      // Marking the user as selected flips TurnkeyProvider's credentialId and
+      // triggers a re-mount of TurnkeyProviderKit with
+      // `allowCredentials: [{ id: user.credentialId, ... }]`. The effect above
+      // picks up once the remount finishes and fires the passkey prompt.
+      selectUserById(userId);
+      setPendingAuthUserId(userId);
     },
-    [handleSelectUserById],
+    [pendingAuthUserId, selectUserById, setPendingAuthUserId],
   );
 
   const handleUseAnotherAccount = useCallback(() => {
@@ -101,7 +145,7 @@ export default function Welcome() {
               variant="brand"
               className="h-14 justify-between rounded-xl border-0 px-6"
               onPress={() => handleSelectUser(user.userId)}
-              disabled={loadingUserId !== null}
+              disabled={pendingAuthUserId !== null}
             >
               <View className="flex-row items-center gap-2">
                 <Text className="text-base font-bold">

--- a/hooks/useUser.ts
+++ b/hooks/useUser.ts
@@ -463,10 +463,17 @@ const useUser = (): UseUserReturn => {
     }
   }, [clearBalance, users, unselectUser, updateUser, clearKycLinkId, router, user, intercom]);
 
-  // New: select user by userId (preferred for email-first users)
+  // Authenticate the user identified by `userId` via passkey.
+  //
+  // Callers (the welcome page) must pre-select the user in the store before
+  // invoking this — TurnkeyProvider reads the selected user's credentialId
+  // and uses it as the passkey stamper's `allowCredentials`, so the user must
+  // already be selected by the time the SDK builds its client.
+  //
+  // Errors (including auth failures) are re-thrown so the caller can revert
+  // the pre-selection and surface the failure in the UI.
   const handleSelectUserById = useCallback(
     async (userId: string) => {
-      const previousUserId = user?.userId;
       clearKycLinkId();
 
       // Find the selected user
@@ -492,51 +499,40 @@ const useUser = (): UseUserReturn => {
         return;
       }
 
-      // Always require passkey authentication on all platforms
-      try {
-        if (!httpClient) {
-          throw new Error('Turnkey client is not initialized. Please wait and try again.');
-        }
+      if (!httpClient) {
+        throw new Error('Turnkey client is not initialized. Please wait and try again.');
+      }
 
-        const result = await httpClient.stampGetWhoami(
-          { organizationId: EXPO_PUBLIC_TURNKEY_ORGANIZATION_ID },
-          StamperType.Passkey,
-        );
+      const result = await httpClient.stampGetWhoami(
+        { organizationId: EXPO_PUBLIC_TURNKEY_ORGANIZATION_ID },
+        StamperType.Passkey,
+      );
 
-        const authedUser = await login(result);
+      const authedUser = await login(result);
 
-        // Update the stored user with fresh tokens and select them
-        if (selectedUser && authedUser) {
-          storeUser({
-            ...selectedUser,
-            selected: true,
-            tokens: authedUser.tokens || undefined,
-          });
-        } else {
-          selectUserById(authedUser?._id ?? userId);
-        }
+      // Update the stored user with fresh tokens and keep them selected
+      if (selectedUser && authedUser) {
+        storeUser({
+          ...selectedUser,
+          selected: true,
+          tokens: authedUser.tokens || undefined,
+        });
+      } else {
+        selectUserById(authedUser?._id ?? userId);
+      }
 
-        // Reset logout flag so future session expiries show the toast
-        setIsLoggingOut(false);
+      // Reset logout flag so future session expiries show the toast
+      setIsLoggingOut(false);
 
-        const { redirectFrom, setRedirectFrom } = useUserStore.getState();
-        if (redirectFrom) {
-          setRedirectFrom(null);
-          router.replace(redirectFrom as any);
-        } else {
-          router.replace(path.HOME);
-        }
-      } catch (_) {
-        // Revert to previous user or clear selection on auth failure
-        if (previousUserId) {
-          selectUserById(previousUserId);
-        } else {
-          unselectUser();
-        }
-        // Don't navigate on error - stay on welcome screen
+      const { redirectFrom, setRedirectFrom } = useUserStore.getState();
+      if (redirectFrom) {
+        setRedirectFrom(null);
+        router.replace(redirectFrom as any);
+      } else {
+        router.replace(path.HOME);
       }
     },
-    [selectUserById, storeUser, clearKycLinkId, router, user, unselectUser, users, httpClient],
+    [selectUserById, storeUser, clearKycLinkId, router, users, httpClient],
   );
 
   const handleRemoveUsers = useCallback(() => {

--- a/store/useUserStore.ts
+++ b/store/useUserStore.ts
@@ -13,6 +13,12 @@ interface UserState {
   signupUser: SignupUser;
   safeAddressSynced: Record<string, boolean>;
   redirectFrom: string | null;
+  /**
+   * userId awaiting passkey authentication after the welcome-page user
+   * selection. Scoped to a single session — survives the TurnkeyProvider
+   * re-mount triggered by credentialId changes but is not persisted.
+   */
+  pendingAuthUserId: string | null;
   _hasHydrated: boolean;
   storeUser: (user: User) => void;
   updateUser: (user: User) => void;
@@ -24,15 +30,16 @@ interface UserState {
   setSignupUser: (user: SignupUser) => void;
   markSafeAddressSynced: (userId: string) => void;
   setRedirectFrom: (path: string | null) => void;
+  setPendingAuthUserId: (userId: string | null) => void;
   setHasHydrated: (state: boolean) => void;
 }
 
 // Selectors - pure functions for deriving state
 // These can be used with useUserStore(selector) for optimal re-render behavior
 
-/** Get the currently selected user, or the only user if there's just one */
+/** Get the currently selected user */
 export const selectSelectedUser = ({ users }: UserState): User | undefined =>
-  users.find(u => u.selected) ?? (users.length === 1 ? users[0] : undefined);
+  users.find(u => u.selected);
 
 /** Get the credentialId of the selected user (for passkey filtering) */
 export const selectSelectedCredentialId = (state: UserState): string | undefined => {
@@ -48,6 +55,7 @@ export const useUserStore = create<UserState>()(
       signupUser: { username: '' },
       safeAddressSynced: {},
       redirectFrom: null,
+      pendingAuthUserId: null,
       _hasHydrated: false,
       setHasHydrated: (state: boolean) => set({ _hasHydrated: state }),
 
@@ -124,6 +132,8 @@ export const useUserStore = create<UserState>()(
         ),
 
       setRedirectFrom: (path: string | null) => set({ redirectFrom: path }),
+
+      setPendingAuthUserId: (userId: string | null) => set({ pendingAuthUserId: userId }),
     }),
     {
       name: USER.storageKey,
@@ -132,7 +142,7 @@ export const useUserStore = create<UserState>()(
         state?.setHasHydrated(true);
       },
       partialize: state => {
-        const { redirectFrom, ...rest } = state;
+        const { redirectFrom, pendingAuthUserId, ...rest } = state;
         return rest;
       },
     },

--- a/store/useUserStore.ts
+++ b/store/useUserStore.ts
@@ -32,7 +32,7 @@ interface UserState {
 
 /** Get the currently selected user, or the only user if there's just one */
 export const selectSelectedUser = ({ users }: UserState): User | undefined =>
-  users.find(u => u.selected);
+  users.find(u => u.selected) ?? (users.length === 1 ? users[0] : undefined);
 
 /** Get the credentialId of the selected user (for passkey filtering) */
 export const selectSelectedCredentialId = (state: UserState): string | undefined => {


### PR DESCRIPTION
## Summary
This PR refactors the passkey authentication flow in the welcome screen to separate user selection from the actual authentication process. Previously, authentication was triggered immediately upon user selection. Now, the flow is split into two phases: first the user is marked as selected (which triggers a TurnkeyProvider re-mount with the correct credential filter), then authentication is triggered once the provider is ready with the new httpClient.

## Key Changes

- **Welcome screen (`app/welcome.tsx`)**:
  - Replaced local `loadingUserId` state with store-managed `pendingAuthUserId` to track authentication in-flight status
  - Moved authentication logic into a separate effect that waits for TurnkeyProvider to re-mount with the selected user's credentialId before triggering the passkey prompt
  - Split `handleSelectUser` into two phases: immediate user selection via `selectUserById()`, then deferred authentication via the effect
  - Added `isAuthInFlight` ref to prevent concurrent authentication attempts
  - Removed `useState` import, added `useRef` and `useTurnkey` imports

- **User hook (`hooks/useUser.ts`)**:
  - Simplified `handleSelectUserById` to focus solely on authentication logic
  - Removed error handling that reverted user selection (now handled by the welcome screen)
  - Removed `previousUserId` tracking since pre-selection is now the caller's responsibility
  - Updated JSDoc to clarify that callers must pre-select the user before invoking this function
  - Errors are now re-thrown so the welcome screen can handle UI state reversion

- **User store (`store/useUserStore.ts`)**:
  - Added `pendingAuthUserId` state field to track which user is awaiting authentication
  - Added `setPendingAuthUserId` action to update this field
  - Excluded `pendingAuthUserId` from persistence (session-scoped only)
  - Updated `selectSelectedUser` JSDoc to clarify it returns the currently selected user

## Implementation Details

The refactored flow ensures that:
1. When a user clicks a login button, `handleSelectUser` immediately calls `selectUserById()` and `setPendingAuthUserId()`
2. This selection change causes TurnkeyProvider to re-mount with the new user's credentialId in `allowCredentials`
3. The effect monitors `pendingAuthUserId`, `httpClient`, and `selectedUserId` and triggers authentication only when all three conditions align
4. If authentication fails, the welcome screen reverts the selection via `unselectUser()` and clears `pendingAuthUserId`
5. All buttons remain disabled while `pendingAuthUserId` is set, preventing concurrent auth attempts

https://claude.ai/code/session_017pCtNrFfjv1ge1t1LiVBSA