### PR TITLE
fix(kyc,card-activate): redirect to /card/pending after questionnaire…

### DIFF
--- a/app/(protected)/(tabs)/kyc.tsx
+++ b/app/(protected)/(tabs)/kyc.tsx
@@ -52,6 +52,18 @@ export default function KycWeb() {
       }
     };
 
+    // With manual review enabled the SDK does not auto-close after submission
+    // (`onComplete` only fires for terminal Approved/Declined states), leaving
+    // the user staring at a blank Didit screen. The `verification_submitted`
+    // event fires as soon as the questionnaire is submitted, so use it to
+    // proactively send the user to /card/pending where the polling continues.
+    DiditSdk.shared.onEvent = event => {
+      if (event.type === 'didit:verification_submitted' && hasStartedRef.current) {
+        hasStartedRef.current = false;
+        onVerificationPending();
+      }
+    };
+
     // Reset any previous SDK state so the embed container can be reused on retry
     DiditSdk.reset();
     DiditSdk.shared.startVerification({

--- a/hooks/useCardSteps/stepHelpers.ts
+++ b/hooks/useCardSteps/stepHelpers.ts
@@ -1,14 +1,8 @@
 import { useCallback, useEffect, useState } from 'react';
-import Toast from 'react-native-toast-message';
 import { Router } from 'expo-router';
-import { useQueryClient } from '@tanstack/react-query';
 
 import { EndorsementStatus } from '@/components/BankTransfer/enums';
 import { path } from '@/constants/path';
-import { TRACKING_EVENTS } from '@/constants/tracking-events';
-import { CARD_STATUS_QUERY_KEY } from '@/hooks/useCardStatus';
-import { track } from '@/lib/analytics';
-import { createCard } from '@/lib/api';
 import {
   BridgeCustomerEndorsement,
   BridgeRejectionReason,
@@ -17,9 +11,7 @@ import {
   KycStatus,
   RainApplicationStatus,
 } from '@/lib/types';
-import { withRefreshToken } from '@/lib/utils';
 
-import { extractCardActivationErrorMessage } from './cardActivationHelpers';
 import { getStepButtonText, getStepDescription, isStepButtonDisabled } from './kycDisplayHelpers';
 import { Step } from './types';
 
@@ -33,7 +25,7 @@ export function buildCardSteps(
   activationBlocked: boolean | undefined,
   activationBlockedReason: string | undefined,
   handleProceedToKyc: () => void,
-  handleActivateCard: () => void,
+  pushCardReady: () => void,
   pushCardDetails: () => void,
   options?: {
     cardIssuer?: CardProvider | null;
@@ -66,7 +58,7 @@ export function buildCardSteps(
 
   const orderCardDesc = activationBlocked
     ? activationBlockedReason || 'There was an issue activating your card. Please contact support.'
-    : 'All is set! now click on the "Create card" button to issue your new card';
+    : 'All is set! Click on "Activate card" to review the agreements and issue your new card.';
 
   const kycStepOnPress =
     options?.cardIssuer === CardProvider.RAIN && options?.handleRainKYCPress
@@ -90,8 +82,8 @@ export function buildCardSteps(
       description: orderCardDesc,
       completed: cardActivated,
       status: cardActivated ? 'completed' : 'pending',
-      buttonText: activationBlocked || !isKycComplete ? undefined : 'Order card',
-      onPress: activationBlocked || !isKycComplete ? undefined : handleActivateCard,
+      buttonText: activationBlocked || !isKycComplete ? undefined : 'Activate card',
+      onPress: activationBlocked || !isKycComplete ? undefined : pushCardReady,
     },
     {
       id: 3,
@@ -116,46 +108,13 @@ export function findFirstIncompleteStep(steps: Step[]): Step | undefined {
 }
 
 /**
- * Hook to manage card activation state and actions
+ * Hook to manage card activation state and actions.
+ * Card creation itself happens on /card/ready after the user accepts the
+ * consents; this hook only tracks completion state and exposes navigation.
  */
 export function useCardActivation(router: Router) {
-  const queryClient = useQueryClient();
   const [cardActivated, setCardActivated] = useState(false);
-  const [activatingCard, setActivatingCard] = useState(false);
-  const handleActivateCard = useCallback(async () => {
-    track(TRACKING_EVENTS.CARD_ACTIVATION_STARTED);
-    try {
-      setActivatingCard(true);
-
-      // Create the card
-      const card = await withRefreshToken(() => createCard());
-
-      if (!card) throw new Error('Failed to create card');
-
-      if (card.status !== CardStatus.PENDING) {
-        setCardActivated(true);
-        track(TRACKING_EVENTS.CARD_ACTIVATION_SUCCEEDED, { cardId: card.id });
-        router.replace(path.CARD_DETAILS);
-      } else {
-        // If card is pending, we don't mark as activated and don't redirect.
-        // We just invalidate the card status to show the "pending" UI on the same page.
-        queryClient.invalidateQueries({ queryKey: [CARD_STATUS_QUERY_KEY] });
-      }
-    } catch (error) {
-      console.error('Error activating card:', error);
-      const errorMessage = await extractCardActivationErrorMessage(error);
-
-      track(TRACKING_EVENTS.CARD_ACTIVATION_FAILED, { message: errorMessage });
-      Toast.show({
-        type: 'error',
-        text1: 'Error activating card',
-        text2: errorMessage,
-        props: { badgeText: '' },
-      });
-    } finally {
-      setActivatingCard(false);
-    }
-  }, [router, queryClient]);
+  const [activatingCard] = useState(false);
 
   const syncCardActivationState = useCallback((cardStatus: CardStatus | undefined) => {
     // Mark card as activated if user has a card in any state
@@ -172,12 +131,16 @@ export function useCardActivation(router: Router) {
     router.push(path.CARD_DETAILS);
   }, [router]);
 
+  const pushCardReady = useCallback(() => {
+    router.push(path.CARD_READY);
+  }, [router]);
+
   return {
     cardActivated,
     activatingCard,
-    handleActivateCard,
     syncCardActivationState,
     pushCardDetails,
+    pushCardReady,
   };
 }
 

--- a/hooks/useCardSteps/useCardSteps.ts
+++ b/hooks/useCardSteps/useCardSteps.ts
@@ -11,12 +11,7 @@ import { getCustomerFromBridge, getKycLinkFromBridge } from '@/lib/api';
 import { EXPO_PUBLIC_CARD_ISSUER } from '@/lib/config';
 import { openIntercom } from '@/lib/intercom';
 import { redirectToRainVerification } from '@/lib/rainVerification';
-import {
-  CardProvider,
-  CardStatusResponse,
-  KycStatus,
-  RainApplicationStatus,
-} from '@/lib/types';
+import { CardProvider, CardStatusResponse, KycStatus, RainApplicationStatus } from '@/lib/types';
 import { withRefreshToken } from '@/lib/utils';
 import { useCountryStore } from '@/store/useCountryStore';
 import { useKycStore } from '@/store/useKycStore';
@@ -102,13 +97,8 @@ export function useCardSteps(
   );
 
   // Card activation state and handlers
-  const {
-    cardActivated,
-    activatingCard,
-    handleActivateCard,
-    syncCardActivationState,
-    pushCardDetails,
-  } = useCardActivation(router);
+  const { cardActivated, activatingCard, syncCardActivationState, pushCardDetails, pushCardReady } =
+    useCardActivation(router);
 
   // Sync card activation state with server
   useEffect(() => {
@@ -256,7 +246,7 @@ export function useCardSteps(
         cardStatusResponse?.activationBlocked,
         cardStatusResponse?.activationBlockedReason,
         handleProceedToKyc,
-        handleActivateCard,
+        pushCardReady,
         pushCardDetails,
         {
           cardIssuer,
@@ -276,7 +266,7 @@ export function useCardSteps(
       cardStatusResponse?.kycStatus,
       cardStatusResponse?.kycWarnings,
       handleProceedToKyc,
-      handleActivateCard,
+      pushCardReady,
       pushCardDetails,
       cardIssuer,
       handleRainKYCPress,


### PR DESCRIPTION
… submission and route step 2 through /card/ready

When the Didit questionnaire has manual review enabled the SDK does not auto-close after submission and onComplete only fires for terminal Approved/Declined states, leaving the user on /kyc with a blank Didit screen. Listen to the didit:verification_submitted event so the user is sent to /card/pending as soon as the questionnaire is submitted.

The "Activate your card" button on /card/activate previously called the createCard API directly, which skipped the consent step on /card/ready. Route the button through /card/ready instead so consents are captured before card creation. The dead createCard handler in useCardActivation is removed; /card/ready owns the activation call now.