### PR TITLE
fix(kyc): redirect to /card/pending when Rain KYC is in manual review

### DIFF
--- a/components/kyc/useDiditSession.ts
+++ b/components/kyc/useDiditSession.ts
@@ -70,13 +70,19 @@ export function useDiditSession() {
       queryClient.invalidateQueries({ queryKey: [CARD_STATUS_QUERY_KEY] });
 
       if (kycStatus === KycStatus.APPROVED) {
-        // Didit KYC approved: only go to ready page when Rain is also approved.
-        // Otherwise redirect to activate page so the user sees the dynamic
-        // step-one button (e.g. "Provide more info" for Rain needsInformation).
+        // Didit KYC approved: route by Rain status. Approved -> ready.
+        // Manual review (Rain pending/manualReview, which maps to backend
+        // kycStatus = under_review) -> pending so the user sees the review
+        // state. Anything else (needsInformation/needsVerification) ->
+        // activate so they see the step-one button.
         try {
           const cardStatusResponse = await withRefreshToken(() => getCardStatus());
           if (cardStatusResponse?.rainApplicationStatus === RainApplicationStatus.APPROVED) {
             router.replace(path.CARD_READY as any);
+            return;
+          }
+          if (cardStatusResponse?.kycStatus === KycStatus.UNDER_REVIEW) {
+            router.replace(path.CARD_PENDING as any);
             return;
           }
         } catch {
@@ -131,18 +137,19 @@ export function useDiditSession() {
         const status = await withRefreshToken(() => getDiditVerificationStatus());
         if (!status) return;
 
-        if (status.status === 'Approved' || status.kycStatus === 'approved') {
-          clearInterval(interval);
-          onVerificationComplete();
-        } else if (status.status === 'Declined' || status.kycStatus === 'rejected') {
-          clearInterval(interval);
-          onVerificationError('Your identity verification was declined. Please try again.');
-        } else if (
-          status.status === 'In Review' ||
-          status.kycStatus === KycStatus.UNDER_REVIEW
-        ) {
+        // Backend kycStatus is the canonical source — it reflects the full
+        // pipeline (Didit + Rain) so check it before the Didit-only
+        // status.status. A Didit `Approved` with kycStatus `under_review`
+        // means manual review is in progress and should route to pending.
+        if (status.kycStatus === KycStatus.UNDER_REVIEW || status.status === 'In Review') {
           clearInterval(interval);
           onVerificationPending();
+        } else if (status.kycStatus === KycStatus.REJECTED || status.status === 'Declined') {
+          clearInterval(interval);
+          onVerificationError('Your identity verification was declined. Please try again.');
+        } else if (status.kycStatus === KycStatus.APPROVED || status.status === 'Approved') {
+          clearInterval(interval);
+          onVerificationComplete();
         }
       } catch {
         // silently retry on network errors


### PR DESCRIPTION
## Summary
Fixes the KYC redirect when Solid's manual review (via Rain `pending` / `manualReview`) is in progress. After the user finishes the Didit form, the page was stuck at `/kyc` showing "Verification complete! Redirecting…" or landing on `/card/activate` instead of `/card/pending`.

## Root cause
Didit's web SDK fires `onComplete` with `Approved` as soon as the user submits the questionnaire, even when the application still needs manual review on the Rain side. `useDiditSession.redirectBasedOnKycStatus` was hardcoded to call `redirectBasedOnKycStatus(KycStatus.APPROVED)` from `onVerificationComplete`, and the APPROVED branch only handled Rain `APPROVED` → `/card/ready`, falling through to `/card/activate` for everything else. There was no branch for the manual-review-in-progress state, so users got the activation step list instead of the pending screen.

## Fix
In `components/kyc/useDiditSession.ts`:

1. **`redirectBasedOnKycStatus` (APPROVED branch)** — after `getCardStatus()`, if `cardStatusResponse.kycStatus === UNDER_REVIEW` (which is what Rain `pending` / `manualReview` map to via `mapRainApplicationStatusToKycStatus`, and what the backend sets at webhook time before `forwardToRain` finishes), redirect to `/card/pending` instead of falling through to `/card/activate`.
2. **Polling fallback** — reordered the priority so the canonical backend `kycStatus` is checked before the Didit-only `status.status`. `kycStatus === 'under_review'` now wins over `status.status === 'Approved'`, which would otherwise have hit the same wrong-branch bug if the SDK callbacks were missed.

No backend change needed — the webhook handler already sets `kycStatus = UNDER_REVIEW` for both Didit `Approved` (pre-Rain) and `In Review`, and `mapRainApplicationStatusToKycStatus` already maps Rain `pending` / `manualReview` to `UNDER_REVIEW`.

## Test plan
- [ ] Complete a Didit KYC where the application requires manual review on Rain → should land on `/card/pending`.
- [ ] Complete a Didit KYC where Rain auto-approves → should land on `/card/ready`.
- [ ] Complete a Didit KYC where Rain returns `needsInformation` / `needsVerification` → should land on `/card/activate`.
- [ ] Decline / fail Didit verification → error toast, stays on `/kyc`.

https://claude.ai/code/session_014YuRpztcuaGS56tbrjugmH