### PR TITLE
fix(kyc): redirect on didit:status_updated so manual review doesn't leave user on blank screen

### DIFF
--- a/app/(protected)/(tabs)/kyc.tsx
+++ b/app/(protected)/(tabs)/kyc.tsx
@@ -52,15 +52,38 @@ export default function KycWeb() {
       }
     };
 
-    // With manual review enabled the SDK does not auto-close after submission
-    // (`onComplete` only fires for terminal Approved/Declined states), leaving
-    // the user staring at a blank Didit screen. The `verification_submitted`
-    // event fires as soon as the questionnaire is submitted, so use it to
-    // proactively send the user to /card/pending where the polling continues.
+    // With manual review enabled the SDK never fires `didit:completed` (that
+    // only fires for terminal Approved/Declined states), so `onComplete` won't
+    // run for a Pending/In Review session. The user then stares at a blank
+    // Didit screen. We listen to the SDK's lower-level events instead:
+    //   - `verification_submitted` fires as soon as the user finishes the
+    //     verification flow (including the questionnaire);
+    //   - `status_updated` fires when Didit reports a new status, which is
+    //     where Pending/In Review actually arrives for manual-review sessions.
+    // Either one is enough to send the user to /card/pending where the polling
+    // takes over.
     DiditSdk.shared.onEvent = event => {
-      if (event.type === 'didit:verification_submitted' && hasStartedRef.current) {
+      if (!hasStartedRef.current) return;
+
+      if (event.type === 'didit:verification_submitted') {
         hasStartedRef.current = false;
         onVerificationPending();
+        return;
+      }
+
+      if (event.type === 'didit:status_updated') {
+        const status = event.data?.status;
+        if (status === 'Approved') {
+          hasStartedRef.current = false;
+          onVerificationComplete();
+        } else if (status === 'Declined') {
+          hasStartedRef.current = false;
+          onVerificationError('Your identity verification was declined.');
+        } else if (status && status !== 'Not Started' && status !== 'In Progress') {
+          // 'Pending', 'In Review', 'Resubmitted', etc.
+          hasStartedRef.current = false;
+          onVerificationPending();
+        }
       }
     };
 

--- a/app/(protected)/(tabs)/kyc.tsx
+++ b/app/(protected)/(tabs)/kyc.tsx
@@ -54,14 +54,15 @@ export default function KycWeb() {
 
     // With manual review enabled the SDK never fires `didit:completed` (that
     // only fires for terminal Approved/Declined states), so `onComplete` won't
-    // run for a Pending/In Review session. The user then stares at a blank
-    // Didit screen. We listen to the SDK's lower-level events instead:
+    // run for an In Review session. The user then stares at a blank Didit
+    // screen. We listen to the SDK's lower-level events instead:
     //   - `verification_submitted` fires as soon as the user finishes the
     //     verification flow (including the questionnaire);
-    //   - `status_updated` fires when Didit reports a new status, which is
-    //     where Pending/In Review actually arrives for manual-review sessions.
-    // Either one is enough to send the user to /card/pending where the polling
-    // takes over.
+    //   - `status_updated` fires whenever Didit reports a new status. Per
+    //     the Didit docs the values surfaced here are: Not Started,
+    //     In Progress, Approved, Declined, In Review, Awaiting User,
+    //     Resubmitted, Expired, Abandoned, Kyc Expired. ('Pending' shows up
+    //     in `onComplete` only, not here.)
     DiditSdk.shared.onEvent = event => {
       if (!hasStartedRef.current) return;
 
@@ -73,16 +74,33 @@ export default function KycWeb() {
 
       if (event.type === 'didit:status_updated') {
         const status = event.data?.status;
-        if (status === 'Approved') {
-          hasStartedRef.current = false;
-          onVerificationComplete();
-        } else if (status === 'Declined') {
-          hasStartedRef.current = false;
-          onVerificationError('Your identity verification was declined.');
-        } else if (status && status !== 'Not Started' && status !== 'In Progress') {
-          // 'Pending', 'In Review', 'Resubmitted', etc.
-          hasStartedRef.current = false;
-          onVerificationPending();
+        switch (status) {
+          case 'Approved':
+            hasStartedRef.current = false;
+            onVerificationComplete();
+            break;
+          case 'Declined':
+            hasStartedRef.current = false;
+            onVerificationError('Your identity verification was declined.');
+            break;
+          case 'Expired':
+          case 'Kyc Expired':
+            hasStartedRef.current = false;
+            onVerificationError('Your verification session expired. Please try again.');
+            break;
+          case 'Abandoned':
+            hasStartedRef.current = false;
+            onVerificationError('Your verification was abandoned. Please try again.');
+            break;
+          case 'In Review':
+          case 'Resubmitted':
+            hasStartedRef.current = false;
+            onVerificationPending();
+            break;
+          // 'Not Started', 'In Progress', 'Awaiting User' — keep the user in
+          // the widget; they still have something to do or are mid-flow.
+          default:
+            break;
         }
       }
     };


### PR DESCRIPTION
## Summary

Follow-up to PR #1994. After landing the previous fix on qa, users with manual-review Didit verification still got stuck on the blank `/kyc` screen because `didit:verification_submitted` alone doesn't always fire reliably after the questionnaire step.

This adds a second event listener for `didit:status_updated` so that as soon as Didit reports a status of `Pending`, `In Review`, `Resubmitted`, `Approved`, or `Declined`, the user is redirected from `/kyc` to the appropriate destination (`/card/pending` for under-review states, `/card/ready` or `/card/activate` for Approved, error toast for Declined).

## Test plan
- [ ] Run Didit KYC end-to-end with manual review enabled — confirm redirect to `/card/pending` after questionnaire submission instead of staying on a blank `/kyc` screen.
- [ ] Run Didit KYC where verification auto-approves — confirm existing happy-path redirect still works.
- [ ] Run Didit KYC where verification is auto-declined — confirm existing decline toast still surfaces.

https://claude.ai/code/session_01RoB8EWZbasX3uiHQFQvgsu

---
_Generated by [Claude Code](https://claude.ai/code/session_01RoB8EWZbasX3uiHQFQvgsu)_