### PR TITLE
Add declined and reversed transaction status handling

### DIFF
--- a/app/(protected)/(tabs)/activity/[clientTxId].tsx
+++ b/app/(protected)/(tabs)/activity/[clientTxId].tsx
@@ -192,6 +192,8 @@ const CardTransactionDetail = memo(function CardTransactionDetail({
 
   const txHash = transaction.crypto_transaction_details?.tx_hash;
   const isApproved = transaction.status === 'approved';
+  const isDeclined = transaction.status === 'declined';
+  const isReversed = transaction.status === 'reversed';
   const postedDate = useMemo(() => {
     const dateStr = isApproved
       ? transaction.authorized_at || transaction.posted_at
@@ -214,18 +216,37 @@ const CardTransactionDetail = memo(function CardTransactionDetail({
 
   const cashbackInfo = getCashbackAmount(transaction.id, cashbacks);
 
+  const statusLabel = isApproved
+    ? 'Pending'
+    : isDeclined
+      ? 'Declined'
+      : isReversed
+        ? 'Reversed'
+        : 'Confirmed';
+  const statusColor = isApproved
+    ? 'text-yellow-500'
+    : isDeclined
+      ? 'text-red-400'
+      : '';
+
   const rows = useMemo(() => {
     const allRows = [
       { key: 'from', label: <Label>Sent from</Label>, value: <Value>Card</Value> },
       {
         key: 'status',
         label: <Label>Status</Label>,
-        value: (
-          <Value className={isApproved ? 'text-yellow-500' : ''}>
-            {isApproved ? 'Pending' : 'Confirmed'}
-          </Value>
-        ),
+        value: <Value className={statusColor}>{statusLabel}</Value>,
       },
+      isDeclined &&
+        transaction.declined_reason && {
+          key: 'reason',
+          label: <Label>Reason</Label>,
+          value: (
+            <Value className="max-w-[60%] text-right text-base">
+              {toTitleCase(transaction.declined_reason)}
+            </Value>
+          ),
+        },
       cashbackInfo && {
         key: 'cashback',
         label: (
@@ -273,7 +294,15 @@ const CardTransactionDetail = memo(function CardTransactionDetail({
     ].filter(Boolean) as { key: string; label: React.ReactNode; value: React.ReactNode }[];
 
     return allRows;
-  }, [cashbackInfo, txHash, handleExplorerPress, isApproved]);
+  }, [
+    cashbackInfo,
+    txHash,
+    handleExplorerPress,
+    statusLabel,
+    statusColor,
+    isDeclined,
+    transaction.declined_reason,
+  ]);
 
   const tokenIcon = useMemo(
     () => getTokenIcon({ tokenSymbol: transaction.currency?.toUpperCase(), size: 75 }),

--- a/components/Activity/CardTransactions.tsx
+++ b/components/Activity/CardTransactions.tsx
@@ -161,6 +161,7 @@ export default function CardTransactions() {
         .join(' ') || undefined;
       const initials = getInitials(merchantName);
       const isPurchase = transaction.category === CardTransactionCategory.PURCHASE;
+      const isDeclined = transaction.status === 'declined';
       const color = getColorForTransaction(merchantName);
       const cashbackInfo = getCashbackAmount(transaction.id, cashbacks);
 
@@ -218,7 +219,12 @@ export default function CardTransactions() {
             </View>
           </View>
           <View className="items-end">
-            <Text className="text-xl font-semibold text-white">
+            <Text
+              className={cn(
+                'text-xl font-semibold',
+                isDeclined ? 'text-red-400' : 'text-white',
+              )}
+            >
               {formatCardAmount(transaction.amount, provider)}
             </Text>
             {cashbackInfo && cashbackInfo.amount !== 'Pending' && (

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1255,6 +1255,7 @@ export interface CardTransaction {
   merchant_city?: string;
   merchant_country?: string;
   local_transaction_details?: LocalTransactionDetails;
+  declined_reason?: string;
 }
 
 export interface CardTransactionsResponse {


### PR DESCRIPTION
## Summary
Enhanced transaction detail view to properly handle and display declined and reversed transaction statuses, including showing decline reasons when available.

## Key Changes
- Added support for `declined` and `reversed` transaction statuses in addition to the existing `approved` status
- Implemented dynamic status label and color logic that displays:
  - "Pending" (yellow) for approved transactions
  - "Declined" (red) for declined transactions
  - "Reversed" for reversed transactions
  - "Confirmed" as default for other statuses
- Added conditional rendering of decline reason row when transaction is declined and reason is available
- Extended `CardTransaction` type with optional `declined_reason` field
- Updated useMemo dependency array to include new status-related variables and declined reason

## Implementation Details
- Status determination is now centralized in `statusLabel` and `statusColor` variables using ternary operators
- Decline reason row uses `toTitleCase` utility for consistent formatting
- Decline reason row is conditionally included in the rows array using the filter(Boolean) pattern
- All new dependencies properly added to the useMemo hook to prevent stale closures

https://claude.ai/code/session_01SVqSbAsNGSA1qvMczThNGv