### PR TITLE
fix(agent): hide expo-router 'agent/index' header, restyle setup card

### DIFF
--- a/app/(protected)/_layout.tsx
+++ b/app/(protected)/_layout.tsx
@@ -215,6 +215,12 @@ export default function ProtectedLayout() {
           presentation: 'fullScreenModal',
         }}
       />
+      <Stack.Screen
+        name="agent/index"
+        options={{
+          headerShown: false,
+        }}
+      />
     </Stack>
   );
 }

--- a/app/(protected)/agent/index.tsx
+++ b/app/(protected)/agent/index.tsx
@@ -89,11 +89,14 @@ export default function AgentPage() {
               payments on Base. Start earning yield on idle USDC in your agent wallet.
             </Text>
             <Button
-              className="mt-4 w-full"
+              variant="brand"
               onPress={handleProvision}
               disabled={provision.isPending}
+              className="mt-6 h-12 w-full rounded-xl"
             >
-              <Text>{provision.isPending ? 'Setting up…' : 'Set up Agent'}</Text>
+              <Text className="text-base font-bold text-primary-foreground">
+                {provision.isPending ? 'Setting up…' : 'Set up Agent'}
+              </Text>
             </Button>
           </View>
         ) : (

--- a/app/(protected)/agent/index.tsx
+++ b/app/(protected)/agent/index.tsx
@@ -80,13 +80,19 @@ export default function AgentPage() {
             <ActivityIndicator />
           </View>
         ) : !isProvisioned ? (
-          <View className="gap-3 rounded-twice border border-border bg-card p-5">
-            <Text className="text-lg font-semibold">Set up your agent</Text>
-            <Text className="text-sm text-muted-foreground">
+          <View className="items-center rounded-2xl border border-white/5 bg-[#1C1C1C] px-6 pb-8 pt-10">
+            <Text className="mt-2 text-center text-2xl font-bold text-white">
+              Set up your agent
+            </Text>
+            <Text className="my-3 text-center text-base leading-tight text-[#ACACAC]">
               We&apos;ll create a new EOA under your existing Turnkey wallet that can sign x402
               payments on Base. Start earning yield on idle USDC in your agent wallet.
             </Text>
-            <Button onPress={handleProvision} disabled={provision.isPending}>
+            <Button
+              className="mt-4 w-full"
+              onPress={handleProvision}
+              disabled={provision.isPending}
+            >
               <Text>{provision.isPending ? 'Setting up…' : 'Set up Agent'}</Text>
             </Button>
           </View>


### PR DESCRIPTION
- Register agent/index in the protected Stack with headerShown: false so the default 'agent/index' header strip stops rendering above the page (matches every other route in (protected)).
- Restyle the 'Set up your agent' empty state to mirror the /card/pending box (rounded-2xl, border-white/5, bg-[#1C1C1C], padded px-6 pb-8 pt-10, centered title + description). Skipping the image per the screenshot direction; full-width primary CTA at the bottom.