### PR TITLE
feat(agent): restructure provisioned page to /card/details layout

### DIFF
--- a/app/(protected)/agent/index.tsx
+++ b/app/(protected)/agent/index.tsx
@@ -1,7 +1,8 @@
 import { useState } from 'react';
-import { ActivityIndicator, View } from 'react-native';
+import { ActivityIndicator, Pressable, View } from 'react-native';
 import Toast from 'react-native-toast-message';
 import { useLocalSearchParams } from 'expo-router';
+import { KeyRound, Plus } from 'lucide-react-native';
 
 import ApiKeyList from '@/components/Agent/ApiKeyList';
 import ApiKeyRevealModal from '@/components/Agent/ApiKeyRevealModal';
@@ -9,17 +10,16 @@ import IntegrationSnippet from '@/components/Agent/IntegrationSnippet';
 import CopyToClipboard from '@/components/CopyToClipboard';
 import PageLayout from '@/components/PageLayout';
 import { Button } from '@/components/ui/button';
-import { Switch } from '@/components/ui/switch';
 import { Text } from '@/components/ui/text';
 import {
   useAgentApiKeys,
   useAgentBalance,
-  useAgentDeposited,
   useAgentQuery,
   useGenerateAgentApiKey,
   useProvisionAgent,
   useRevokeAgentApiKey,
 } from '@/hooks/useAgent';
+import { useDimension } from '@/hooks/useDimension';
 import { isProduction } from '@/lib/config';
 import { eclipseAddress } from '@/lib/utils';
 
