### PR TITLE
feat(card-pending): poll KYC status and redirect on transition

### DIFF
--- a/app/(protected)/(tabs)/card/pending.tsx
+++ b/app/(protected)/(tabs)/card/pending.tsx
@@ -1,6 +1,52 @@
+import { useEffect } from 'react';
+import { useRouter } from 'expo-router';
+
 import { CardStatusPage } from '@/components/Card/CardStatusPage';
+import { path } from '@/constants/path';
+import { useCardStatus } from '@/hooks/useCardStatus';
+import { CardStatus, KycStatus, RainApplicationStatus } from '@/lib/types';
+import { hasCard } from '@/lib/utils';
+
+const POLL_INTERVAL_MS = 5000;
 
 export default function CardPending() {
+  const router = useRouter();
+  const { data: cardStatusResponse } = useCardStatus({ refetchInterval: POLL_INTERVAL_MS });
+
+  useEffect(() => {
+    if (!cardStatusResponse) return;
+
+    // User already has a card (e.g. status synced after this tab was open).
+    if (hasCard(cardStatusResponse) && cardStatusResponse.status !== CardStatus.PENDING) {
+      router.replace(path.CARD_DETAILS);
+      return;
+    }
+
+    const { kycStatus, rainApplicationStatus } = cardStatusResponse;
+
+    // Still under manual review — keep showing the pending page.
+    if (kycStatus === KycStatus.UNDER_REVIEW) return;
+
+    // Didit approved.
+    if (kycStatus === KycStatus.APPROVED) {
+      if (rainApplicationStatus === RainApplicationStatus.APPROVED) {
+        router.replace(path.CARD_READY);
+      } else {
+        // Rain still needs to finish (pending, needsInformation, etc.) — let
+        // the activate page render the appropriate next step / status.
+        router.replace(path.CARD_ACTIVATE);
+      }
+      return;
+    }
+
+    // Any other terminal/incomplete state (rejected, offboarded, incomplete,
+    // resubmitted, etc.) — bounce back to the activate page so the user sees
+    // the error or retry CTA.
+    if (kycStatus && kycStatus !== KycStatus.NOT_STARTED) {
+      router.replace(`${String(path.CARD_ACTIVATE)}?kycStatus=${kycStatus}` as any);
+    }
+  }, [cardStatusResponse, router]);
+
   return (
     <CardStatusPage
       title="Your card is on its way!"


### PR DESCRIPTION
The /card/pending page was a static placeholder. Now that we redirect users here as soon as Didit reports In Review, it needs to actually react to status changes. Poll card status every 5s and redirect:
- Didit Approved + Rain Approved -> /card/ready
- Didit Approved + Rain not yet Approved -> /card/activate (so the activate page surfaces the next Rain step)
- User already has a non-pending card -> /card/details
- Any other terminal/incomplete KYC state -> /card/activate with the kycStatus query param so the activate page can show the right copy
- KYC still UNDER_REVIEW -> stay on /card/pending