### PR TITLE
style(toast): style info toast to match success/error (master)

### DIFF
--- a/components/Toast.tsx
+++ b/components/Toast.tsx
@@ -93,6 +93,17 @@ const toastConfig = {
       }}
     />
   ),
+  info: ({ text1, text2, props }: IBaseToast) => (
+    <BaseToast
+      text1={text1}
+      text2={text2}
+      props={{ badgeText: '', ...props }}
+      classNames={{
+        badge: 'border-blue-400',
+        badgeText: 'text-blue-400',
+      }}
+    />
+  ),
 };
 
 export const toastProps: ToastProps = {


### PR DESCRIPTION
## Summary
- Cherry-picks #1981 from `qa` onto `master`.
- Adds an `info` variant to `toastConfig` using the same `BaseToast` layout as `success`/`error`, styled with a `blue-400` badge.
- Defaults `badgeText` to `''` for info toasts so the `Onchain` placeholder no longer appears (e.g. on the `/card/pending` flow). Callers can still override.

## Test plan
- [ ] Trigger an info toast (e.g. KYC `Verification submitted` → redirect to `/card/pending`) and confirm it matches the success/error card layout with no badge shown.
- [ ] Verify success and error toasts are unchanged and still show their default `Onchain` badge when `badgeText` isn't passed.

https://claude.ai/code/session_018ucueVTmQT5vkRPtBwYZA3