### PR TITLE
feat(card): remove order physical card button from details page

### DIFF
--- a/app/(protected)/(tabs)/card/details.tsx
+++ b/app/(protected)/(tabs)/card/details.tsx
@@ -13,12 +13,10 @@ import * as Clipboard from 'expo-clipboard';
 import { Image } from 'expo-image';
 import { LinearGradient } from 'expo-linear-gradient';
 import { useRouter } from 'expo-router';
-import { useQuery } from '@tanstack/react-query';
 import {
   ChevronDown,
   ChevronRight,
   Copy,
-  CreditCard,
   KeyRound,
   Plus,
   Settings,
@@ -29,10 +27,6 @@ import { BorrowPositionCard } from '@/components/Card/BorrowPositionCard';
 import { CircularActionButton } from '@/components/Card/CircularActionButton';
 import DepositToCardModal from '@/components/Card/DepositToCardModal';
 import ManagePinModal from '@/components/Card/ManagePinModal';
-import CancelPhysicalCardModal from '@/components/Card/CancelPhysicalCardModal';
-import OrderPhysicalCardModal, {
-  PHYSICAL_CARD_STATUS_QUERY_KEY,
-} from '@/components/Card/OrderPhysicalCardModal';
 import WithdrawToCardModal from '@/components/Card/WithdrawToCardModal';
 import PageLayout from '@/components/PageLayout';
 import { Button } from '@/components/ui/button';
@@ -52,11 +46,11 @@ import { useCardProvider } from '@/hooks/useCardProvider';
 import { useCardWithdrawals } from '@/hooks/useCardWithdrawals';
 import { useCustomer } from '@/hooks/useCustomer';
 import { useDimension } from '@/hooks/useDimension';
-import { freezeCard, getPhysicalCardStatus, unfreezeCard } from '@/lib/api';
+import { freezeCard, unfreezeCard } from '@/lib/api';
 import { getAsset } from '@/lib/assets';
 import { EXPO_PUBLIC_ENVIRONMENT } from '@/lib/config';
 import { CardHolderName, CardProvider, CardStatus, FreezeInitiator, KycStatus } from '@/lib/types';
-import { cn, withRefreshToken } from '@/lib/utils/utils';
+import { cn } from '@/lib/utils/utils';
 import { CardDepositSource, useCardDepositStore } from '@/store/useCardDepositStore';
 
 export default function CardDetails() {
@@ -72,17 +66,7 @@ export default function CardDetails() {
   const [isLoadingCardDetails, setIsLoadingCardDetails] = useState(false);
   const [shouldRevealDetails, setShouldRevealDetails] = useState(false);
   const [isAddToWalletModalOpen, setIsAddToWalletModalOpen] = useState(false);
-  const [isOrderPhysicalCardModalOpen, setIsOrderPhysicalCardModalOpen] = useState(false);
-  const [isCancelPhysicalCardModalOpen, setIsCancelPhysicalCardModalOpen] = useState(false);
   const flipAnimation = useRef(new Animated.Value(0)).current;
-
-  const { data: physicalCardStatusData } = useQuery({
-    queryKey: [PHYSICAL_CARD_STATUS_QUERY_KEY],
-    queryFn: () => withRefreshToken(() => getPhysicalCardStatus()),
-    enabled: provider === CardProvider.RAIN,
-  });
-
-  const hasPhysicalCard = physicalCardStatusData?.hasPhysicalCard ?? false;
 
   const availableBalance = cardDetails?.balances.available;
   const availableAmount = Number(availableBalance?.amount || '0').toString();
@@ -158,12 +142,6 @@ export default function CardDetails() {
         onFreezeToggle={handleFreezeToggle}
         isWithdrawFromCardAllowed={isWithdrawFromCardAllowed}
         isRain={provider === CardProvider.RAIN}
-        hasPhysicalCard={hasPhysicalCard}
-        onPhysicalCardPress={() =>
-          hasPhysicalCard
-            ? setIsCancelPhysicalCardModalOpen(true)
-            : setIsOrderPhysicalCardModalOpen(true)
-        }
       />
     </View>
   ) : (
@@ -222,16 +200,6 @@ export default function CardDetails() {
           onOpenChange={setIsAddToWalletModalOpen}
           trigger={null}
         />
-        <OrderPhysicalCardModal
-          isOpen={isOrderPhysicalCardModalOpen}
-          onOpenChange={setIsOrderPhysicalCardModalOpen}
-          trigger={null}
-        />
-        <CancelPhysicalCardModal
-          isOpen={isCancelPhysicalCardModalOpen}
-          onOpenChange={setIsCancelPhysicalCardModalOpen}
-          trigger={null}
-        />
       </PageLayout>
     );
   }
@@ -262,12 +230,6 @@ export default function CardDetails() {
             onFreezeToggle={handleFreezeToggle}
             isWithdrawFromCardAllowed={isWithdrawFromCardAllowed}
             isRain={provider === CardProvider.RAIN}
-            hasPhysicalCard={hasPhysicalCard}
-            onPhysicalCardPress={() =>
-              hasPhysicalCard
-                ? setIsCancelPhysicalCardModalOpen(true)
-                : setIsOrderPhysicalCardModalOpen(true)
-            }
           />
           <BorrowPositionCard className="mb-4" />
           <DepositBonusBanner />
@@ -281,16 +243,6 @@ export default function CardDetails() {
       <AddToWalletModal
         isOpen={isAddToWalletModalOpen}
         onOpenChange={setIsAddToWalletModalOpen}
-        trigger={null}
-      />
-      <OrderPhysicalCardModal
-        isOpen={isOrderPhysicalCardModalOpen}
-        onOpenChange={setIsOrderPhysicalCardModalOpen}
-        trigger={null}
-      />
-      <CancelPhysicalCardModal
-        isOpen={isCancelPhysicalCardModalOpen}
-        onOpenChange={setIsCancelPhysicalCardModalOpen}
         trigger={null}
       />
     </PageLayout>
@@ -311,8 +263,6 @@ interface DesktopHeaderProps {
   onFreezeToggle: () => Promise<void>;
   isWithdrawFromCardAllowed: boolean;
   isRain: boolean;
-  hasPhysicalCard: boolean;
-  onPhysicalCardPress: () => void;
 }
 
 function DesktopHeader({
@@ -325,8 +275,6 @@ function DesktopHeader({
   onFreezeToggle,
   isWithdrawFromCardAllowed,
   isRain,
-  hasPhysicalCard,
-  onPhysicalCardPress,
 }: DesktopHeaderProps) {
   const [isManageOpen, setIsManageOpen] = useState(false);
   const manageRef = useRef<View>(null);
@@ -429,22 +377,6 @@ function DesktopHeader({
               </View>
             )}
           </View>
-        )}
-        {isRain && (
-          <Button
-            variant="secondary"
-            className={`h-12 rounded-xl border-0 px-6 ${hasPhysicalCard ? 'bg-red-500/20' : 'bg-[#303030]'}`}
-            onPress={onPhysicalCardPress}
-          >
-            <View className="flex-row items-center gap-2">
-              <CreditCard size={18} color={hasPhysicalCard ? '#ef4444' : 'white'} />
-              <Text
-                className={`text-base font-bold ${hasPhysicalCard ? 'text-red-400' : 'text-white'}`}
-              >
-                {hasPhysicalCard ? 'Cancel Physical Card' : 'Order Physical Card'}
-              </Text>
-            </View>
-          </Button>
         )}
         {isWithdrawFromCardAllowed && (
           <WithdrawToCardModal
@@ -855,8 +787,6 @@ interface CardActionsProps {
   onFreezeToggle: () => Promise<void>;
   isWithdrawFromCardAllowed: boolean;
   isRain: boolean;
-  hasPhysicalCard: boolean;
-  onPhysicalCardPress: () => void;
 }
 
 function CardActions({
@@ -869,8 +799,6 @@ function CardActions({
   onFreezeToggle,
   isWithdrawFromCardAllowed,
   isRain,
-  hasPhysicalCard,
-  onPhysicalCardPress,
 }: CardActionsProps) {
   const [isManageSheetOpen, setIsManageSheetOpen] = useState(false);
   const showManageButton = isRain || !isCardFrozen || canUnfreeze;
@@ -960,20 +888,6 @@ function CardActions({
               </View>
             </DialogContent>
           </Dialog>
-        </View>
-      )}
-      {isRain && (
-        <View className="flex-1 items-center">
-          <Pressable
-            onPress={onPhysicalCardPress}
-            className={`items-center justify-center rounded-full ${hasPhysicalCard ? 'bg-red-500/20' : 'bg-[#303030]'}`}
-            style={{ width: 50, height: 50 }}
-          >
-            <CreditCard size={24} color={hasPhysicalCard ? '#ef4444' : '#BFBFBF'} />
-          </Pressable>
-          <Text className={`mt-2 ${hasPhysicalCard ? 'text-red-400' : 'text-[#BFBFBF]'}`}>
-            {hasPhysicalCard ? 'Cancel' : 'Physical'}
-          </Text>
         </View>
       )}
       {isWithdrawFromCardAllowed && (


### PR DESCRIPTION
## Summary
- Removes the Order/Cancel Physical Card toggle button (and its modals, state, and physical-card status query) from both the desktop header and the mobile card actions on the card details page.
- Cherry-picked from the qa-targeting branch `claude/remove-order-card-button-o5CL3` (commit `d574c9c`).

## Test plan
- [ ] Verify the card details page renders correctly on desktop without the Order/Cancel Physical Card button
- [ ] Verify the card details page renders correctly on mobile without the Physical/Cancel circular action button
- [ ] Confirm remaining card actions (Card details, Manage, Withdraw, Deposit, Add to Wallet) still work
- [ ] Verify no console errors or unused-import warnings


---
_Generated by [Claude Code](https://claude.ai/code/session_01DfFkxkJbV84tsQZZqk24im)_