### PR TITLE
Cherry-pick: move consent checkboxes to /card/ready (qa → master)

### DIFF
--- a/app/(protected)/(tabs)/card/ready.tsx
+++ b/app/(protected)/(tabs)/card/ready.tsx
@@ -12,9 +12,9 @@ import { Underline } from '@/components/ui/underline';
 import { path } from '@/constants/path';
 import { CARD_STATUS_QUERY_KEY } from '@/hooks/useCardStatus';
 import { createCard, submitCardConsents } from '@/lib/api';
-import { EXPO_PUBLIC_BASE_URL } from '@/lib/config';
 import { CardStatus } from '@/lib/types';
 import { withRefreshToken } from '@/lib/utils';
+import { useCountryStore } from '@/store/useCountryStore';
 
 type ConsentKey =
   | 'agreedToEsign'
@@ -33,6 +33,15 @@ const initialConsents: ConsentState = {
   agreedToNoSolicitation: false,
 };
 
+const ESIGN_CONSENT_URL =
+  'https://support.solid.xyz/en/articles/14167249-e-sign-electronic-communications-notice';
+const ACCOUNT_OPENING_PRIVACY_URL =
+  'https://support.solid.xyz/en/articles/14285527-account-opening-privacy-notice-fuse-network-lt-solid-xyz';
+const US_CARD_TERMS_URL =
+  'https://support.solid.xyz/en/articles/14285503-fuse-network-ltd-card-terms-for-u-s-consumer-program';
+const INTL_CARD_TERMS_URL = 'https://support.solid.xyz/en/articles/14167026-solid-user-terms';
+const ISSUER_PRIVACY_URL = 'https://www.third-national.com/privacypolicy';
+
 const underlineProps = {
   textClassName: 'text-sm font-bold text-white' as const,
   borderColor: 'rgba(255, 255, 255, 1)' as const,
@@ -44,11 +53,32 @@ export default function CardReady() {
   const [activating, setActivating] = useState(false);
   const [consents, setConsents] = useState<ConsentState>(initialConsents);
 
-  const baseUrl = EXPO_PUBLIC_BASE_URL || 'https://solid.xyz';
+  const countryCode = useCountryStore(state => state.countryInfo?.countryCode);
+  const isUS = countryCode?.toUpperCase() === 'US';
+  const cardTermsUrl = isUS ? US_CARD_TERMS_URL : INTL_CARD_TERMS_URL;
+
+  const requiredKeys = useMemo<ConsentKey[]>(
+    () =>
+      isUS
+        ? [
+            'agreedToEsign',
+            'agreedToAccountOpeningPrivacy',
+            'isTermsOfServiceAccepted',
+            'agreedToCertify',
+            'agreedToNoSolicitation',
+          ]
+        : [
+            'agreedToEsign',
+            'isTermsOfServiceAccepted',
+            'agreedToCertify',
+            'agreedToNoSolicitation',
+          ],
+    [isUS],
+  );
 
   const allAccepted = useMemo(
-    () => (Object.keys(consents) as ConsentKey[]).every(key => consents[key]),
-    [consents],
+    () => requiredKeys.every(key => consents[key]),
+    [requiredKeys, consents],
   );
 
   const toggle = (key: ConsentKey) => setConsents(prev => ({ ...prev, [key]: !prev[key] }));
@@ -59,7 +89,13 @@ export default function CardReady() {
     try {
       setActivating(true);
 
-      await withRefreshToken(() => submitCardConsents(consents));
+      await withRefreshToken(() =>
+        submitCardConsents({
+          ...consents,
+          // Non-US users never see this consent; send false so the field is always present.
+          agreedToAccountOpeningPrivacy: isUS ? consents.agreedToAccountOpeningPrivacy : false,
+        }),
+      );
 
       const card = await withRefreshToken(() => createCard());
       if (!card) throw new Error('Failed to create card');
@@ -94,49 +130,39 @@ export default function CardReady() {
       <View className="mt-4 w-full gap-3">
         <ConsentRow checked={consents.agreedToEsign} onToggle={() => toggle('agreedToEsign')}>
           I accept the{' '}
-          <Underline
-            inline
-            {...underlineProps}
-            onPress={() => Linking.openURL(`${baseUrl}/legal/esign-consent`)}
-          >
+          <Underline inline {...underlineProps} onPress={() => Linking.openURL(ESIGN_CONSENT_URL)}>
             E-Sign Consent
           </Underline>
           .
         </ConsentRow>
 
-        <ConsentRow
-          checked={consents.agreedToAccountOpeningPrivacy}
-          onToggle={() => toggle('agreedToAccountOpeningPrivacy')}
-        >
-          I accept the{' '}
-          <Underline
-            inline
-            {...underlineProps}
-            onPress={() => Linking.openURL(`${baseUrl}/legal/account-opening-privacy`)}
+        {isUS && (
+          <ConsentRow
+            checked={consents.agreedToAccountOpeningPrivacy}
+            onToggle={() => toggle('agreedToAccountOpeningPrivacy')}
           >
-            Account Opening Privacy Notice
-          </Underline>
-          .
-        </ConsentRow>
+            I accept the{' '}
+            <Underline
+              inline
+              {...underlineProps}
+              onPress={() => Linking.openURL(ACCOUNT_OPENING_PRIVACY_URL)}
+            >
+              Account Opening Privacy Notice
+            </Underline>
+            .
+          </ConsentRow>
+        )}
 
         <ConsentRow
           checked={consents.isTermsOfServiceAccepted}
           onToggle={() => toggle('isTermsOfServiceAccepted')}
         >
           I accept the{' '}
-          <Underline
-            inline
-            {...underlineProps}
-            onPress={() => Linking.openURL(`${baseUrl}/legal/card-terms`)}
-          >
+          <Underline inline {...underlineProps} onPress={() => Linking.openURL(cardTermsUrl)}>
             Solid Card Terms
           </Underline>{' '}
           and the{' '}
-          <Underline
-            inline
-            {...underlineProps}
-            onPress={() => Linking.openURL(`${baseUrl}/legal/issuer-privacy`)}
-          >
+          <Underline inline {...underlineProps} onPress={() => Linking.openURL(ISSUER_PRIVACY_URL)}>
             Issuer Privacy Policy
           </Underline>
           .

--- a/app/(protected)/(tabs)/card/ready.tsx
+++ b/app/(protected)/(tabs)/card/ready.tsx
@@ -1,25 +1,66 @@
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
+import { Linking, Pressable, View } from 'react-native';
 import Toast from 'react-native-toast-message';
 import { useRouter } from 'expo-router';
 import { useQueryClient } from '@tanstack/react-query';
 
 import { CardStatusPage } from '@/components/Card/CardStatusPage';
 import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
 import { Text } from '@/components/ui/text';
+import { Underline } from '@/components/ui/underline';
 import { path } from '@/constants/path';
 import { CARD_STATUS_QUERY_KEY } from '@/hooks/useCardStatus';
-import { createCard } from '@/lib/api';
+import { createCard, submitCardConsents } from '@/lib/api';
+import { EXPO_PUBLIC_BASE_URL } from '@/lib/config';
 import { CardStatus } from '@/lib/types';
 import { withRefreshToken } from '@/lib/utils';
+
+type ConsentKey =
+  | 'agreedToEsign'
+  | 'agreedToAccountOpeningPrivacy'
+  | 'isTermsOfServiceAccepted'
+  | 'agreedToCertify'
+  | 'agreedToNoSolicitation';
+
+type ConsentState = Record<ConsentKey, boolean>;
+
+const initialConsents: ConsentState = {
+  agreedToEsign: false,
+  agreedToAccountOpeningPrivacy: false,
+  isTermsOfServiceAccepted: false,
+  agreedToCertify: false,
+  agreedToNoSolicitation: false,
+};
+
+const underlineProps = {
+  textClassName: 'text-sm font-bold text-white' as const,
+  borderColor: 'rgba(255, 255, 255, 1)' as const,
+};
 
 export default function CardReady() {
   const router = useRouter();
   const queryClient = useQueryClient();
   const [activating, setActivating] = useState(false);
+  const [consents, setConsents] = useState<ConsentState>(initialConsents);
+
+  const baseUrl = EXPO_PUBLIC_BASE_URL || 'https://solid.xyz';
+
+  const allAccepted = useMemo(
+    () => (Object.keys(consents) as ConsentKey[]).every(key => consents[key]),
+    [consents],
+  );
+
+  const toggle = (key: ConsentKey) => setConsents(prev => ({ ...prev, [key]: !prev[key] }));
 
   const handleActivateCard = async () => {
+    if (!allAccepted) return;
+
     try {
       setActivating(true);
+
+      await withRefreshToken(() => submitCardConsents(consents));
+
       const card = await withRefreshToken(() => createCard());
       if (!card) throw new Error('Failed to create card');
 
@@ -49,20 +90,101 @@ export default function CardReady() {
   };
 
   return (
-    <CardStatusPage
-      title="Your card is ready!"
-      description={'All is set! now click on the "Activate card"\nbutton to issue your new card'}
-    >
+    <CardStatusPage title="Your card is ready!">
+      <View className="mt-4 w-full gap-3">
+        <ConsentRow checked={consents.agreedToEsign} onToggle={() => toggle('agreedToEsign')}>
+          I accept the{' '}
+          <Underline
+            inline
+            {...underlineProps}
+            onPress={() => Linking.openURL(`${baseUrl}/legal/esign-consent`)}
+          >
+            E-Sign Consent
+          </Underline>
+          .
+        </ConsentRow>
+
+        <ConsentRow
+          checked={consents.agreedToAccountOpeningPrivacy}
+          onToggle={() => toggle('agreedToAccountOpeningPrivacy')}
+        >
+          I accept the{' '}
+          <Underline
+            inline
+            {...underlineProps}
+            onPress={() => Linking.openURL(`${baseUrl}/legal/account-opening-privacy`)}
+          >
+            Account Opening Privacy Notice
+          </Underline>
+          .
+        </ConsentRow>
+
+        <ConsentRow
+          checked={consents.isTermsOfServiceAccepted}
+          onToggle={() => toggle('isTermsOfServiceAccepted')}
+        >
+          I accept the{' '}
+          <Underline
+            inline
+            {...underlineProps}
+            onPress={() => Linking.openURL(`${baseUrl}/legal/card-terms`)}
+          >
+            Solid Card Terms
+          </Underline>{' '}
+          and the{' '}
+          <Underline
+            inline
+            {...underlineProps}
+            onPress={() => Linking.openURL(`${baseUrl}/legal/issuer-privacy`)}
+          >
+            Issuer Privacy Policy
+          </Underline>
+          .
+        </ConsentRow>
+
+        <ConsentRow checked={consents.agreedToCertify} onToggle={() => toggle('agreedToCertify')}>
+          I certify that the information I have provided is accurate and that I will abide by all
+          the rules and requirements related to my Solid Spend Card.
+        </ConsentRow>
+
+        <ConsentRow
+          checked={consents.agreedToNoSolicitation}
+          onToggle={() => toggle('agreedToNoSolicitation')}
+        >
+          I acknowledge that applying for the Solid Spend Card does not constitute unauthorized
+          solicitation.
+        </ConsentRow>
+      </View>
+
       <Button
         variant="brand"
         onPress={handleActivateCard}
-        disabled={activating}
-        className="mt-4 h-12 w-full rounded-xl"
+        disabled={activating || !allAccepted}
+        className="mt-6 h-12 w-full rounded-xl"
       >
         <Text className="text-base font-bold text-primary-foreground">
           {activating ? 'Activating...' : 'Activate card'}
         </Text>
       </Button>
     </CardStatusPage>
+  );
+}
+
+function ConsentRow({
+  checked,
+  onToggle,
+  children,
+}: {
+  checked: boolean;
+  onToggle: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <View className="w-full flex-row items-start">
+      <Checkbox checked={checked} onCheckedChange={onToggle} className="mr-3 mt-0.5" />
+      <Pressable onPress={onToggle} className="flex-1">
+        <Text className="text-left text-sm leading-5 text-[#ACACAC]">{children}</Text>
+      </Pressable>
+    </View>
   );
 }

--- a/app/(protected)/(tabs)/kyc.tsx
+++ b/app/(protected)/(tabs)/kyc.tsx
@@ -52,6 +52,18 @@ export default function KycWeb() {
       }
     };
 
+    // With manual review enabled the SDK does not auto-close after submission
+    // (`onComplete` only fires for terminal Approved/Declined states), leaving
+    // the user staring at a blank Didit screen. The `verification_submitted`
+    // event fires as soon as the questionnaire is submitted, so use it to
+    // proactively send the user to /card/pending where the polling continues.
+    DiditSdk.shared.onEvent = event => {
+      if (event.type === 'didit:verification_submitted' && hasStartedRef.current) {
+        hasStartedRef.current = false;
+        onVerificationPending();
+      }
+    };
+
     // Reset any previous SDK state so the embed container can be reused on retry
     DiditSdk.reset();
     DiditSdk.shared.startVerification({

--- a/app/(protected)/(tabs)/kyc.tsx
+++ b/app/(protected)/(tabs)/kyc.tsx
@@ -52,15 +52,38 @@ export default function KycWeb() {
       }
     };
 
-    // With manual review enabled the SDK does not auto-close after submission
-    // (`onComplete` only fires for terminal Approved/Declined states), leaving
-    // the user staring at a blank Didit screen. The `verification_submitted`
-    // event fires as soon as the questionnaire is submitted, so use it to
-    // proactively send the user to /card/pending where the polling continues.
+    // With manual review enabled the SDK never fires `didit:completed` (that
+    // only fires for terminal Approved/Declined states), so `onComplete` won't
+    // run for a Pending/In Review session. The user then stares at a blank
+    // Didit screen. We listen to the SDK's lower-level events instead:
+    //   - `verification_submitted` fires as soon as the user finishes the
+    //     verification flow (including the questionnaire);
+    //   - `status_updated` fires when Didit reports a new status, which is
+    //     where Pending/In Review actually arrives for manual-review sessions.
+    // Either one is enough to send the user to /card/pending where the polling
+    // takes over.
     DiditSdk.shared.onEvent = event => {
-      if (event.type === 'didit:verification_submitted' && hasStartedRef.current) {
+      if (!hasStartedRef.current) return;
+
+      if (event.type === 'didit:verification_submitted') {
         hasStartedRef.current = false;
         onVerificationPending();
+        return;
+      }
+
+      if (event.type === 'didit:status_updated') {
+        const status = event.data?.status;
+        if (status === 'Approved') {
+          hasStartedRef.current = false;
+          onVerificationComplete();
+        } else if (status === 'Declined') {
+          hasStartedRef.current = false;
+          onVerificationError('Your identity verification was declined.');
+        } else if (status && status !== 'Not Started' && status !== 'In Progress') {
+          // 'Pending', 'In Review', 'Resubmitted', etc.
+          hasStartedRef.current = false;
+          onVerificationPending();
+        }
       }
     };
 

--- a/app/(protected)/(tabs)/kyc.tsx
+++ b/app/(protected)/(tabs)/kyc.tsx
@@ -54,14 +54,15 @@ export default function KycWeb() {
 
     // With manual review enabled the SDK never fires `didit:completed` (that
     // only fires for terminal Approved/Declined states), so `onComplete` won't
-    // run for a Pending/In Review session. The user then stares at a blank
-    // Didit screen. We listen to the SDK's lower-level events instead:
+    // run for an In Review session. The user then stares at a blank Didit
+    // screen. We listen to the SDK's lower-level events instead:
     //   - `verification_submitted` fires as soon as the user finishes the
     //     verification flow (including the questionnaire);
-    //   - `status_updated` fires when Didit reports a new status, which is
-    //     where Pending/In Review actually arrives for manual-review sessions.
-    // Either one is enough to send the user to /card/pending where the polling
-    // takes over.
+    //   - `status_updated` fires whenever Didit reports a new status. Per
+    //     the Didit docs the values surfaced here are: Not Started,
+    //     In Progress, Approved, Declined, In Review, Awaiting User,
+    //     Resubmitted, Expired, Abandoned, Kyc Expired. ('Pending' shows up
+    //     in `onComplete` only, not here.)
     DiditSdk.shared.onEvent = event => {
       if (!hasStartedRef.current) return;
 
@@ -73,16 +74,33 @@ export default function KycWeb() {
 
       if (event.type === 'didit:status_updated') {
         const status = event.data?.status;
-        if (status === 'Approved') {
-          hasStartedRef.current = false;
-          onVerificationComplete();
-        } else if (status === 'Declined') {
-          hasStartedRef.current = false;
-          onVerificationError('Your identity verification was declined.');
-        } else if (status && status !== 'Not Started' && status !== 'In Progress') {
-          // 'Pending', 'In Review', 'Resubmitted', etc.
-          hasStartedRef.current = false;
-          onVerificationPending();
+        switch (status) {
+          case 'Approved':
+            hasStartedRef.current = false;
+            onVerificationComplete();
+            break;
+          case 'Declined':
+            hasStartedRef.current = false;
+            onVerificationError('Your identity verification was declined.');
+            break;
+          case 'Expired':
+          case 'Kyc Expired':
+            hasStartedRef.current = false;
+            onVerificationError('Your verification session expired. Please try again.');
+            break;
+          case 'Abandoned':
+            hasStartedRef.current = false;
+            onVerificationError('Your verification was abandoned. Please try again.');
+            break;
+          case 'In Review':
+          case 'Resubmitted':
+            hasStartedRef.current = false;
+            onVerificationPending();
+            break;
+          // 'Not Started', 'In Progress', 'Awaiting User' — keep the user in
+          // the widget; they still have something to do or are mid-flow.
+          default:
+            break;
         }
       }
     };

--- a/components/Card/CardStatusPage.tsx
+++ b/components/Card/CardStatusPage.tsx
@@ -9,7 +9,7 @@ import { getAsset } from '@/lib/assets';
 
 interface CardStatusPageProps {
   title: string;
-  description: string;
+  description?: string;
   children?: ReactNode;
 }
 
@@ -37,9 +37,11 @@ export function CardStatusPage({ title, description, children }: CardStatusPageP
             </View>
 
             <Text className="mt-2 text-center text-2xl font-bold text-white">{title}</Text>
-            <Text className="my-3 text-center text-base leading-tight text-[#ACACAC]">
-              {description}
-            </Text>
+            {description ? (
+              <Text className="my-3 text-center text-base leading-tight text-[#ACACAC]">
+                {description}
+              </Text>
+            ) : null}
 
             {children}
           </View>

--- a/hooks/useCardSteps/stepHelpers.ts
+++ b/hooks/useCardSteps/stepHelpers.ts
@@ -1,14 +1,8 @@
 import { useCallback, useEffect, useState } from 'react';
-import Toast from 'react-native-toast-message';
 import { Router } from 'expo-router';
-import { useQueryClient } from '@tanstack/react-query';
 
 import { EndorsementStatus } from '@/components/BankTransfer/enums';
 import { path } from '@/constants/path';
-import { TRACKING_EVENTS } from '@/constants/tracking-events';
-import { CARD_STATUS_QUERY_KEY } from '@/hooks/useCardStatus';
-import { track } from '@/lib/analytics';
-import { createCard } from '@/lib/api';
 import {
   BridgeCustomerEndorsement,
   BridgeRejectionReason,
@@ -17,9 +11,7 @@ import {
   KycStatus,
   RainApplicationStatus,
 } from '@/lib/types';
-import { withRefreshToken } from '@/lib/utils';
 
-import { extractCardActivationErrorMessage } from './cardActivationHelpers';
 import { getStepButtonText, getStepDescription, isStepButtonDisabled } from './kycDisplayHelpers';
 import { Step } from './types';
 
@@ -33,7 +25,7 @@ export function buildCardSteps(
   activationBlocked: boolean | undefined,
   activationBlockedReason: string | undefined,
   handleProceedToKyc: () => void,
-  handleActivateCard: () => void,
+  pushCardReady: () => void,
   pushCardDetails: () => void,
   options?: {
     cardIssuer?: CardProvider | null;
@@ -66,7 +58,7 @@ export function buildCardSteps(
 
   const orderCardDesc = activationBlocked
     ? activationBlockedReason || 'There was an issue activating your card. Please contact support.'
-    : 'All is set! now click on the "Create card" button to issue your new card';
+    : 'All is set! Click on "Activate card" to review the agreements and issue your new card.';
 
   const kycStepOnPress =
     options?.cardIssuer === CardProvider.RAIN && options?.handleRainKYCPress
@@ -90,8 +82,8 @@ export function buildCardSteps(
       description: orderCardDesc,
       completed: cardActivated,
       status: cardActivated ? 'completed' : 'pending',
-      buttonText: activationBlocked || !isKycComplete ? undefined : 'Order card',
-      onPress: activationBlocked || !isKycComplete ? undefined : handleActivateCard,
+      buttonText: activationBlocked || !isKycComplete ? undefined : 'Activate card',
+      onPress: activationBlocked || !isKycComplete ? undefined : pushCardReady,
     },
     {
       id: 3,
@@ -116,46 +108,13 @@ export function findFirstIncompleteStep(steps: Step[]): Step | undefined {
 }
 
 /**
- * Hook to manage card activation state and actions
+ * Hook to manage card activation state and actions.
+ * Card creation itself happens on /card/ready after the user accepts the
+ * consents; this hook only tracks completion state and exposes navigation.
  */
 export function useCardActivation(router: Router) {
-  const queryClient = useQueryClient();
   const [cardActivated, setCardActivated] = useState(false);
-  const [activatingCard, setActivatingCard] = useState(false);
-  const handleActivateCard = useCallback(async () => {
-    track(TRACKING_EVENTS.CARD_ACTIVATION_STARTED);
-    try {
-      setActivatingCard(true);
-
-      // Create the card
-      const card = await withRefreshToken(() => createCard());
-
-      if (!card) throw new Error('Failed to create card');
-
-      if (card.status !== CardStatus.PENDING) {
-        setCardActivated(true);
-        track(TRACKING_EVENTS.CARD_ACTIVATION_SUCCEEDED, { cardId: card.id });
-        router.replace(path.CARD_DETAILS);
-      } else {
-        // If card is pending, we don't mark as activated and don't redirect.
-        // We just invalidate the card status to show the "pending" UI on the same page.
-        queryClient.invalidateQueries({ queryKey: [CARD_STATUS_QUERY_KEY] });
-      }
-    } catch (error) {
-      console.error('Error activating card:', error);
-      const errorMessage = await extractCardActivationErrorMessage(error);
-
-      track(TRACKING_EVENTS.CARD_ACTIVATION_FAILED, { message: errorMessage });
-      Toast.show({
-        type: 'error',
-        text1: 'Error activating card',
-        text2: errorMessage,
-        props: { badgeText: '' },
-      });
-    } finally {
-      setActivatingCard(false);
-    }
-  }, [router, queryClient]);
+  const [activatingCard] = useState(false);
 
   const syncCardActivationState = useCallback((cardStatus: CardStatus | undefined) => {
     // Mark card as activated if user has a card in any state
@@ -172,12 +131,16 @@ export function useCardActivation(router: Router) {
     router.push(path.CARD_DETAILS);
   }, [router]);
 
+  const pushCardReady = useCallback(() => {
+    router.push(path.CARD_READY);
+  }, [router]);
+
   return {
     cardActivated,
     activatingCard,
-    handleActivateCard,
     syncCardActivationState,
     pushCardDetails,
+    pushCardReady,
   };
 }
 

--- a/hooks/useCardSteps/useCardSteps.ts
+++ b/hooks/useCardSteps/useCardSteps.ts
@@ -11,12 +11,7 @@ import { getCustomerFromBridge, getKycLinkFromBridge } from '@/lib/api';
 import { EXPO_PUBLIC_CARD_ISSUER } from '@/lib/config';
 import { openIntercom } from '@/lib/intercom';
 import { redirectToRainVerification } from '@/lib/rainVerification';
-import {
-  CardProvider,
-  CardStatusResponse,
-  KycStatus,
-  RainApplicationStatus,
-} from '@/lib/types';
+import { CardProvider, CardStatusResponse, KycStatus, RainApplicationStatus } from '@/lib/types';
 import { withRefreshToken } from '@/lib/utils';
 import { useCountryStore } from '@/store/useCountryStore';
 import { useKycStore } from '@/store/useKycStore';
@@ -102,13 +97,8 @@ export function useCardSteps(
   );
 
   // Card activation state and handlers
-  const {
-    cardActivated,
-    activatingCard,
-    handleActivateCard,
-    syncCardActivationState,
-    pushCardDetails,
-  } = useCardActivation(router);
+  const { cardActivated, activatingCard, syncCardActivationState, pushCardDetails, pushCardReady } =
+    useCardActivation(router);
 
   // Sync card activation state with server
   useEffect(() => {
@@ -256,7 +246,7 @@ export function useCardSteps(
         cardStatusResponse?.activationBlocked,
         cardStatusResponse?.activationBlockedReason,
         handleProceedToKyc,
-        handleActivateCard,
+        pushCardReady,
         pushCardDetails,
         {
           cardIssuer,
@@ -276,7 +266,7 @@ export function useCardSteps(
       cardStatusResponse?.kycStatus,
       cardStatusResponse?.kycWarnings,
       handleProceedToKyc,
-      handleActivateCard,
+      pushCardReady,
       pushCardDetails,
       cardIssuer,
       handleRainKYCPress,

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -495,6 +495,35 @@ export const personaSimulateAction = async (
   return response.json();
 };
 
+/**
+ * Card-activation consents collected on /card/ready.
+ * Stored in MongoDB (rainKycAgreements) for compliance retention; not forwarded to Rain.
+ */
+export const submitCardConsents = async (consents: {
+  agreedToEsign: boolean;
+  agreedToAccountOpeningPrivacy: boolean;
+  isTermsOfServiceAccepted: boolean;
+  agreedToCertify: boolean;
+  agreedToNoSolicitation: boolean;
+}): Promise<{ id: string; createdAt: string }> => {
+  const jwt = getJWTToken();
+
+  const response = await fetch(`${EXPO_PUBLIC_FLASH_API_BASE_URL}/accounts/v1/cards/kyc/consents`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...getPlatformHeaders(),
+      ...(jwt ? { Authorization: `Bearer ${jwt}` } : {}),
+    },
+    credentials: 'include',
+    body: JSON.stringify(consents),
+  });
+
+  if (!response.ok) throw response;
+
+  return response.json();
+};
+
 /** Rain KYC (in-house): single multipart POST with application fields + document files. Backend creates Rain application then uploads docs. */
 export const submitRainKyc = async (formData: FormData): Promise<RainKycSubmitResponse> => {
   const jwt = getJWTToken();


### PR DESCRIPTION
## Summary

Cherry-picks the consent-related changes from qa onto master:

- `feat(card): move consents to /card/ready page` — replaces the centered description with five left-aligned consent checkboxes; "Activate card" stays disabled until all are checked, then submits to `POST /accounts/v1/cards/kyc/consents` (stored in MongoDB, not forwarded to Rain) before `createCard`.
- `feat(card-ready): show consents based on US vs international` — uses `useCountryStore` to decide whether to show the US-only Account Opening Privacy notice, and to switch between the US vs international Solid Card Terms link.
- `fix(kyc,card-activate): redirect to /card/pending after questionnaire submission and route step 2 through /card/ready` — listens to the Didit SDK's `didit:verification_submitted` event so users with manual review enabled don't get stuck on a blank /kyc page; step 2 of /card/activate now pushes to /card/ready instead of calling `createCard` directly.

## Test plan
- [ ] Walk through Didit KYC with manual review on; confirm redirect to `/card/pending` after questionnaire submission.
- [ ] On `/card/ready`, confirm US users see five consents (incl. Account Opening Privacy) and non-US users see four.
- [ ] Activate button stays disabled until every required consent is checked.
- [ ] Submitting the consents records a `rainKycAgreements` document and creates the card.
- [ ] From `/card/activate`, step 2 button routes to `/card/ready` (no direct API call).

Backend companion PR: cherry-pick of `claude/move-consent-checkboxes-1jhiu` in `solid-backend`.

https://claude.ai/code/session_01RoB8EWZbasX3uiHQFQvgsu

---
_Generated by [Claude Code](https://claude.ai/code/session_01RoB8EWZbasX3uiHQFQvgsu)_