### PR TITLE
Add info toast type with blue styling

### DIFF
--- a/components/Toast.tsx
+++ b/components/Toast.tsx
@@ -97,7 +97,7 @@ const toastConfig = {
     <BaseToast
       text1={text1}
       text2={text2}
-      props={props}
+      props={{ badgeText: '', ...props }}
       classNames={{
         badge: 'border-blue-400',
         badgeText: 'text-blue-400',

--- a/components/Toast.tsx
+++ b/components/Toast.tsx
@@ -93,6 +93,17 @@ const toastConfig = {
       }}
     />
   ),
+  info: ({ text1, text2, props }: IBaseToast) => (
+    <BaseToast
+      text1={text1}
+      text2={text2}
+      props={props}
+      classNames={{
+        badge: 'border-blue-400',
+        badgeText: 'text-blue-400',
+      }}
+    />
+  ),
 };
 
 export const toastProps: ToastProps = {


### PR DESCRIPTION
## Summary
Added a new `info` toast type to the toast configuration with blue-themed styling to complement the existing toast variants.

## Changes
- Added `info` toast type to `toastConfig` object in `components/Toast.tsx`
- Configured with blue color scheme using `border-blue-400` and `text-blue-400` classes for badge styling
- Follows the same pattern as existing toast types (success, error, etc.)

## Implementation Details
The new info toast type uses the `BaseToast` component with custom classNames for the badge and badgeText, maintaining consistency with the existing toast configuration structure. This allows users to display informational messages with a distinct blue visual style.

https://claude.ai/code/session_018ucueVTmQT5vkRPtBwYZA3