### PR TITLE
feat(data-source): use Alchemy as primary on-chain data source

### DIFF
--- a/constants/alchemy.ts
+++ b/constants/alchemy.ts
@@ -1,0 +1,27 @@
+import { arbitrum, base, mainnet, polygon } from 'viem/chains';
+
+import { EXPO_PUBLIC_ALCHEMY_API_KEY } from '@/lib/config';
+
+/**
+ * Alchemy is the primary on-chain data provider for these chains;
+ * Blockscout is used as fallback on Alchemy failure. Fuse (122) is not
+ * supported by Alchemy and always uses Blockscout.
+ */
+export const ALCHEMY_SUPPORTED_CHAIN_IDS: ReadonlySet<number> = new Set([
+  mainnet.id,
+  base.id,
+  polygon.id,
+  arbitrum.id,
+]);
+
+export const ALCHEMY_CHAIN_URLS: Record<number, string> = {
+  [mainnet.id]: `https://eth-mainnet.g.alchemy.com/v2/${EXPO_PUBLIC_ALCHEMY_API_KEY}`,
+  [base.id]: `https://base-mainnet.g.alchemy.com/v2/${EXPO_PUBLIC_ALCHEMY_API_KEY}`,
+  [polygon.id]: `https://polygon-mainnet.g.alchemy.com/v2/${EXPO_PUBLIC_ALCHEMY_API_KEY}`,
+  [arbitrum.id]: `https://arb-mainnet.g.alchemy.com/v2/${EXPO_PUBLIC_ALCHEMY_API_KEY}`,
+};
+
+export const isAlchemyChain = (chainId: number): boolean =>
+  ALCHEMY_SUPPORTED_CHAIN_IDS.has(chainId) && !!ALCHEMY_CHAIN_URLS[chainId];
+
+export const ALCHEMY_REQUEST_TIMEOUT_MS = 10_000;

