### PR TITLE
feat: standardize back buttons via shared BackButton component

### DIFF
--- a/app/(protected)/(tabs)/activity/[clientTxId].tsx
+++ b/app/(protected)/(tabs)/activity/[clientTxId].tsx
@@ -4,7 +4,7 @@ import { useLocalSearchParams, useRouter } from 'expo-router';
 import * as Sentry from '@sentry/react-native';
 import { useQuery } from '@tanstack/react-query';
 import { format, formatDistanceStrict, minutesToSeconds } from 'date-fns';
-import { ArrowUpRight, ChevronLeft, X } from 'lucide-react-native';
+import { ArrowUpRight, X } from 'lucide-react-native';
 import { mainnet } from 'viem/chains';
 
 import Diamond from '@/assets/images/diamond';
@@ -13,6 +13,7 @@ import CopyToClipboard from '@/components/CopyToClipboard';
 import EstimatedTime from '@/components/EstimatedTime';
 import PageLayout from '@/components/PageLayout';
 import RenderTokenIcon from '@/components/RenderTokenIcon';
+import { BackButton } from '@/components/ui/back-button';
 import { Button } from '@/components/ui/button';
 import { Text } from '@/components/ui/text';
 import { Underline } from '@/components/ui/underline';
@@ -122,12 +123,9 @@ const Back = memo(function Back({ title, className }: BackProps) {
 
   return (
     <View className="relative flex-row items-center justify-center">
-      <Pressable
-        onPress={handleBackPress}
-        className="absolute left-0 web:hover:opacity-70"
-      >
-        <ChevronLeft color="white" />
-      </Pressable>
+      <View className="absolute left-0">
+        <BackButton onPress={handleBackPress} />
+      </View>
       <Text className={cn('text-center text-lg font-semibold text-white', className)}>{title}</Text>
     </View>
   );

--- a/app/(protected)/(tabs)/add-referrer.tsx
+++ b/app/(protected)/(tabs)/add-referrer.tsx
@@ -1,10 +1,10 @@
 import React, { useEffect, useState } from 'react';
-import { ActivityIndicator, Pressable, TextInput, View } from 'react-native';
+import { ActivityIndicator, TextInput, View } from 'react-native';
 import { router } from 'expo-router';
-import { ArrowLeft } from 'lucide-react-native';
 
 import InfoError from '@/assets/images/info-error';
 import PageLayout from '@/components/PageLayout';
+import { BackButton } from '@/components/ui/back-button';
 import { Button } from '@/components/ui/button';
 import { Text } from '@/components/ui/text';
 import { path } from '@/constants/path';
@@ -68,9 +68,7 @@ export default function AddReferrer() {
       <View className="mx-auto w-full max-w-lg flex-1 justify-center gap-10 px-4 py-8">
         <View className="mx-auto w-full gap-5 md:gap-5">
           <View className="flex-row items-center justify-between">
-            <Pressable onPress={() => router.back()} className="web:hover:opacity-70">
-              <ArrowLeft color="white" />
-            </Pressable>
+            <BackButton />
             <Text className="text-center text-lg font-semibold text-white md:text-xl">
               Enter your friend&apos;s referral code
             </Text>

--- a/app/(protected)/(tabs)/bridge-kyc.tsx
+++ b/app/(protected)/(tabs)/bridge-kyc.tsx
@@ -1,9 +1,9 @@
 import React, { useEffect, useRef, useState } from 'react';
-import { Pressable, StyleSheet, View } from 'react-native';
+import { StyleSheet, View } from 'react-native';
 import { useLocalSearchParams, useRouter } from 'expo-router';
-import { ArrowLeft } from 'lucide-react-native';
 
 import PageLayout from '@/components/PageLayout';
+import { BackButton } from '@/components/ui/back-button';
 import { Text } from '@/components/ui/text';
 import { TRACKING_EVENTS } from '@/constants/tracking-events';
 import { track } from '@/lib/analytics';
@@ -246,12 +246,7 @@ export default function BridgeKyc({ onSuccess }: BridgeKycParams = {}) {
     <PageLayout desktopOnly>
       <View className="mx-auto w-full max-w-lg flex-1 pt-8">
         <View className="flex-row items-center justify-between">
-          <Pressable
-            onPress={() => (router.canGoBack() ? router.back() : router.replace('/'))}
-            className="web:hover:opacity-70"
-          >
-            <ArrowLeft color="white" />
-          </Pressable>
+          <BackButton />
           <Text className="text-center text-xl font-semibold text-white md:text-2xl">
             Verify identity
           </Text>

--- a/app/(protected)/(tabs)/card-onboard/country-verification-required.tsx
+++ b/app/(protected)/(tabs)/card-onboard/country-verification-required.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
-import { Pressable, View } from 'react-native';
+import { View } from 'react-native';
 import { useRouter } from 'expo-router';
-import { ArrowLeft, ShieldAlert } from 'lucide-react-native';
+import { ShieldAlert } from 'lucide-react-native';
 
 import PageLayout from '@/components/PageLayout';
+import { BackButton } from '@/components/ui/back-button';
 import { Button } from '@/components/ui/button';
 import { Text } from '@/components/ui/text';
 import { path } from '@/constants/path';
@@ -42,9 +43,7 @@ export default function CountryVerificationRequired() {
       <View className="mx-auto w-full max-w-lg px-4 pt-12">
         {/* Header */}
         <View className="mb-10 flex-row items-center justify-between">
-          <Pressable onPress={goBack} className="web:hover:opacity-70">
-            <ArrowLeft color="white" />
-          </Pressable>
+          <BackButton onPress={goBack} />
           <Text className="text-center text-xl font-semibold text-white md:text-2xl">
             Verification Required
           </Text>

--- a/app/(protected)/(tabs)/card-onboard/country_selection.tsx
+++ b/app/(protected)/(tabs)/card-onboard/country_selection.tsx
@@ -9,12 +9,13 @@ import {
   View,
 } from 'react-native';
 import { useRouter } from 'expo-router';
-import { ArrowLeft, ChevronDown } from 'lucide-react-native';
+import { ChevronDown } from 'lucide-react-native';
 import { useShallow } from 'zustand/react/shallow';
 
 import CountryFlagImage from '@/components/CountryFlagImage';
 import { NotificationEmailModalDialog } from '@/components/NotificationEmailModal/NotificationEmailModalDialog';
 import PageLayout from '@/components/PageLayout';
+import { BackButton } from '@/components/ui/back-button';
 import { Button } from '@/components/ui/button';
 import { Text } from '@/components/ui/text';
 import { COUNTRIES, Country } from '@/constants/countries';
@@ -330,9 +331,7 @@ export default function CountrySelection() {
       />
       <View className="mx-auto w-full max-w-lg px-4 pt-12">
         <View className="mb-10 flex-row items-center justify-between">
-          <Pressable onPress={goBack} className="web:hover:opacity-70">
-            <ArrowLeft color="white" />
-          </Pressable>
+          <BackButton onPress={goBack} />
           <Text className="text-center text-xl font-semibold text-white md:text-2xl">
             Solid card
           </Text>

--- a/app/(protected)/(tabs)/card/activate/country_selection.tsx
+++ b/app/(protected)/(tabs)/card/activate/country_selection.tsx
@@ -1,11 +1,12 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import { ActivityIndicator, Modal, Pressable, ScrollView, TextInput, View } from 'react-native';
 import { useRouter } from 'expo-router';
-import { ArrowLeft, ChevronDown } from 'lucide-react-native';
+import { ChevronDown } from 'lucide-react-native';
 import { useShallow } from 'zustand/react/shallow';
 
 import CountryFlagImage from '@/components/CountryFlagImage';
 import PageLayout from '@/components/PageLayout';
+import { BackButton } from '@/components/ui/back-button';
 import { Button } from '@/components/ui/button';
 import { Text } from '@/components/ui/text';
 import { COUNTRIES, Country } from '@/constants/countries';
@@ -260,9 +261,7 @@ export default function ActivateCountrySelection() {
     <PageLayout desktopOnly>
       <View className="mx-auto w-full max-w-lg px-4 pt-12">
         <View className="mb-10 flex-row items-center justify-between">
-          <Pressable onPress={goBack} className="web:hover:opacity-70">
-            <ArrowLeft color="white" />
-          </Pressable>
+          <BackButton onPress={goBack} />
           <Text className="text-center text-xl font-semibold text-white md:text-2xl">
             Solid card
           </Text>

--- a/app/(protected)/(tabs)/card/deposit.tsx
+++ b/app/(protected)/(tabs)/card/deposit.tsx
@@ -3,10 +3,10 @@ import { ActivityIndicator, Pressable, View } from 'react-native';
 import Toast from 'react-native-toast-message';
 import { Image } from 'expo-image';
 import { useRouter } from 'expo-router';
-import { ArrowLeft } from 'lucide-react-native';
 import { Address, formatUnits } from 'viem';
 
 import PageLayout from '@/components/PageLayout';
+import { BackButton } from '@/components/ui/back-button';
 import { Button } from '@/components/ui/button';
 import { Text } from '@/components/ui/text';
 import { TRACKING_EVENTS } from '@/constants/tracking-events';
@@ -216,9 +216,7 @@ const DepositToCard = () => {
     <PageLayout desktopOnly contentClassName="px-4 py-8">
       <View className="mx-auto h-full w-full max-w-md">
         <View className="mb-8 flex-row items-center justify-between">
-          <Pressable onPress={() => router.back()} className="web:hover:opacity-70">
-            <ArrowLeft color="white" />
-          </Pressable>
+          <BackButton />
           <Text className="text-center text-xl font-semibold md:text-2xl">Deposit to card</Text>
           <View className="w-6" />
         </View>

--- a/app/(protected)/(tabs)/card/details/transactions.tsx
+++ b/app/(protected)/(tabs)/card/details/transactions.tsx
@@ -3,13 +3,14 @@ import { ActivityIndicator, Platform, Pressable, RefreshControl, View } from 're
 import { useRouter } from 'expo-router';
 import { FlashList } from '@shopify/flash-list';
 import { useQueryClient } from '@tanstack/react-query';
-import { ArrowLeft, RotateCw } from 'lucide-react-native';
+import { RotateCw } from 'lucide-react-native';
 
 import Loading from '@/components/Loading';
 import PageLayout from '@/components/PageLayout';
 import RenderTokenIcon from '@/components/RenderTokenIcon';
 import TransactionDrawer from '@/components/Transaction/TransactionDrawer';
 import TransactionDropdown from '@/components/Transaction/TransactionDropdown';
+import { BackButton } from '@/components/ui/back-button';
 import { Text } from '@/components/ui/text';
 import { path } from '@/constants/path';
 import { useCardProvider } from '@/hooks/useCardProvider';
@@ -156,14 +157,7 @@ export default function CardTransactions() {
       <View className="mx-auto w-full max-w-[600px] flex-1">
         <View className="px-8 pt-8">
           <View className="mb-8 flex-row items-center justify-between">
-            <Pressable
-              onPress={() =>
-                router.canGoBack() ? router.back() : router.replace(path.CARD_DETAILS)
-              }
-              className="web:hover:opacity-70"
-            >
-              <ArrowLeft color="white" />
-            </Pressable>
+            <BackButton fallbackHref={path.CARD_DETAILS} />
             <Text className="text-center text-xl font-semibold text-white md:text-2xl">
               Solid card transactions
             </Text>

--- a/app/(protected)/(tabs)/referral.tsx
+++ b/app/(protected)/(tabs)/referral.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import { Pressable, View } from 'react-native';
+import { View } from 'react-native';
 import { Image } from 'expo-image';
-import { Link, router } from 'expo-router';
-import { ArrowLeft } from 'lucide-react-native';
+import { Link } from 'expo-router';
 
 import CopyToClipboard from '@/components/CopyToClipboard';
 import PageLayout from '@/components/PageLayout';
+import { BackButton } from '@/components/ui/back-button';
 import { Text } from '@/components/ui/text';
 import { path } from '@/constants/path';
 import useUser from '@/hooks/useUser';
@@ -19,9 +19,7 @@ export default function Referral() {
       <View className="mx-auto w-full max-w-lg flex-1 justify-center gap-10 px-4 py-8">
         <View className="mx-auto w-full gap-5 md:gap-5">
           <View className="flex-row items-center justify-between">
-            <Pressable onPress={() => router.back()} className="web:hover:opacity-70">
-              <ArrowLeft color="white" />
-            </Pressable>
+            <BackButton />
             <Text className="text-center text-lg font-semibold text-white md:text-xl">
               Share your referral code
             </Text>

--- a/app/(protected)/(tabs)/rewards/benefits.tsx
+++ b/app/(protected)/(tabs)/rewards/benefits.tsx
@@ -1,11 +1,11 @@
-import { Pressable, View } from 'react-native';
+import { View } from 'react-native';
 import { router } from 'expo-router';
-import { ArrowLeft } from 'lucide-react-native';
 
 import PageLayout from '@/components/PageLayout';
 import CompareTiersTable from '@/components/Rewards/CompareTiersTable';
 import EarnPointsSection from '@/components/Rewards/EarnPointsSection';
 import TierFeesTable from '@/components/Rewards/TierFeesTable';
+import { BackButton } from '@/components/ui/back-button';
 import { Text } from '@/components/ui/text';
 import { path } from '@/constants/path';
 import { useDimension } from '@/hooks/useDimension';
@@ -23,12 +23,7 @@ export default function RewardsBenefits() {
     <PageLayout isLoading={isLoading}>
       <View className="mx-auto w-full max-w-7xl gap-8 px-4 pb-24 pt-6 md:gap-12 md:py-12">
         <View className="flex-row items-center gap-6">
-          <Pressable
-            onPress={() => router.push(path.REWARDS)}
-            className="flex h-10 w-10 items-center justify-center rounded-full border-0 bg-popover web:transition-colors web:hover:bg-muted"
-          >
-            <ArrowLeft size={24} color="#FFFFFF" />
-          </Pressable>
+          <BackButton onPress={() => router.push(path.REWARDS)} />
           <Text className="text-2xl font-semibold opacity-50">Rewards</Text>
         </View>
 

--- a/app/(protected)/(tabs)/settings/account.tsx
+++ b/app/(protected)/(tabs)/settings/account.tsx
@@ -1,8 +1,7 @@
 import { useState } from 'react';
 import { ActivityIndicator, Alert, Modal, Pressable, Text, View } from 'react-native';
 import { Image } from 'expo-image';
-import { router } from 'expo-router';
-import { ArrowLeft, ChevronLeft, ChevronRight, X } from 'lucide-react-native';
+import { ChevronRight, X } from 'lucide-react-native';
 import { Address } from 'viem';
 
 import WalletIcon from '@/assets/images/wallet';
@@ -10,6 +9,7 @@ import CopyToClipboard from '@/components/CopyToClipboard';
 import Navbar from '@/components/Navbar';
 import PageLayout from '@/components/PageLayout';
 import { SettingsCard } from '@/components/Settings';
+import { BackButton } from '@/components/ui/back-button';
 import { useDimension } from '@/hooks/useDimension';
 import useUser from '@/hooks/useUser';
 import { getAsset } from '@/lib/assets';
@@ -41,9 +41,7 @@ export default function Account() {
 
   const mobileHeader = (
     <View className="flex-row items-center justify-between px-4 py-3">
-      <Pressable onPress={() => router.back()} className="p-2">
-        <ChevronLeft size={24} color="#ffffff" />
-      </Pressable>
+      <BackButton />
       <Text className="mr-10 flex-1 text-center text-xl font-bold text-white">Account details</Text>
     </View>
   );
@@ -53,9 +51,7 @@ export default function Account() {
       <Navbar />
       <View className="mx-auto w-full max-w-[512px] px-4 pb-8 pt-8">
         <View className="mb-8 flex-row items-center justify-between">
-          <Pressable onPress={() => router.back()} className="web:hover:opacity-70">
-            <ArrowLeft color="white" />
-          </Pressable>
+          <BackButton />
           <Text className="text-3xl font-semibold text-white">Account details</Text>
           <View className="w-6" />
         </View>

--- a/app/(protected)/(tabs)/settings/email.tsx
+++ b/app/(protected)/(tabs)/settings/email.tsx
@@ -1,13 +1,13 @@
 import { useEffect, useRef } from 'react';
 import { Controller } from 'react-hook-form';
-import { ActivityIndicator, Pressable, TextInput, View } from 'react-native';
+import { ActivityIndicator, TextInput, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useRouter } from 'expo-router';
-import { ArrowLeft, ChevronLeft } from 'lucide-react-native';
 
 import Checkmark from '@/assets/images/checkmark';
 import Navbar from '@/components/Navbar';
 import PageLayout from '@/components/PageLayout';
+import { BackButton } from '@/components/ui/back-button';
 import { Button } from '@/components/ui/button';
 import { Text } from '@/components/ui/text';
 import { useDimension } from '@/hooks/useDimension';
@@ -60,9 +60,7 @@ export default function Email() {
 
   const mobileHeader = (
     <View className="flex-row items-center justify-between px-4 py-3">
-      <Pressable onPress={() => router.back()} className="p-2">
-        <ChevronLeft size={24} color="#ffffff" />
-      </Pressable>
+      <BackButton />
       <Text className="mr-10 flex-1 text-center text-xl font-bold text-white">Email</Text>
     </View>
   );
@@ -72,9 +70,7 @@ export default function Email() {
       <Navbar />
       <View className="mx-auto w-full max-w-[512px] px-4 pb-8 pt-8">
         <View className="mb-8 flex-row items-center justify-between">
-          <Pressable onPress={() => router.back()} className="web:hover:opacity-70">
-            <ArrowLeft color="white" />
-          </Pressable>
+          <BackButton />
           <Text className="text-3xl font-semibold text-white">Email</Text>
           <View className="w-6" />
         </View>

--- a/app/(protected)/(tabs)/settings/help.tsx
+++ b/app/(protected)/(tabs)/settings/help.tsx
@@ -1,6 +1,4 @@
-import { Pressable, Text, View } from 'react-native';
-import { router } from 'expo-router';
-import { ArrowLeft, ChevronLeft } from 'lucide-react-native';
+import { Text, View } from 'react-native';
 
 import EmailIcon from '@/assets/images/email';
 import LegalIcon from '@/assets/images/legal';
@@ -9,6 +7,7 @@ import MessageCircle from '@/assets/images/messages';
 import Navbar from '@/components/Navbar';
 import PageLayout from '@/components/PageLayout';
 import { SettingsCard } from '@/components/Settings';
+import { BackButton } from '@/components/ui/back-button';
 import { useDimension } from '@/hooks/useDimension';
 import { openIntercom } from '@/lib/intercom';
 import { cn } from '@/lib/utils';
@@ -53,9 +52,7 @@ export default function Help() {
 
   const mobileHeader = (
     <View className="flex-row items-center justify-between px-4 py-3">
-      <Pressable onPress={() => router.back()} className="p-2">
-        <ChevronLeft size={24} color="#ffffff" />
-      </Pressable>
+      <BackButton />
       <Text className="mr-10 flex-1 text-center text-xl font-bold text-white">Help & Support</Text>
     </View>
   );
@@ -65,9 +62,7 @@ export default function Help() {
       <Navbar />
       <View className="mx-auto w-full max-w-[512px] px-4 pb-8 pt-8">
         <View className="mb-8 flex-row items-center justify-between">
-          <Pressable onPress={() => router.back()} className="web:hover:opacity-70">
-            <ArrowLeft color="white" />
-          </Pressable>
+          <BackButton />
           <Text className="text-3xl font-semibold text-white">Help & Support</Text>
           <View className="w-6" />
         </View>

--- a/app/(protected)/(tabs)/settings/security.tsx
+++ b/app/(protected)/(tabs)/settings/security.tsx
@@ -1,14 +1,13 @@
 import { lazy, Suspense, useCallback, useEffect, useState } from 'react';
 import { ActivityIndicator, Pressable, Text, View } from 'react-native';
 import { Image } from 'expo-image';
-import { router } from 'expo-router';
 import * as Sentry from '@sentry/react-native';
 import { StamperType, useTurnkey } from '@turnkey/react-native-wallet-kit';
-import { ArrowLeft, ChevronLeft } from 'lucide-react-native';
 
 import Navbar from '@/components/Navbar';
 import PageLayout from '@/components/PageLayout';
 import { SettingsCard } from '@/components/Settings';
+import { BackButton } from '@/components/ui/back-button';
 import { useDimension } from '@/hooks/useDimension';
 import useUser from '@/hooks/useUser';
 import { getTotpStatus } from '@/lib/api';
@@ -149,14 +148,7 @@ export default function Security() {
 
   const mobileHeader = (
     <View className="flex-row items-center justify-between px-4 py-3">
-      <Pressable
-        onPress={() => router.back()}
-        className="p-2"
-        accessibilityLabel="Go back"
-        accessibilityRole="button"
-      >
-        <ChevronLeft size={24} color="#ffffff" />
-      </Pressable>
+      <BackButton />
       <Text className="mr-10 flex-1 text-center text-xl font-bold text-white">Security</Text>
     </View>
   );
@@ -166,14 +158,7 @@ export default function Security() {
       <Navbar />
       <View className="mx-auto w-full max-w-[512px] px-4 pb-8 pt-8">
         <View className="mb-8 flex-row items-center justify-between">
-          <Pressable
-            onPress={() => router.back()}
-            className="web:hover:opacity-70"
-            accessibilityLabel="Go back"
-            accessibilityRole="button"
-          >
-            <ArrowLeft color="white" />
-          </Pressable>
+          <BackButton />
           <Text className="text-3xl font-semibold text-white">Security</Text>
           <View className="w-6" />
         </View>

--- a/app/(protected)/(tabs)/user-kyc-info.tsx
+++ b/app/(protected)/(tabs)/user-kyc-info.tsx
@@ -1,13 +1,13 @@
 import React, { useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
-import { Pressable, View } from 'react-native';
+import { View } from 'react-native';
 import Toast from 'react-native-toast-message';
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import { zodResolver } from '@hookform/resolvers/zod';
-import { ArrowLeft } from 'lucide-react-native';
 import { z } from 'zod';
 
 import PageLayout from '@/components/PageLayout';
+import { BackButton } from '@/components/ui/back-button';
 import { Text } from '@/components/ui/text';
 import { UserInfoFooter, UserInfoForm, UserInfoHeader } from '@/components/UserKyc';
 import { KycMode, type UserInfoFormData, userInfoSchema } from '@/components/UserKyc/types';
@@ -128,9 +128,7 @@ export default function UserKycInfo() {
     <PageLayout desktopOnly>
       <View className="mx-auto w-full max-w-lg flex-1 px-6 pt-8">
         <View className="flex-row items-center justify-between">
-          <Pressable onPress={() => router.back()} className="web:hover:opacity-70">
-            <ArrowLeft color="white" />
-          </Pressable>
+          <BackButton />
           <Text className="text-center text-xl font-semibold text-white md:text-2xl">
             Identity verification
           </Text>

--- a/app/notifications.native.tsx
+++ b/app/notifications.native.tsx
@@ -1,10 +1,10 @@
 import { useState } from 'react';
-import { Pressable, View } from 'react-native';
+import { View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useRouter } from 'expo-router';
-import { ArrowLeft } from 'lucide-react-native';
 
 import Notification from '@/assets/images/notification';
+import { BackButton } from '@/components/ui/back-button';
 import { Button } from '@/components/ui/button';
 import { Text } from '@/components/ui/text';
 import { path } from '@/constants/path';
@@ -13,10 +13,6 @@ import { registerForPushNotificationsAsync } from '@/lib/registerForPushNotifica
 export default function Notifications() {
   const router = useRouter();
   const [isLoading, setIsLoading] = useState(false);
-
-  const handleBack = () => {
-    router.back();
-  };
 
   const handleContinue = async () => {
     setIsLoading(true);
@@ -36,12 +32,7 @@ export default function Notifications() {
       <View className="flex-1 px-6">
         {/* Header with back button */}
         <View className="flex-row items-center py-3">
-          <Pressable
-            onPress={handleBack}
-            className="h-10 w-10 items-center justify-center rounded-full bg-white/10"
-          >
-            <ArrowLeft size={20} color="#ffffff" />
-          </Pressable>
+          <BackButton />
         </View>
 
         {/* Content - centered */}

--- a/app/signup/email.tsx
+++ b/app/signup/email.tsx
@@ -5,12 +5,12 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import { Image } from 'expo-image';
 import { Link, useRouter } from 'expo-router';
 import { zodResolver } from '@hookform/resolvers/zod';
-import { ArrowLeft } from 'lucide-react-native';
 import { z } from 'zod';
 import { useShallow } from 'zustand/react/shallow';
 
 import InfoError from '@/assets/images/info-error';
 import { DesktopCarousel } from '@/components/Onboarding';
+import { BackButton } from '@/components/ui/back-button';
 import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
 import Input from '@/components/ui/input';
@@ -207,12 +207,9 @@ export default function SignupEmail() {
       <View className="my-auto">
         {/* Back button - positioned above form on desktop */}
         {isDesktop && (
-          <Pressable
-            onPress={handleBack}
-            className="mb-20 h-10 w-10 items-center justify-center rounded-full bg-white/10 web:hover:bg-white/20"
-          >
-            <ArrowLeft size={20} color="#ffffff" />
-          </Pressable>
+          <View className="mb-20">
+            <BackButton onPress={handleBack} />
+          </View>
         )}
 
         {/* Header */}
@@ -316,12 +313,7 @@ export default function SignupEmail() {
         <View className="flex-1">
           {/* Header with back button */}
           <View className="flex-row items-center px-6 py-3">
-            <Pressable
-              onPress={handleBack}
-              className="h-10 w-10 items-center justify-center rounded-full bg-white/10"
-            >
-              <ArrowLeft size={20} color="#ffffff" />
-            </Pressable>
+            <BackButton onPress={handleBack} />
           </View>
 
           {/* Content - flex between to push button to bottom */}

--- a/app/signup/otp.tsx
+++ b/app/signup/otp.tsx
@@ -1,16 +1,16 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { Controller, useForm } from 'react-hook-form';
-import { ActivityIndicator, Pressable, View } from 'react-native';
+import { ActivityIndicator, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { Image } from 'expo-image';
 import { useRouter } from 'expo-router';
 import { zodResolver } from '@hookform/resolvers/zod';
-import { ArrowLeft } from 'lucide-react-native';
 import { z } from 'zod';
 import { useShallow } from 'zustand/react/shallow';
 
 import InfoError from '@/assets/images/info-error';
 import { DesktopCarousel } from '@/components/Onboarding';
+import { BackButton } from '@/components/ui/back-button';
 import { Button } from '@/components/ui/button';
 import { OtpInput } from '@/components/ui/otp-input';
 import { Text } from '@/components/ui/text';
@@ -240,12 +240,9 @@ export default function SignupOtp() {
     <View className="w-full max-w-[440px] items-center">
       {/* Back button - positioned above form on desktop */}
       {isDesktop && (
-        <Pressable
-          onPress={handleBack}
-          className="mb-20 h-10 w-10 items-center justify-center self-start rounded-full bg-white/10 web:hover:bg-white/20"
-        >
-          <ArrowLeft size={20} color="#ffffff" />
-        </Pressable>
+        <View className="mb-20 self-start">
+          <BackButton onPress={handleBack} />
+        </View>
       )}
 
       {/* Header */}
@@ -321,12 +318,7 @@ export default function SignupOtp() {
         <View className="flex-1">
           {/* Header with back button */}
           <View className="flex-row items-center px-6 py-3">
-            <Pressable
-              onPress={handleBack}
-              className="h-10 w-10 items-center justify-center rounded-full bg-white/10"
-            >
-              <ArrowLeft size={20} color="#ffffff" />
-            </Pressable>
+            <BackButton onPress={handleBack} />
           </View>
 
           {/* Content - positioned at top, centered horizontally */}

--- a/app/signup/passkey.tsx
+++ b/app/signup/passkey.tsx
@@ -1,17 +1,17 @@
 import { useEffect, useState } from 'react';
-import { ActivityIndicator, Linking, Platform, Pressable, View } from 'react-native';
+import { ActivityIndicator, Linking, Platform, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import Toast from 'react-native-toast-message';
 import { Image } from 'expo-image';
 import { useRouter } from 'expo-router';
 import * as Sentry from '@sentry/react-native';
 import { useTurnkey } from '@turnkey/react-native-wallet-kit';
-import { ArrowLeft } from 'lucide-react-native';
 import { useShallow } from 'zustand/react/shallow';
 
 import LoginKeyIcon from '@/assets/images/login_key_icon';
 import PasskeySvg from '@/assets/images/passkey-svg';
 import { DesktopCarousel } from '@/components/Onboarding';
+import { BackButton } from '@/components/ui/back-button';
 import { Button } from '@/components/ui/button';
 import { Text } from '@/components/ui/text';
 import { Underline } from '@/components/ui/underline';
@@ -137,12 +137,9 @@ export default function SignupPasskey() {
       <View className="my-auto items-center">
         {/* Back button - positioned above form on desktop */}
         {isDesktop && (
-          <Pressable
-            onPress={handleBack}
-            className="mb-20 h-10 w-10 items-center justify-center self-start rounded-full bg-white/10 web:hover:bg-white/20"
-          >
-            <ArrowLeft size={20} color="#ffffff" />
-          </Pressable>
+          <View className="mb-20 self-start">
+            <BackButton onPress={handleBack} />
+          </View>
         )}
 
         {/* Passkey Icon */}
@@ -192,12 +189,7 @@ export default function SignupPasskey() {
         <View className="flex-1">
           {/* Header with back button */}
           <View className="flex-row items-center px-6 py-3">
-            <Pressable
-              onPress={handleBack}
-              className="h-10 w-10 items-center justify-center rounded-full bg-white/10"
-            >
-              <ArrowLeft size={20} color="#ffffff" />
-            </Pressable>
+            <BackButton onPress={handleBack} />
           </View>
 
           {/* Content - positioned at top, centered horizontally */}

--- a/components/Card/ActivateCard/ActivateCardHeader.tsx
+++ b/components/Card/ActivateCard/ActivateCardHeader.tsx
@@ -1,6 +1,6 @@
-import { Pressable, View } from 'react-native';
-import { ArrowLeft } from 'lucide-react-native';
+import { View } from 'react-native';
 
+import { BackButton } from '@/components/ui/back-button';
 import { Text } from '@/components/ui/text';
 
 interface ActivateCardHeaderProps {
@@ -10,9 +10,7 @@ interface ActivateCardHeaderProps {
 export function ActivateCardHeader({ onBack }: ActivateCardHeaderProps) {
   return (
     <View className="flex-row items-center justify-between">
-      <Pressable onPress={onBack} className="web:hover:opacity-70">
-        <ArrowLeft color="white" />
-      </Pressable>
+      <BackButton onPress={onBack} />
       <Text className="text-center text-xl font-semibold text-white md:text-2xl">Solid card</Text>
       <View className="w-10" />
     </View>

--- a/components/ui/back-button.tsx
+++ b/components/ui/back-button.tsx
@@ -4,15 +4,26 @@ import { ArrowLeft } from 'lucide-react-native';
 
 interface BackButtonProps {
   fallbackHref?: string;
+  onPress?: () => void;
+  accessibilityLabel?: string;
 }
 
-export function BackButton({ fallbackHref = '/' }: BackButtonProps) {
+export function BackButton({
+  fallbackHref = '/',
+  onPress,
+  accessibilityLabel = 'Go back',
+}: BackButtonProps) {
   const router = useRouter();
+
+  const handlePress =
+    onPress ?? (() => (router.canGoBack() ? router.back() : router.replace(fallbackHref as any)));
 
   return (
     <Pressable
-      onPress={() => (router.canGoBack() ? router.back() : router.replace(fallbackHref as any))}
+      onPress={handlePress}
       className="flex h-10 w-10 items-center justify-center rounded-full border-0 bg-popover web:transition-colors web:hover:bg-muted"
+      accessibilityLabel={accessibilityLabel}
+      accessibilityRole="button"
     >
       <ArrowLeft size={24} color="#FFFFFF" />
     </Pressable>


### PR DESCRIPTION
## Summary
- Standardizes back buttons across the app via the shared `BackButton` component (rounded-circle with `bg-popover`).
- Extends `BackButton` with optional `onPress` and `accessibilityLabel` so screens with custom navigation logic can opt in.
- 19 screens / shared headers migrated; reusable modal back buttons (AnimatedModal, ResponsiveModal*, CoinBackButton) intentionally untouched.
- Cherry-picked from qa (PR #2006).

## Test plan
- [ ] Open Settings (account, email, help, security) on mobile and desktop — back button is rounded-circle, taps go back.
- [ ] Verify signup flow (email, otp, passkey) back buttons still navigate to the previous step on both layouts.
- [ ] Verify card flows: deposit, details/transactions, country_selection (card-onboard and activate), country-verification-required.
- [ ] Verify activity detail back button still respects `from`/`tab` query params.
- [ ] Verify rewards/benefits back button returns to Rewards.
- [ ] Verify referral, add-referrer, user-kyc-info, bridge-kyc, notifications.native screens.

https://claude.ai/code/session_015abE3yneWZwkkzqAsvp7su

---
_Generated by [Claude Code](https://claude.ai/code/session_015abE3yneWZwkkzqAsvp7su)_