### PR TITLE
fix(kyc): attach Didit handlers after reset, not before

### DIFF
--- a/app/(protected)/(tabs)/kyc.tsx
+++ b/app/(protected)/(tabs)/kyc.tsx
@@ -60,54 +60,48 @@ export default function KycWeb() {
 
     // With manual review enabled the SDK never fires `didit:completed` (that
     // only fires for terminal Approved/Declined states), so `onComplete` won't
-    // run for an In Review session. The user then stares at a blank Didit
-    // screen. We listen to the SDK's lower-level events instead:
-    //   - `verification_submitted` fires as soon as the user finishes the
-    //     verification flow (including the questionnaire);
-    //   - `status_updated` fires whenever Didit reports a new status. Per
-    //     the Didit docs the values surfaced here are: Not Started,
-    //     In Progress, Approved, Declined, In Review, Awaiting User,
-    //     Resubmitted, Expired, Abandoned, Kyc Expired. ('Pending' shows up
-    //     in `onComplete` only, not here.)
+    // run for an In Review session and the user just stares at a blank Didit
+    // screen. We listen to `didit:status_updated` to catch the moment Didit
+    // moves the session into a review/terminal state. Per the Didit docs the
+    // values that surface here are: Not Started, In Progress, Approved,
+    // Declined, In Review, Awaiting User, Resubmitted, Expired, Abandoned,
+    // Kyc Expired. ('Pending' shows up in `onComplete` only.)
+    //
+    // Note: `didit:verification_submitted` fires for every step (document,
+    // selfie, questionnaire), so it can't be used to detect that the user
+    // has finished the entire flow.
     DiditSdk.shared.onEvent = event => {
       if (!hasStartedRef.current) return;
+      if (event.type !== 'didit:status_updated') return;
 
-      if (event.type === 'didit:verification_submitted') {
-        hasStartedRef.current = false;
-        onVerificationPending();
-        return;
-      }
-
-      if (event.type === 'didit:status_updated') {
-        const status = event.data?.status;
-        switch (status) {
-          case 'Approved':
-            hasStartedRef.current = false;
-            onVerificationComplete();
-            break;
-          case 'Declined':
-            hasStartedRef.current = false;
-            onVerificationError('Your identity verification was declined.');
-            break;
-          case 'Expired':
-          case 'Kyc Expired':
-            hasStartedRef.current = false;
-            onVerificationError('Your verification session expired. Please try again.');
-            break;
-          case 'Abandoned':
-            hasStartedRef.current = false;
-            onVerificationError('Your verification was abandoned. Please try again.');
-            break;
-          case 'In Review':
-          case 'Resubmitted':
-            hasStartedRef.current = false;
-            onVerificationPending();
-            break;
-          // 'Not Started', 'In Progress', 'Awaiting User' — keep the user in
-          // the widget; they still have something to do or are mid-flow.
-          default:
-            break;
-        }
+      const status = event.data?.status;
+      switch (status) {
+        case 'Approved':
+          hasStartedRef.current = false;
+          onVerificationComplete();
+          break;
+        case 'Declined':
+          hasStartedRef.current = false;
+          onVerificationError('Your identity verification was declined.');
+          break;
+        case 'Expired':
+        case 'Kyc Expired':
+          hasStartedRef.current = false;
+          onVerificationError('Your verification session expired. Please try again.');
+          break;
+        case 'Abandoned':
+          hasStartedRef.current = false;
+          onVerificationError('Your verification was abandoned. Please try again.');
+          break;
+        case 'In Review':
+        case 'Resubmitted':
+          hasStartedRef.current = false;
+          onVerificationPending();
+          break;
+        // 'Not Started', 'In Progress', 'Awaiting User' — keep the user in
+        // the widget; they still have something to do or are mid-flow.
+        default:
+          break;
       }
     };
 

--- a/app/(protected)/(tabs)/kyc.tsx
+++ b/app/(protected)/(tabs)/kyc.tsx
@@ -27,6 +27,13 @@ export default function KycWeb() {
 
     hasStartedRef.current = true;
 
+    // Reset BEFORE wiring handlers. `DiditSdk.reset()` is a static method that
+    // destroys the singleton (`_instance = null`), so the next `DiditSdk.shared`
+    // access creates a fresh instance. If we attach `onComplete` / `onEvent`
+    // before resetting, the handlers land on the about-to-be-destroyed instance
+    // and the new instance silently has no callbacks at all.
+    DiditSdk.reset();
+
     DiditSdk.shared.onComplete = result => {
       switch (result.type) {
         case 'completed':
@@ -36,8 +43,7 @@ export default function KycWeb() {
           } else if (result.session?.status === 'Declined') {
             onVerificationError('Your identity verification was declined.');
           } else {
-            // 'Pending', 'In Review', etc. — redirect back to activate page
-            // so user sees "Under Review" state instead of blank page
+            // 'Pending' shows up here for manual-review sessions.
             onVerificationPending();
           }
           break;
@@ -105,8 +111,6 @@ export default function KycWeb() {
       }
     };
 
-    // Reset any previous SDK state so the embed container can be reused on retry
-    DiditSdk.reset();
     DiditSdk.shared.startVerification({
       url: verificationUrl,
       configuration: {


### PR DESCRIPTION
DiditSdk.reset() is a static method that destroys the singleton instance (_instance = null). The next access to DiditSdk.shared lazily creates a fresh instance, which means the previous order — set onComplete / onEvent, then reset, then startVerification — was attaching callbacks to an instance that was about to be thrown away. The new instance ran the verification with no callbacks at all, so the user never saw a redirect when the questionnaire was submitted under manual review and stayed on a blank Didit screen on /kyc.

Move the reset call to the very start of the effect so handlers are attached to the same instance that runs the verification.