--- a/hooks/useAnalytics.ts
+++ b/hooks/useAnalytics.ts
@@ -178,11 +178,13 @@ export const useSendTransactions = (address: string) => {
     queryFn: async () => {
       const fuseTransfers = await fetchTokenTransfer({
         address,
+        chainId: fuse.id,
         filter: 'from',
       });
 
       const ethereumTransfers = await fetchTokenTransfer({
         address,
+        chainId: mainnet.id,
         filter: 'from',
         explorerUrl: explorerUrls[mainnet.id].blockscout,
       });

--- a/hooks/useBalances.ts
+++ b/hooks/useBalances.ts
@@ -6,6 +6,7 @@ import { base, fuse, mainnet } from 'viem/chains';
 import { NATIVE_COINGECKO_TOKENS, NATIVE_TOKENS } from '@/constants/tokens';
 import { fetchCoinSimplePrice, fetchTokenList, fetchTokenPriceUsd } from '@/lib/api';
 import { ADDRESSES } from '@/lib/config';
+import { fetchTokenBalancesWithFallback } from '@/lib/data-source';
 import { PromiseStatus, SwapTokenResponse, TokenBalance, TokenType } from '@/lib/types';
 import { isSoFUSEToken, isSoUSDToken, isWalletCardExcludedToken } from '@/lib/utils';
 import { publicClient } from '@/lib/wagmi';
@@ -13,7 +14,7 @@ import { publicClient } from '@/lib/wagmi';
 import useUser from './useUser';
 
 // Blockscout response structure for both Ethereum and Fuse
-interface BlockscoutTokenBalance {
+export interface BlockscoutTokenBalance {
   token: {
     address: string;
     address_hash: string;
@@ -34,8 +35,6 @@ interface BlockscoutTokenBalance {
   token_instance: null;
   value: string;
 }
-
-type BlockscoutResponse = BlockscoutTokenBalance[];
 
 type CalculatedTokenValue = {
   soUSDValue: number;
@@ -117,21 +116,13 @@ const fetchTokenBalances = async (safeAddress: string) => {
     basePrice,
     tokenList,
   ] = await Promise.allSettled([
-    fetch(`https://base.blockscout.com/api/v2/addresses/${safeAddress}/token-balances`, {
-      headers: { accept: 'application/json' },
-    }),
-    fetch(`https://eth.blockscout.com/api/v2/addresses/${safeAddress}/token-balances`, {
-      headers: { accept: 'application/json' },
-    }),
-    fetch(`https://explorer.fuse.io/api/v2/addresses/${safeAddress}/token-balances`, {
-      headers: { accept: 'application/json' },
-    }),
-    fetch(`https://polygon.blockscout.com/api/v2/addresses/${safeAddress}/token-balances`, {
-      headers: { accept: 'application/json' },
-    }),
-    fetch(`https://arbitrum.blockscout.com/api/v2/addresses/${safeAddress}/token-balances`, {
-      headers: { accept: 'application/json' },
-    }),
+    // Token balances via the data-source dispatcher (Alchemy primary,
+    // Blockscout fallback). Fuse (122) skips Alchemy entirely.
+    fetchTokenBalancesWithFallback(BASE_CHAIN_ID, safeAddress),
+    fetchTokenBalancesWithFallback(ETHEREUM_CHAIN_ID, safeAddress),
+    fetchTokenBalancesWithFallback(FUSE_CHAIN_ID, safeAddress),
+    fetchTokenBalancesWithFallback(POLYGON_CHAIN_ID, safeAddress),
+    fetchTokenBalancesWithFallback(ARBITRUM_CHAIN_ID, safeAddress),
     readContract(publicClient(mainnet.id), {
       address: ADDRESSES.ethereum.accountant,
       abi: ACCOUNTANT_ABI,
@@ -235,77 +226,68 @@ const fetchTokenBalances = async (safeAddress: string) => {
     );
   };
 
-  // Process Ethereum response (Blockscout)
-  if (ethereumResponse.status === PromiseStatus.FULFILLED && ethereumResponse.value.ok) {
-    const ethereumData: BlockscoutResponse = await ethereumResponse.value.json();
-    // Filter out NFTs and only include ERC-20 tokens
-    ethereumTokens = ethereumData
+  // Process Ethereum tokens
+  if (ethereumResponse.status === PromiseStatus.FULFILLED) {
+    ethereumTokens = ethereumResponse.value
       .filter(
         item =>
           item.token.type === TokenType.ERC20 &&
           filterTokenList(tokenListData, ETHEREUM_CHAIN_ID, getAddress(item)),
       )
       .map(item => convertBlockscoutToTokenBalance(item, ETHEREUM_CHAIN_ID));
-  } else if (ethereumResponse.status === PromiseStatus.REJECTED) {
+  } else {
     console.warn('Failed to fetch Ethereum balances:', ethereumResponse.reason);
   }
 
-  // Process Base response (Blockscout)
-  if (baseResponse.status === PromiseStatus.FULFILLED && baseResponse.value.ok) {
-    const baseData: BlockscoutResponse = await baseResponse.value.json();
-    // Filter out NFTs and only include ERC-20 tokens
-    baseTokens = baseData
+  // Process Base tokens
+  if (baseResponse.status === PromiseStatus.FULFILLED) {
+    baseTokens = baseResponse.value
       .filter(
         item =>
           item.token.type === TokenType.ERC20 &&
           filterTokenList(tokenListData, BASE_CHAIN_ID, getAddress(item)),
       )
       .map(item => convertBlockscoutToTokenBalance(item, BASE_CHAIN_ID));
-  } else if (baseResponse.status === PromiseStatus.REJECTED) {
+  } else {
     console.warn('Failed to fetch Base balances:', baseResponse.reason);
   }
 
-  // Process Fuse response (Blockscout)
-  if (fuseResponse.status === PromiseStatus.FULFILLED && fuseResponse.value.ok) {
-    const fuseData: BlockscoutResponse = await fuseResponse.value.json();
-    // Filter out NFTs and only include ERC-20 tokens
-    fuseTokens = fuseData
+  // Process Fuse tokens (always Blockscout)
+  if (fuseResponse.status === PromiseStatus.FULFILLED) {
+    fuseTokens = fuseResponse.value
       .filter(
         item =>
           item.token.type === TokenType.ERC20 &&
           filterTokenList(tokenListData, FUSE_CHAIN_ID, getAddress(item)),
       )
       .map(item => convertBlockscoutToTokenBalance(item, FUSE_CHAIN_ID));
-  } else if (fuseResponse.status === PromiseStatus.REJECTED) {
+  } else {
     console.warn('Failed to fetch Fuse balances:', fuseResponse.reason);
   }
 
-  // Process Polygon response (Blockscout)
-  if (polygonResponse.status === PromiseStatus.FULFILLED && polygonResponse.value.ok) {
-    const polygonData: BlockscoutResponse = await polygonResponse.value.json();
-    polygonTokens = polygonData
+  // Process Polygon tokens
+  if (polygonResponse.status === PromiseStatus.FULFILLED) {
+    polygonTokens = polygonResponse.value
       .filter(
         item =>
           item.token.type === TokenType.ERC20 &&
           filterTokenList(tokenListData, POLYGON_CHAIN_ID, getAddress(item)),
       )
       .map(item => convertBlockscoutToTokenBalance(item, POLYGON_CHAIN_ID));
-  } else if (polygonResponse.status === PromiseStatus.REJECTED) {
+  } else {
     console.warn('Failed to fetch Polygon balances:', polygonResponse.reason);
   }
 
-  // Process Arbitrum response (Blockscout)
-  if (arbitrumResponse.status === PromiseStatus.FULFILLED && arbitrumResponse.value.ok) {
-    const arbitrumData: BlockscoutResponse = await arbitrumResponse.value.json();
-    // Filter out NFTs and only include ERC-20 tokens
-    arbitrumTokens = arbitrumData
+  // Process Arbitrum tokens
+  if (arbitrumResponse.status === PromiseStatus.FULFILLED) {
+    arbitrumTokens = arbitrumResponse.value
       .filter(
         item =>
           item.token.type === TokenType.ERC20 &&
           filterTokenList(tokenListData, ARBITRUM_CHAIN_ID, getAddress(item)),
       )
       .map(item => convertBlockscoutToTokenBalance(item, ARBITRUM_CHAIN_ID));
-  } else if (arbitrumResponse.status === PromiseStatus.REJECTED) {
+  } else {
     console.warn('Failed to fetch Arbitrum balances:', arbitrumResponse.reason);
   }
 
@@ -374,7 +356,13 @@ const fetchTokenBalances = async (safeAddress: string) => {
     });
   }
 
-  let allTokens = [...ethereumTokens, ...fuseTokens, ...polygonTokens, ...baseTokens, ...arbitrumTokens];
+  let allTokens = [
+    ...ethereumTokens,
+    ...fuseTokens,
+    ...polygonTokens,
+    ...baseTokens,
+    ...arbitrumTokens,
+  ];
 
   const isZeroRate = (r: number | null | undefined) =>
     r == null || r === 0 || (typeof r === 'number' && Number.isNaN(r));

--- a/lib/alchemy.ts
+++ b/lib/alchemy.ts
@@ -1,0 +1,281 @@
+import axios from 'axios';
+
+import { ALCHEMY_CHAIN_URLS, ALCHEMY_REQUEST_TIMEOUT_MS } from '@/constants/alchemy';
+import { BlockscoutTransaction, BlockscoutTransactions, TokenType } from '@/lib/types';
+
+import type { BlockscoutTokenBalance } from '@/hooks/useBalances';
+
+/**
+ * Thin Alchemy JSON-RPC client plus mappers that shape responses into the
+ * existing `BlockscoutTokenBalance` / `BlockscoutTransactions` types so
+ * consumers (useBalances, fetchTokenTransfer) don't need to change.
+ *
+ * Native balances are NOT fetched here — viem `getBalance` handles that.
+ */
+
+interface JsonRpcResponse<T> {
+  jsonrpc: string;
+  id: number | string;
+  result?: T;
+  error?: { code: number; message: string };
+}
+
+interface AlchemyTokenBalancesResult {
+  address: string;
+  tokenBalances: { contractAddress: string; tokenBalance: string | null }[];
+  pageKey?: string;
+}
+
+interface AlchemyTokenMetadata {
+  decimals: number | null;
+  logo: string | null;
+  name: string | null;
+  symbol: string | null;
+}
+
+export type AlchemyTransferCategory = 'external' | 'erc20' | 'erc721' | 'erc1155';
+
+interface AlchemyAssetTransfer {
+  blockNum: string;
+  uniqueId: string;
+  hash: string;
+  from: string;
+  to: string | null;
+  value: number | null;
+  asset: string | null;
+  category: AlchemyTransferCategory;
+  rawContract: {
+    value: string | null;
+    address: string | null;
+    decimal: string | null;
+  };
+  metadata: { blockTimestamp: string };
+}
+
+interface AlchemyAssetTransfersResult {
+  transfers: AlchemyAssetTransfer[];
+  pageKey?: string;
+}
+
+const jsonRpc = async <T>(chainId: number, method: string, params: unknown[]): Promise<T> => {
+  const url = ALCHEMY_CHAIN_URLS[chainId];
+  if (!url) throw new Error(`No Alchemy URL configured for chain ${chainId}`);
+  const response = await axios.post<JsonRpcResponse<T>>(
+    url,
+    { jsonrpc: '2.0', id: 1, method, params },
+    { timeout: ALCHEMY_REQUEST_TIMEOUT_MS },
+  );
+  if (response.data.error) {
+    throw new Error(
+      `Alchemy ${method} error ${response.data.error.code}: ${response.data.error.message}`,
+    );
+  }
+  if (response.data.result === undefined) {
+    throw new Error(`Alchemy ${method} returned no result`);
+  }
+  return response.data.result;
+};
+
+// Module-level cache for token metadata. Immutable per contract; no TTL
+// needed for a single app session on mobile.
+const metadataCache = new Map<string, AlchemyTokenMetadata>();
+const metadataCacheKey = (chainId: number, address: string) =>
+  `${chainId}:${address.toLowerCase()}`;
+
+/**
+ * Resolve metadata for a batch of contract addresses using a single JSON-RPC
+ * batch request. Results are populated into the shared metadata cache.
+ */
+const alchemyGetTokenMetadataBatch = async (
+  chainId: number,
+  addresses: string[],
+): Promise<void> => {
+  const url = ALCHEMY_CHAIN_URLS[chainId];
+  if (!url) return;
+
+  const toFetch = addresses.filter(addr => !metadataCache.has(metadataCacheKey(chainId, addr)));
+  if (toFetch.length === 0) return;
+
+  const body = toFetch.map((addr, idx) => ({
+    jsonrpc: '2.0',
+    id: idx,
+    method: 'alchemy_getTokenMetadata',
+    params: [addr],
+  }));
+
+  try {
+    const response = await axios.post<JsonRpcResponse<AlchemyTokenMetadata>[]>(url, body, {
+      timeout: ALCHEMY_REQUEST_TIMEOUT_MS,
+    });
+    const data = Array.isArray(response.data) ? response.data : [];
+    for (const entry of data) {
+      const idx = Number(entry.id);
+      if (Number.isFinite(idx) && toFetch[idx]) {
+        const meta = entry.result ?? {
+          decimals: null,
+          logo: null,
+          name: null,
+          symbol: null,
+        };
+        metadataCache.set(metadataCacheKey(chainId, toFetch[idx]), meta);
+      }
+    }
+  } catch {
+    // Populate cache with empty entries so we don't retry endlessly.
+    for (const addr of toFetch) {
+      metadataCache.set(metadataCacheKey(chainId, addr), {
+        decimals: null,
+        logo: null,
+        name: null,
+        symbol: null,
+      });
+    }
+  }
+};
+
+/**
+ * Fetch ERC-20 balances from Alchemy and map into the existing
+ * `BlockscoutTokenBalance` shape so `convertBlockscoutToTokenBalance` in
+ * useBalances can consume it without changes.
+ *
+ * Native balance (ETH, MATIC) is not included — handled via viem `getBalance`
+ * in useBalances as before.
+ */
+export const fetchAlchemyTokenBalances = async (
+  chainId: number,
+  address: string,
+): Promise<BlockscoutTokenBalance[]> => {
+  // Paginate via pageKey so wallets with >100 tokens aren't truncated.
+  const tokenBalances: { contractAddress: string; tokenBalance: string | null }[] = [];
+  let pageKey: string | undefined;
+  // Safety cap at 10 pages (≈1000 tokens) to bound worst case.
+  for (let i = 0; i < 10; i++) {
+    const params: unknown[] = [address, 'erc20'];
+    if (pageKey) params.push({ pageKey });
+    const page = await jsonRpc<AlchemyTokenBalancesResult>(
+      chainId,
+      'alchemy_getTokenBalances',
+      params,
+    );
+    tokenBalances.push(...(page.tokenBalances ?? []));
+    if (!page.pageKey) break;
+    pageKey = page.pageKey;
+  }
+
+  const nonZero = tokenBalances.filter(b => {
+    if (!b.tokenBalance) return false;
+    try {
+      return BigInt(b.tokenBalance) !== 0n;
+    } catch {
+      return false;
+    }
+  });
+
+  if (nonZero.length === 0) return [];
+
+  await alchemyGetTokenMetadataBatch(
+    chainId,
+    nonZero.map(b => b.contractAddress),
+  );
+
+  return nonZero.map(b => {
+    const meta = metadataCache.get(metadataCacheKey(chainId, b.contractAddress)) ?? {
+      decimals: null,
+      logo: null,
+      name: null,
+      symbol: null,
+    };
+    const decimalsNum = meta.decimals ?? 18;
+    const value = BigInt(b.tokenBalance ?? '0x0').toString();
+    return {
+      token: {
+        address: b.contractAddress,
+        address_hash: b.contractAddress,
+        decimals: String(decimalsNum),
+        name: meta.name ?? '',
+        symbol: meta.symbol ?? '',
+        type: TokenType.ERC20,
+        icon_url: meta.logo ?? undefined,
+        exchange_rate: undefined,
+      },
+      token_id: null,
+      token_instance: null,
+      value,
+    };
+  });
+};
+
+/**
+ * Fetch token transfers for an address from Alchemy and map into the existing
+ * `BlockscoutTransactions` shape.
+ */
+export const fetchAlchemyTokenTransfers = async ({
+  chainId,
+  address,
+  token,
+  filter = 'to',
+}: {
+  chainId: number;
+  address: string;
+  token?: string;
+  filter?: 'from' | 'to';
+}): Promise<BlockscoutTransactions> => {
+  const category: AlchemyTransferCategory[] = token ? ['erc20'] : ['erc20', 'external'];
+
+  const baseParams: Record<string, unknown> = {
+    category,
+    excludeZeroValue: true,
+    order: 'desc',
+    withMetadata: true,
+    maxCount: '0x64', // 100
+  };
+  if (filter === 'from') baseParams.fromAddress = address;
+  else baseParams.toAddress = address;
+  if (token) baseParams.contractAddresses = [token];
+
+  const result = await jsonRpc<AlchemyAssetTransfersResult>(chainId, 'alchemy_getAssetTransfers', [
+    baseParams,
+  ]);
+
+  // Resolve metadata for any ERC-20 contracts in the batch.
+  const erc20Addrs = Array.from(
+    new Set(
+      result.transfers
+        .filter(t => t.category === 'erc20')
+        .map(t => t.rawContract.address?.toLowerCase())
+        .filter((a): a is string => !!a),
+    ),
+  );
+  if (erc20Addrs.length) {
+    await alchemyGetTokenMetadataBatch(chainId, erc20Addrs);
+  }
+
+  const items: BlockscoutTransaction[] = result.transfers.map(t => {
+    const contractAddr = t.rawContract.address ?? '';
+    const meta = contractAddr
+      ? metadataCache.get(metadataCacheKey(chainId, contractAddr))
+      : undefined;
+    const decimals =
+      meta?.decimals ?? (t.rawContract.decimal ? parseInt(t.rawContract.decimal, 16) : 18);
+    return {
+      to: {
+        hash: (t.to ?? '') as `0x${string}`,
+        name: '',
+      },
+      token: {
+        address: (contractAddr || '0x0000000000000000000000000000000000000000') as `0x${string}`,
+        symbol: meta?.symbol ?? t.asset ?? '',
+        icon_url: meta?.logo ?? '',
+      },
+      total: {
+        decimals: String(decimals),
+        value: t.rawContract.value ? BigInt(t.rawContract.value).toString() : '0',
+      },
+      transaction_hash: t.hash,
+      timestamp: t.metadata.blockTimestamp,
+      type: t.category === 'external' ? 'coin_transfer' : 'token_transfer',
+    };
+  });
+
+  return { items };
+};

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -3,8 +3,8 @@ import * as Sentry from '@sentry/react-native';
 import axios, { AxiosRequestHeaders } from 'axios';
 import { fuse } from 'viem/chains';
 
-import { explorerUrls } from '@/constants/explorers';
 import { MOCK_REWARDS_USER_DATA, MOCK_TIER_BENEFITS } from '@/constants/rewards';
+import { fetchTokenTransferWithFallback } from '@/lib/data-source';
 import { BridgeApiTransfer } from '@/lib/types/bank-transfer';
 import { useUserStore } from '@/store/useUserStore';
 
@@ -25,7 +25,6 @@ import {
   AddressBookRequest,
   AddressBookResponse,
   APYsByAsset,
-  BlockscoutTransactions,
   BridgeCustomerEndorsement,
   BridgeCustomerResponse,
   BridgeDeposit,
@@ -340,28 +339,25 @@ export const fetchTotalAPY = async (): Promise<TotalAPYResponse> => {
 
 export const fetchTokenTransfer = async ({
   address,
+  chainId = fuse.id,
   token,
-  type = 'ERC-20',
   filter = 'to',
-  explorerUrl = explorerUrls[fuse.id].blockscout,
+  explorerUrl,
 }: {
   address: string;
+  chainId?: number;
   token?: string;
-  type?: string;
-  filter?: string;
+  filter?: 'from' | 'to';
+  /** Optional override for the Blockscout explorer URL (used on fallback). */
   explorerUrl?: string;
 }) => {
-  let url = `${explorerUrl}/api/v2/addresses/${address}/token-transfers`;
-  let params = [];
-
-  if (type) params.push(`type=${type}`);
-  if (filter) params.push(`filter=${filter}`);
-  if (token) params.push(`token=${token}`);
-
-  if (params.length) url += `?${params.join('&')}`;
-
-  const response = await axios.get<BlockscoutTransactions>(url);
-  return response.data;
+  return fetchTokenTransferWithFallback({
+    chainId,
+    address,
+    token,
+    filter,
+    blockscoutExplorerUrl: explorerUrl,
+  });
 };
 
 export const fetchTokenPriceUsd = async (token: string) => {

--- a/lib/data-source.ts
+++ b/lib/data-source.ts
@@ -1,0 +1,119 @@
+import axios from 'axios';
+import { arbitrum, base, fuse, mainnet, polygon } from 'viem/chains';
+
+import { isAlchemyChain } from '@/constants/alchemy';
+import { explorerUrls } from '@/constants/explorers';
+import { fetchAlchemyTokenBalances, fetchAlchemyTokenTransfers } from '@/lib/alchemy';
+import { BlockscoutTransactions } from '@/lib/types';
+
+import type { BlockscoutTokenBalance } from '@/hooks/useBalances';
+
+/**
+ * Dispatcher: tries Alchemy first, falls back to Blockscout on failure.
+ * Fuse (122) is always Blockscout (not supported by Alchemy).
+ */
+
+const BLOCKSCOUT_URLS: Record<number, string> = {
+  [mainnet.id]: 'https://eth.blockscout.com',
+  [base.id]: 'https://base.blockscout.com',
+  [polygon.id]: 'https://polygon.blockscout.com',
+  [arbitrum.id]: 'https://arbitrum.blockscout.com',
+  [fuse.id]: explorerUrls[fuse.id]?.blockscout ?? 'https://explorer.fuse.io',
+};
+
+const blockscoutUrlForChain = (chainId: number): string | undefined => BLOCKSCOUT_URLS[chainId];
+
+const fetchBlockscoutTokenBalances = async (
+  chainId: number,
+  address: string,
+): Promise<BlockscoutTokenBalance[]> => {
+  const url = blockscoutUrlForChain(chainId);
+  if (!url) return [];
+  const response = await fetch(`${url}/api/v2/addresses/${address}/token-balances`, {
+    headers: { accept: 'application/json' },
+  });
+  if (!response.ok) {
+    throw new Error(`Blockscout token-balances ${response.status} for chain ${chainId}`);
+  }
+  return (await response.json()) as BlockscoutTokenBalance[];
+};
+
+const fetchBlockscoutTokenTransfers = async ({
+  chainId,
+  address,
+  token,
+  filter = 'to',
+  explorerUrl,
+}: {
+  chainId: number;
+  address: string;
+  token?: string;
+  filter?: 'from' | 'to';
+  explorerUrl?: string;
+}): Promise<BlockscoutTransactions> => {
+  const url = explorerUrl ?? blockscoutUrlForChain(chainId) ?? BLOCKSCOUT_URLS[fuse.id];
+  const params: string[] = ['type=ERC-20'];
+  if (filter) params.push(`filter=${filter}`);
+  if (token) params.push(`token=${token}`);
+  const response = await axios.get<BlockscoutTransactions>(
+    `${url}/api/v2/addresses/${address}/token-transfers?${params.join('&')}`,
+  );
+  return response.data;
+};
+
+export const fetchTokenBalancesWithFallback = async (
+  chainId: number,
+  address: string,
+): Promise<BlockscoutTokenBalance[]> => {
+  if (!isAlchemyChain(chainId)) {
+    return fetchBlockscoutTokenBalances(chainId, address);
+  }
+  try {
+    return await fetchAlchemyTokenBalances(chainId, address);
+  } catch (err) {
+    console.warn(
+      `[data-source] alchemy balances failed for chain ${chainId}, falling back to blockscout`,
+      err,
+    );
+    return fetchBlockscoutTokenBalances(chainId, address);
+  }
+};
+
+export const fetchTokenTransferWithFallback = async ({
+  chainId,
+  address,
+  token,
+  filter = 'to',
+  blockscoutExplorerUrl,
+}: {
+  chainId: number;
+  address: string;
+  token?: string;
+  filter?: 'from' | 'to';
+  blockscoutExplorerUrl?: string;
+}): Promise<BlockscoutTransactions> => {
+  if (!isAlchemyChain(chainId)) {
+    return fetchBlockscoutTokenTransfers({
+      chainId,
+      address,
+      token,
+      filter,
+      explorerUrl: blockscoutExplorerUrl,
+    });
+  }
+  try {
+    return await fetchAlchemyTokenTransfers({ chainId, address, token, filter });
+  } catch (err) {
+    console.warn(
+      `[data-source] alchemy transfers failed for chain ${chainId}, falling back to blockscout`,
+      err,
+    );
+    return fetchBlockscoutTokenTransfers({
+      chainId,
+      address,
+      token,
+      filter,
+      explorerUrl: blockscoutExplorerUrl,
+    });
+  }
+};


### PR DESCRIPTION
Cherry-pick of #1988 (already on `qa`) onto `master`. Includes the follow-up `pageKey` pagination fix so wallets with >100 tokens aren't truncated.

## Summary
- Token balances and token-transfer history go through an Alchemy-primary / Blockscout-fallback dispatcher for Ethereum (1), Base (8453), Polygon (137), Arbitrum (42161).
- Fuse (122) stays Blockscout-only (no Alchemy support).
- New `lib/alchemy.ts` (JSON-RPC client + mappers into the existing `BlockscoutTokenBalance` / `BlockscoutTransactions` shapes) and `lib/data-source.ts` (dispatcher). Consumers (`useBalances`, `fetchTokenTransfer`, `useAnalytics`) rewired — existing shapes preserved so no downstream refactors needed.
- `alchemy_getTokenBalances` loops on `pageKey` (capped at 10 pages) so wallets with large token counts aren't truncated.

## Test plan
- [ ] Launch Expo against an account with tokens on all 5 chains; confirm `g.alchemy.com` calls for 1/8453/137/42161 and `explorer.fuse.io` call for Fuse
- [ ] Set invalid `EXPO_PUBLIC_ALCHEMY_API_KEY`; confirm `useBalances` still renders via Blockscout fallback and `console.warn('[data-source] … fallback')` fires
- [ ] Navigate analytics screens (`useAnalytics`); verify transaction lists populate from Alchemy (Ethereum) and Blockscout (Fuse)

https://claude.ai/code/session_019vFUDndSSXn7JWfF7XcStC

---
_Generated by [Claude Code](https://claude.ai/code/session_019vFUDndSSXn7JWfF7XcStC)_