@@ -37,7 +37,7 @@ const formatUsdc = (raw?: bigint) => {
  *   /agent?status=loading
  *   /agent?status=not_provisioned
  *   /agent?status=provisioned
- *   /agent?status=deposited        (provisioned + Switch flipped + balance set)
+ *   /agent?status=deposited        (provisioned + non-zero balance)
  *
  * Disabled in production builds — the param is ignored when isProduction.
  */
@@ -51,8 +51,17 @@ const VALID_OVERRIDES: AgentStatusOverride[] = [
 const DEMO_AGENT_ADDRESS = '0x0000000000000000000000000000000000000000';
 const DEMO_BALANCE_USDC = 12_345_670n; // $12.34
 
+const handleDepositComingSoon = () =>
+  Toast.show({
+    type: 'info',
+    text1: 'Deposit flow coming soon',
+    text2: 'Will mirror borrow-against-savings: Aave borrow USDC on Fuse + Stargate to Base.',
+    props: { badgeText: 'Soon' },
+  });
+
 export default function AgentPage() {
   const { status } = useLocalSearchParams<{ status?: string }>();
+  const { isScreenMedium } = useDimension();
   const statusOverride: AgentStatusOverride | undefined =
     !isProduction && VALID_OVERRIDES.includes(status as AgentStatusOverride)
       ? (status as AgentStatusOverride)
@@ -82,13 +91,6 @@ export default function AgentPage() {
       : liveAgent?.agentEoaAddress;
 
   const balanceQuery = useAgentBalance(agentEoaAddress);
-  const depositedQuery = useAgentDeposited(isProvisioned);
-  const hasDeposited =
-    statusOverride === 'deposited'
-      ? true
-      : statusOverride === 'provisioned'
-        ? false
-        : (depositedQuery.data ?? false);
   const balance =
     statusOverride === 'deposited' || statusOverride === 'provisioned'
       ? DEMO_BALANCE_USDC
@@ -123,25 +125,16 @@ export default function AgentPage() {
       <View
         className={
           isProvisioned
-            ? 'mx-auto w-full max-w-3xl gap-6 px-4 py-6 md:py-10'
+            ? 'mx-auto w-full max-w-5xl gap-6 px-4 py-6 md:py-10'
             : 'mx-auto w-full max-w-lg gap-6 px-4 pt-8'
         }
       >
-        {isProvisioned ? (
-          <View className="gap-1">
-            <Text className="text-3xl font-semibold md:text-5xl">Agent Wallet</Text>
-            <Text className="text-base text-muted-foreground">
-              Your Solid Wallet is now Agentic
-            </Text>
-          </View>
-        ) : null}
-
         {isLoading ? (
           <View className="items-center py-12">
-            <ActivityIndicator />
+            <ActivityIndicator color="white" />
           </View>
         ) : !isProvisioned ? (
-          <View className="items-center rounded-2xl border border-white/5 bg-[#1C1C1C] px-6 pb-8 pt-10">
+          <View className="items-center rounded-2xl bg-[#1C1C1C] px-6 pb-8 pt-10">
             {/* Placeholder for hero artwork — keep the height stable so the
                 later swap to a real Image doesn't shift the layout. */}
             <View className="mb-6 h-[268px] w-full rounded-xl bg-white/5" />
@@ -165,67 +158,36 @@ export default function AgentPage() {
           </View>
         ) : (
           <>
-            <View className="flex-row items-center justify-between gap-3 rounded-twice border border-border bg-card p-4">
-              <Text className="text-base font-medium">Human</Text>
-              <Switch checked={hasDeposited} onCheckedChange={() => {}} disabled />
-              <Text className="text-base font-medium">Agent</Text>
+            <ProvisionedHeader
+              isScreenMedium={isScreenMedium}
+              isGenerating={generateApiKey.isPending}
+              onDeposit={handleDepositComingSoon}
+              onGenerateApiKey={handleGenerate}
+            />
+
+            {/* Wallet + API keys side-by-side on desktop, stacked on mobile */}
+            <View className="flex-col gap-6 md:flex-row">
+              <View className="flex-1">
+                <WalletAddressCard
+                  address={agentEoaAddress}
+                  balance={balance}
+                  balanceLoading={balanceLoading}
+                />
+              </View>
+              <View className="flex-1">
+                <ApiKeysCard
+                  apiKeys={apiKeysQuery.data}
+                  isLoading={apiKeysQuery.isLoading}
+                  onRevoke={id => revokeApiKey.mutate(id)}
+                  revokingId={
+                    revokeApiKey.isPending ? (revokeApiKey.variables as string) : undefined
+                  }
+                />
+              </View>
             </View>
 
-            <View className="gap-3 rounded-twice border border-border bg-card p-5">
-              <View className="flex-row items-center justify-between gap-2">
-                <Text className="text-sm text-muted-foreground">Agent wallet address</Text>
-                <CopyToClipboard text={agentEoaAddress ?? ''} />
-              </View>
-              <Text className="font-mono text-sm" selectable>
-                {agentEoaAddress ? eclipseAddress(agentEoaAddress, 8, 6) : ''}
-              </Text>
-              <View className="mt-2 gap-1">
-                <Text className="text-xs uppercase text-muted-foreground">
-                  USDC balance on Base
-                </Text>
-                {balanceLoading ? (
-                  <ActivityIndicator size="small" />
-                ) : (
-                  <Text className="text-2xl font-semibold">{formatUsdc(balance)}</Text>
-                )}
-              </View>
-              <Button
-                variant="secondary"
-                onPress={() =>
-                  Toast.show({
-                    type: 'info',
-                    text1: 'Deposit flow coming soon',
-                    text2: 'Bridge USDC to the agent EOA on Base from the Solid app.',
-                    props: { badgeText: 'Soon' },
-                  })
-                }
-              >
-                <Text>Deposit USD</Text>
-              </Button>
-            </View>
-
-            <View className="gap-3 rounded-twice border border-border bg-card p-5">
-              <View className="flex-row items-center justify-between">
-                <View className="gap-1">
-                  <Text className="text-lg font-semibold">API Keys</Text>
-                  <Text className="text-xs text-muted-foreground">
-                    Authenticate AI tools that pay through your agent wallet.
-                  </Text>
-                </View>
-                <Button size="sm" onPress={handleGenerate} disabled={generateApiKey.isPending}>
-                  <Text>{generateApiKey.isPending ? 'Generating…' : 'Generate API key'}</Text>
-                </Button>
-              </View>
-              <ApiKeyList
-                apiKeys={apiKeysQuery.data}
-                isLoading={apiKeysQuery.isLoading}
-                onRevoke={id => revokeApiKey.mutate(id)}
-                revokingId={revokeApiKey.isPending ? (revokeApiKey.variables as string) : undefined}
-              />
-            </View>
-
-            <View className="gap-3 rounded-twice border border-border bg-card p-5">
-              <Text className="text-lg font-semibold">How to use</Text>
+            <View className="w-full rounded-2xl bg-[#1C1C1C] p-6">
+              <Text className="mb-3 text-lg font-semibold">How to use</Text>
               <IntegrationSnippet />
             </View>
           </>
@@ -238,5 +200,164 @@ export default function AgentPage() {
         />
       </View>
     </PageLayout>
+  );
+}
+
+interface ProvisionedHeaderProps {
+  isScreenMedium: boolean;
+  isGenerating: boolean;
+  onDeposit: () => void;
+  onGenerateApiKey: () => void;
+}
+
+function ProvisionedHeader({
+  isScreenMedium,
+  isGenerating,
+  onDeposit,
+  onGenerateApiKey,
+}: ProvisionedHeaderProps) {
+  if (isScreenMedium) {
+    return (
+      <View className="flex-row items-end justify-between">
+        <View className="gap-1">
+          <Text className="text-5xl font-semibold">Agent Wallet</Text>
+          <Text className="text-base text-muted-foreground">Your Solid Wallet is now Agentic</Text>
+        </View>
+        <View className="flex-row items-center gap-2">
+          <Button
+            variant="secondary"
+            className="h-12 rounded-xl border-0 bg-[#303030] px-6"
+            onPress={onGenerateApiKey}
+            disabled={isGenerating}
+          >
+            <View className="flex-row items-center gap-2">
+              {isGenerating ? (
+                <ActivityIndicator size="small" color="white" />
+              ) : (
+                <KeyRound size={18} color="white" />
+              )}
+              <Text className="text-base font-bold text-white">
+                {isGenerating ? 'Generating…' : 'Generate API key'}
+              </Text>
+            </View>
+          </Button>
+          <Button className="h-12 rounded-xl border-0 bg-[#94F27F] px-6" onPress={onDeposit}>
+            <View className="flex-row items-center gap-2">
+              <Plus size={22} color="black" />
+              <Text className="text-base font-bold text-black">Deposit</Text>
+            </View>
+          </Button>
+        </View>
+      </View>
+    );
+  }
+
+  // Mobile: title above, circular action buttons below — same shape as
+  // the spendable-balance hero on /card/details.
+  return (
+    <View className="gap-6">
+      <View className="gap-1">
+        <Text className="text-3xl font-semibold">Agent Wallet</Text>
+        <Text className="text-base text-muted-foreground">Your Solid Wallet is now Agentic</Text>
+      </View>
+      <View className="flex-row items-center justify-around">
+        <CircleAction icon={<Plus size={24} color="black" />} label="Deposit" onPress={onDeposit} />
+        <CircleAction
+          icon={
+            isGenerating ? (
+              <ActivityIndicator color="white" />
+            ) : (
+              <KeyRound size={22} color="white" />
+            )
+          }
+          label="Generate key"
+          onPress={onGenerateApiKey}
+          variant="dark"
+          disabled={isGenerating}
+        />
+      </View>
+    </View>
+  );
+}
+
+interface CircleActionProps {
+  icon: React.ReactNode;
+  label: string;
+  onPress: () => void;
+  variant?: 'brand' | 'dark';
+  disabled?: boolean;
+}
+
+function CircleAction({ icon, label, onPress, variant = 'brand', disabled }: CircleActionProps) {
+  return (
+    <View className="flex-1 items-center">
+      <Pressable
+        onPress={disabled ? undefined : onPress}
+        className={`h-14 w-14 items-center justify-center rounded-full web:hover:opacity-80 ${
+          variant === 'brand' ? 'bg-[#94F27F]' : 'bg-[#303030]'
+        } ${disabled ? 'opacity-50' : ''}`}
+      >
+        {icon}
+      </Pressable>
+      <Text className="mt-2 text-sm text-[#BFBFBF]">{label}</Text>
+    </View>
+  );
+}
+
+interface WalletAddressCardProps {
+  address?: string;
+  balance?: bigint;
+  balanceLoading: boolean;
+}
+
+function WalletAddressCard({ address, balance, balanceLoading }: WalletAddressCardProps) {
+  return (
+    <View className="h-full gap-4 rounded-2xl bg-[#1C1C1C] p-6">
+      <View>
+        <Text className="text-sm text-white/60">USDC balance on Base</Text>
+        {balanceLoading ? (
+          <ActivityIndicator size="small" color="white" className="mt-2 self-start" />
+        ) : (
+          <Text className="text-[40px] font-semibold leading-tight text-white">
+            {formatUsdc(balance)}
+          </Text>
+        )}
+      </View>
+      <View>
+        <Text className="text-sm text-white/60">Agent wallet address</Text>
+        <View className="mt-1 flex-row items-center gap-2">
+          <Text className="font-mono text-base text-white" selectable>
+            {address ? eclipseAddress(address, 8, 6) : ''}
+          </Text>
+          <CopyToClipboard text={address ?? ''} />
+        </View>
+      </View>
+    </View>
+  );
+}
+
+interface ApiKeysCardProps {
+  apiKeys: Parameters<typeof ApiKeyList>[0]['apiKeys'];
+  isLoading: boolean;
+  onRevoke: (id: string) => void;
+  revokingId?: string;
+}
+
+function ApiKeysCard({ apiKeys, isLoading, onRevoke, revokingId }: ApiKeysCardProps) {
+  return (
+    <View className="h-full gap-3 rounded-2xl bg-[#1C1C1C] p-6">
+      <View className="gap-1">
+        <Text className="text-lg font-semibold text-white">API Keys</Text>
+        <Text className="text-sm text-white/60">
+          Authenticate AI tools that pay through your agent wallet.
+        </Text>
+      </View>
+      <ApiKeyList
+        apiKeys={apiKeys}
+        isLoading={isLoading}
+        onRevoke={onRevoke}
+        revokingId={revokingId}
+      />
+    </View>
   );
 }

--- a/components/Agent/ApiKeyList.tsx
+++ b/components/Agent/ApiKeyList.tsx
@@ -20,7 +20,7 @@ const ApiKeyList = ({ apiKeys, isLoading, onRevoke, revokingId }: Props) => {
   if (isLoading) {
     return (
       <View className="items-center py-6">
-        <ActivityIndicator />
+        <ActivityIndicator color="white" />
       </View>
     );
   }
@@ -28,7 +28,7 @@ const ApiKeyList = ({ apiKeys, isLoading, onRevoke, revokingId }: Props) => {
   const active = (apiKeys ?? []).filter(k => !k.revokedAt);
   if (active.length === 0) {
     return (
-      <Text className="text-sm text-muted-foreground">
+      <Text className="text-sm text-white/60">
         No API keys yet. Generate one to start integrating with your AI tool.
       </Text>
     );
@@ -39,11 +39,11 @@ const ApiKeyList = ({ apiKeys, isLoading, onRevoke, revokingId }: Props) => {
       {active.map(k => (
         <View
           key={k.id}
-          className="flex-row items-center justify-between gap-2 rounded-twice border border-border bg-background p-3"
+          className="flex-row items-center justify-between gap-2 rounded-xl bg-[#262626] p-3"
         >
           <View className="flex-1 gap-0.5">
-            <Text className="font-mono text-sm">sk_solid_live_•••••{k.prefix}</Text>
-            <Text className="text-xs text-muted-foreground">
+            <Text className="font-mono text-sm text-white">sk_solid_live_•••••{k.prefix}</Text>
+            <Text className="text-xs text-white/60">
               {k.name ? `${k.name} · ` : ''}created {formatDate(k.createdAt)}
               {k.lastUsedAt ? ` · last used ${formatDate(k.lastUsedAt)}` : ''}
             </Text>

--- a/components/Agent/ApiKeyRevealModal.tsx
+++ b/components/Agent/ApiKeyRevealModal.tsx
@@ -30,8 +30,8 @@ const ApiKeyRevealModal = ({ open, onClose, apiKey }: Props) => {
         </DialogHeader>
         {apiKey ? (
           <View className="gap-3">
-            <View className="flex-row items-center justify-between gap-2 rounded-twice border border-border bg-background p-3">
-              <Text className="flex-1 break-all font-mono text-xs" selectable>
+            <View className="flex-row items-center justify-between gap-2 rounded-xl bg-[#262626] p-3">
+              <Text className="flex-1 break-all font-mono text-xs text-white" selectable>
                 {apiKey}
               </Text>
               <CopyToClipboard text={apiKey} />

--- a/components/Agent/IntegrationSnippet.tsx
+++ b/components/Agent/IntegrationSnippet.tsx
@@ -25,9 +25,9 @@ const IntegrationSnippet = () => {
         Use these to wire up your AI tool. Paste the prompt template into Claude Desktop or ChatGPT
         custom GPTs, and the curl example into a script or n8n node.
       </Text>
-      <View className="rounded-twice border border-border bg-background p-3">
+      <View className="rounded-xl bg-[#262626] p-3">
         <View className="flex-row items-start justify-between gap-2">
-          <Text className="flex-1 break-all font-mono text-xs" selectable>
+          <Text className="flex-1 break-all font-mono text-xs text-white" selectable>
             {snippet}
           </Text>
           <CopyToClipboard text={snippet} />


### PR DESCRIPTION
UI restyle informed by the screenshot direction:

- Move Generate API Key + Deposit out of inline cards into the page header. flex-row justify-between with title block on the left and buttons on the right (desktop), matching /card/details:352. On mobile the header collapses to title above + circular action buttons (a green Deposit + dark Generate Key) in a row, mirroring the mobile hero pattern.
- Drop the Human/Agent toggle entirely. The deposited bool is no longer surfaced in the UI.
- Wallet + API key boxes now sit side-by-side on desktop (flex-row, flex-1 each) and stack on mobile (flex-col). 'How to use' lives below as a single full-width box.
- All three boxes use the same rounded-2xl bg-[#1C1C1C] base as the setup card. Inner content stays left-aligned per the direction; copy + balance live inside the wallet card.
- Strip every border-* class. Sub-elements (api key rows, snippet block, reveal modal key block) now use rounded-xl bg-[#262626] instead of bordered backgrounds.
- All ActivityIndicators on the agent surface explicitly color='white' to drop the platform-default tinted spinner.
- Bump the provisioned-state max-width from max-w-3xl to max-w-5xl so the side-by-side cards have room to breathe.
- Deposit button still no-ops to a clarifying toast — the actual flow is the borrow-against-savings clone (per the original plan U3) and is being tracked as a follow-up.