### PR TITLE
fix(kyc): attach Didit handlers after reset, not before

### DIFF
--- a/app/(protected)/(tabs)/kyc.tsx
+++ b/app/(protected)/(tabs)/kyc.tsx
@@ -27,6 +27,13 @@ export default function KycWeb() {
 
     hasStartedRef.current = true;
 
+    // Reset BEFORE wiring handlers. `DiditSdk.reset()` is a static method that
+    // destroys the singleton (`_instance = null`), so the next `DiditSdk.shared`
+    // access creates a fresh instance. If we attach `onComplete` / `onEvent`
+    // before resetting, the handlers land on the about-to-be-destroyed instance
+    // and the new instance silently has no callbacks at all.
+    DiditSdk.reset();
+
     DiditSdk.shared.onComplete = result => {
       switch (result.type) {
         case 'completed':
@@ -36,8 +43,7 @@ export default function KycWeb() {
           } else if (result.session?.status === 'Declined') {
             onVerificationError('Your identity verification was declined.');
           } else {
-            // 'Pending', 'In Review', etc. — redirect back to activate page
-            // so user sees "Under Review" state instead of blank page
+            // 'Pending' shows up here for manual-review sessions.
             onVerificationPending();
           }
           break;
@@ -105,8 +111,6 @@ export default function KycWeb() {
       }
     };
 
-    // Reset any previous SDK state so the embed container can be reused on retry
-    DiditSdk.reset();
     DiditSdk.shared.startVerification({
       url: verificationUrl,
       configuration: {


### PR DESCRIPTION
DiditSdk.reset() is a static method that destroys the singleton instance (_instance = null). The next access to DiditSdk.shared lazily creates a fresh instance, which means the previous order — set onComplete / onEvent, then reset, then startVerification — was attaching callbacks to an instance that was about to be thrown away. The new instance ran the verification with no callbacks at all, so the user never saw a redirect when the questionnaire was submitted under manual review and stayed on a blank Didit screen on /kyc.

Move the reset call to the very start of the effect so handlers are attached to the same instance that runs the verification.