### PR TITLE
Add card activation consent flow with country-specific requirements

### DIFF
--- a/app/(protected)/(tabs)/card/ready.tsx
+++ b/app/(protected)/(tabs)/card/ready.tsx
@@ -12,9 +12,9 @@ import { Underline } from '@/components/ui/underline';
 import { path } from '@/constants/path';
 import { CARD_STATUS_QUERY_KEY } from '@/hooks/useCardStatus';
 import { createCard, submitCardConsents } from '@/lib/api';
-import { EXPO_PUBLIC_BASE_URL } from '@/lib/config';
 import { CardStatus } from '@/lib/types';
 import { withRefreshToken } from '@/lib/utils';
+import { useCountryStore } from '@/store/useCountryStore';
 
 type ConsentKey =
   | 'agreedToEsign'
@@ -33,6 +33,15 @@ const initialConsents: ConsentState = {
   agreedToNoSolicitation: false,
 };
 
+const ESIGN_CONSENT_URL =
+  'https://support.solid.xyz/en/articles/14167249-e-sign-electronic-communications-notice';
+const ACCOUNT_OPENING_PRIVACY_URL =
+  'https://support.solid.xyz/en/articles/14285527-account-opening-privacy-notice-fuse-network-lt-solid-xyz';
+const US_CARD_TERMS_URL =
+  'https://support.solid.xyz/en/articles/14285503-fuse-network-ltd-card-terms-for-u-s-consumer-program';
+const INTL_CARD_TERMS_URL = 'https://support.solid.xyz/en/articles/14167026-solid-user-terms';
+const ISSUER_PRIVACY_URL = 'https://www.third-national.com/privacypolicy';
+
 const underlineProps = {
   textClassName: 'text-sm font-bold text-white' as const,
   borderColor: 'rgba(255, 255, 255, 1)' as const,
@@ -44,11 +53,32 @@ export default function CardReady() {
   const [activating, setActivating] = useState(false);
   const [consents, setConsents] = useState<ConsentState>(initialConsents);
 
-  const baseUrl = EXPO_PUBLIC_BASE_URL || 'https://solid.xyz';
+  const countryCode = useCountryStore(state => state.countryInfo?.countryCode);
+  const isUS = countryCode?.toUpperCase() === 'US';
+  const cardTermsUrl = isUS ? US_CARD_TERMS_URL : INTL_CARD_TERMS_URL;
+
+  const requiredKeys = useMemo<ConsentKey[]>(
+    () =>
+      isUS
+        ? [
+            'agreedToEsign',
+            'agreedToAccountOpeningPrivacy',
+            'isTermsOfServiceAccepted',
+            'agreedToCertify',
+            'agreedToNoSolicitation',
+          ]
+        : [
+            'agreedToEsign',
+            'isTermsOfServiceAccepted',
+            'agreedToCertify',
+            'agreedToNoSolicitation',
+          ],
+    [isUS],
+  );
 
   const allAccepted = useMemo(
-    () => (Object.keys(consents) as ConsentKey[]).every(key => consents[key]),
-    [consents],
+    () => requiredKeys.every(key => consents[key]),
+    [requiredKeys, consents],
   );
 
   const toggle = (key: ConsentKey) => setConsents(prev => ({ ...prev, [key]: !prev[key] }));
@@ -59,7 +89,13 @@ export default function CardReady() {
     try {
       setActivating(true);
 
-      await withRefreshToken(() => submitCardConsents(consents));
+      await withRefreshToken(() =>
+        submitCardConsents({
+          ...consents,
+          // Non-US users never see this consent; send false so the field is always present.
+          agreedToAccountOpeningPrivacy: isUS ? consents.agreedToAccountOpeningPrivacy : false,
+        }),
+      );
 
       const card = await withRefreshToken(() => createCard());
       if (!card) throw new Error('Failed to create card');
@@ -94,49 +130,39 @@ export default function CardReady() {
       <View className="mt-4 w-full gap-3">
         <ConsentRow checked={consents.agreedToEsign} onToggle={() => toggle('agreedToEsign')}>
           I accept the{' '}
-          <Underline
-            inline
-            {...underlineProps}
-            onPress={() => Linking.openURL(`${baseUrl}/legal/esign-consent`)}
-          >
+          <Underline inline {...underlineProps} onPress={() => Linking.openURL(ESIGN_CONSENT_URL)}>
             E-Sign Consent
           </Underline>
           .
         </ConsentRow>
 
-        <ConsentRow
-          checked={consents.agreedToAccountOpeningPrivacy}
-          onToggle={() => toggle('agreedToAccountOpeningPrivacy')}
-        >
-          I accept the{' '}
-          <Underline
-            inline
-            {...underlineProps}
-            onPress={() => Linking.openURL(`${baseUrl}/legal/account-opening-privacy`)}
+        {isUS && (
+          <ConsentRow
+            checked={consents.agreedToAccountOpeningPrivacy}
+            onToggle={() => toggle('agreedToAccountOpeningPrivacy')}
           >
-            Account Opening Privacy Notice
-          </Underline>
-          .
-        </ConsentRow>
+            I accept the{' '}
+            <Underline
+              inline
+              {...underlineProps}
+              onPress={() => Linking.openURL(ACCOUNT_OPENING_PRIVACY_URL)}
+            >
+              Account Opening Privacy Notice
+            </Underline>
+            .
+          </ConsentRow>
+        )}
 
         <ConsentRow
           checked={consents.isTermsOfServiceAccepted}
           onToggle={() => toggle('isTermsOfServiceAccepted')}
         >
           I accept the{' '}
-          <Underline
-            inline
-            {...underlineProps}
-            onPress={() => Linking.openURL(`${baseUrl}/legal/card-terms`)}
-          >
+          <Underline inline {...underlineProps} onPress={() => Linking.openURL(cardTermsUrl)}>
             Solid Card Terms
           </Underline>{' '}
           and the{' '}
-          <Underline
-            inline
-            {...underlineProps}
-            onPress={() => Linking.openURL(`${baseUrl}/legal/issuer-privacy`)}
-          >
+          <Underline inline {...underlineProps} onPress={() => Linking.openURL(ISSUER_PRIVACY_URL)}>
             Issuer Privacy Policy
           </Underline>
           .

--- a/app/(protected)/(tabs)/card/ready.tsx
+++ b/app/(protected)/(tabs)/card/ready.tsx
@@ -1,25 +1,66 @@
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
+import { Linking, Pressable, View } from 'react-native';
 import Toast from 'react-native-toast-message';
 import { useRouter } from 'expo-router';
 import { useQueryClient } from '@tanstack/react-query';
 
 import { CardStatusPage } from '@/components/Card/CardStatusPage';
 import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
 import { Text } from '@/components/ui/text';
+import { Underline } from '@/components/ui/underline';
 import { path } from '@/constants/path';
 import { CARD_STATUS_QUERY_KEY } from '@/hooks/useCardStatus';
-import { createCard } from '@/lib/api';
+import { createCard, submitCardConsents } from '@/lib/api';
+import { EXPO_PUBLIC_BASE_URL } from '@/lib/config';
 import { CardStatus } from '@/lib/types';
 import { withRefreshToken } from '@/lib/utils';
+
+type ConsentKey =
+  | 'agreedToEsign'
+  | 'agreedToAccountOpeningPrivacy'
+  | 'isTermsOfServiceAccepted'
+  | 'agreedToCertify'
+  | 'agreedToNoSolicitation';
+
+type ConsentState = Record<ConsentKey, boolean>;
+
+const initialConsents: ConsentState = {
+  agreedToEsign: false,
+  agreedToAccountOpeningPrivacy: false,
+  isTermsOfServiceAccepted: false,
+  agreedToCertify: false,
+  agreedToNoSolicitation: false,
+};
+
+const underlineProps = {
+  textClassName: 'text-sm font-bold text-white' as const,
+  borderColor: 'rgba(255, 255, 255, 1)' as const,
+};
 
 export default function CardReady() {
   const router = useRouter();
   const queryClient = useQueryClient();
   const [activating, setActivating] = useState(false);
+  const [consents, setConsents] = useState<ConsentState>(initialConsents);
+
+  const baseUrl = EXPO_PUBLIC_BASE_URL || 'https://solid.xyz';
+
+  const allAccepted = useMemo(
+    () => (Object.keys(consents) as ConsentKey[]).every(key => consents[key]),
+    [consents],
+  );
+
+  const toggle = (key: ConsentKey) => setConsents(prev => ({ ...prev, [key]: !prev[key] }));
 
   const handleActivateCard = async () => {
+    if (!allAccepted) return;
+
     try {
       setActivating(true);
+
+      await withRefreshToken(() => submitCardConsents(consents));
+
       const card = await withRefreshToken(() => createCard());
       if (!card) throw new Error('Failed to create card');
 
@@ -49,20 +90,101 @@ export default function CardReady() {
   };
 
   return (
-    <CardStatusPage
-      title="Your card is ready!"
-      description={'All is set! now click on the "Activate card"\nbutton to issue your new card'}
-    >
+    <CardStatusPage title="Your card is ready!">
+      <View className="mt-4 w-full gap-3">
+        <ConsentRow checked={consents.agreedToEsign} onToggle={() => toggle('agreedToEsign')}>
+          I accept the{' '}
+          <Underline
+            inline
+            {...underlineProps}
+            onPress={() => Linking.openURL(`${baseUrl}/legal/esign-consent`)}
+          >
+            E-Sign Consent
+          </Underline>
+          .
+        </ConsentRow>
+
+        <ConsentRow
+          checked={consents.agreedToAccountOpeningPrivacy}
+          onToggle={() => toggle('agreedToAccountOpeningPrivacy')}
+        >
+          I accept the{' '}
+          <Underline
+            inline
+            {...underlineProps}
+            onPress={() => Linking.openURL(`${baseUrl}/legal/account-opening-privacy`)}
+          >
+            Account Opening Privacy Notice
+          </Underline>
+          .
+        </ConsentRow>
+
+        <ConsentRow
+          checked={consents.isTermsOfServiceAccepted}
+          onToggle={() => toggle('isTermsOfServiceAccepted')}
+        >
+          I accept the{' '}
+          <Underline
+            inline
+            {...underlineProps}
+            onPress={() => Linking.openURL(`${baseUrl}/legal/card-terms`)}
+          >
+            Solid Card Terms
+          </Underline>{' '}
+          and the{' '}
+          <Underline
+            inline
+            {...underlineProps}
+            onPress={() => Linking.openURL(`${baseUrl}/legal/issuer-privacy`)}
+          >
+            Issuer Privacy Policy
+          </Underline>
+          .
+        </ConsentRow>
+
+        <ConsentRow checked={consents.agreedToCertify} onToggle={() => toggle('agreedToCertify')}>
+          I certify that the information I have provided is accurate and that I will abide by all
+          the rules and requirements related to my Solid Spend Card.
+        </ConsentRow>
+
+        <ConsentRow
+          checked={consents.agreedToNoSolicitation}
+          onToggle={() => toggle('agreedToNoSolicitation')}
+        >
+          I acknowledge that applying for the Solid Spend Card does not constitute unauthorized
+          solicitation.
+        </ConsentRow>
+      </View>
+
       <Button
         variant="brand"
         onPress={handleActivateCard}
-        disabled={activating}
-        className="mt-4 h-12 w-full rounded-xl"
+        disabled={activating || !allAccepted}
+        className="mt-6 h-12 w-full rounded-xl"
       >
         <Text className="text-base font-bold text-primary-foreground">
           {activating ? 'Activating...' : 'Activate card'}
         </Text>
       </Button>
     </CardStatusPage>
+  );
+}
+
+function ConsentRow({
+  checked,
+  onToggle,
+  children,
+}: {
+  checked: boolean;
+  onToggle: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <View className="w-full flex-row items-start">
+      <Checkbox checked={checked} onCheckedChange={onToggle} className="mr-3 mt-0.5" />
+      <Pressable onPress={onToggle} className="flex-1">
+        <Text className="text-left text-sm leading-5 text-[#ACACAC]">{children}</Text>
+      </Pressable>
+    </View>
   );
 }

--- a/components/Card/CardStatusPage.tsx
+++ b/components/Card/CardStatusPage.tsx
@@ -9,7 +9,7 @@ import { getAsset } from '@/lib/assets';
 
 interface CardStatusPageProps {
   title: string;
-  description: string;
+  description?: string;
   children?: ReactNode;
 }
 
@@ -37,9 +37,11 @@ export function CardStatusPage({ title, description, children }: CardStatusPageP
             </View>
 
             <Text className="mt-2 text-center text-2xl font-bold text-white">{title}</Text>
-            <Text className="my-3 text-center text-base leading-tight text-[#ACACAC]">
-              {description}
-            </Text>
+            {description ? (
+              <Text className="my-3 text-center text-base leading-tight text-[#ACACAC]">
+                {description}
+              </Text>
+            ) : null}
 
             {children}
           </View>

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -495,6 +495,35 @@ export const personaSimulateAction = async (
   return response.json();
 };
 
+/**
+ * Card-activation consents collected on /card/ready.
+ * Stored in MongoDB (rainKycAgreements) for compliance retention; not forwarded to Rain.
+ */
+export const submitCardConsents = async (consents: {
+  agreedToEsign: boolean;
+  agreedToAccountOpeningPrivacy: boolean;
+  isTermsOfServiceAccepted: boolean;
+  agreedToCertify: boolean;
+  agreedToNoSolicitation: boolean;
+}): Promise<{ id: string; createdAt: string }> => {
+  const jwt = getJWTToken();
+
+  const response = await fetch(`${EXPO_PUBLIC_FLASH_API_BASE_URL}/accounts/v1/cards/kyc/consents`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...getPlatformHeaders(),
+      ...(jwt ? { Authorization: `Bearer ${jwt}` } : {}),
+    },
+    credentials: 'include',
+    body: JSON.stringify(consents),
+  });
+
+  if (!response.ok) throw response;
+
+  return response.json();
+};
+
 /** Rain KYC (in-house): single multipart POST with application fields + document files. Backend creates Rain application then uploads docs. */
 export const submitRainKyc = async (formData: FormData): Promise<RainKycSubmitResponse> => {
   const jwt = getJWTToken();


### PR DESCRIPTION
## Summary
This PR implements a consent collection flow for card activation on the `/card/ready` screen. Users must now accept multiple consent agreements before activating their card, with different requirements based on their country of residence.

## Key Changes

- **Consent Collection UI**: Added a new consent form with 5 checkboxes (E-Sign, Account Opening Privacy Notice, Card Terms, Certification, and No Solicitation acknowledgment)
- **Country-Specific Logic**: US users see an additional "Account Opening Privacy Notice" consent that non-US users don't see
- **Dynamic Card Terms URL**: Card terms link changes based on country (US vs International)
- **Consent Submission**: New `submitCardConsents` API endpoint stores consent agreements in MongoDB for compliance retention
- **Form Validation**: Card activation button is disabled until all required consents are accepted
- **Clickable Links**: Consent text includes underlined links to external compliance documents
- **Component Updates**: Made `description` prop optional in `CardStatusPage` to support custom content layouts

## Implementation Details

- Consent state is managed locally with a `ConsentState` record tracking 5 boolean flags
- `useMemo` hooks optimize the calculation of required consent keys and validation state based on country
- The `ConsentRow` component provides a reusable checkbox + text pattern with press handling
- Non-US users automatically send `false` for `agreedToAccountOpeningPrivacy` to ensure the field is always present in API requests
- Consents are submitted before card creation to ensure compliance data is captured

https://claude.ai/code/session_01RoB8EWZbasX3uiHQFQvgsu