### PR TITLE
feat(agent): wire borrow-against-savings deposit, header actions + ba…

### DIFF
--- a/app/(protected)/agent/index.tsx
+++ b/app/(protected)/agent/index.tsx
@@ -1,9 +1,12 @@
 import { useState } from 'react';
 import { ActivityIndicator, Pressable, View } from 'react-native';
 import Toast from 'react-native-toast-message';
+import * as Clipboard from 'expo-clipboard';
+import { LinearGradient } from 'expo-linear-gradient';
 import { useLocalSearchParams } from 'expo-router';
-import { KeyRound, Plus } from 'lucide-react-native';
+import { FileText, KeyRound, Plus } from 'lucide-react-native';
 
+import AgentDepositModal from '@/components/Agent/AgentDepositModal';
 import ApiKeyList from '@/components/Agent/ApiKeyList';
 import ApiKeyRevealModal from '@/components/Agent/ApiKeyRevealModal';
 import IntegrationSnippet from '@/components/Agent/IntegrationSnippet';
@@ -11,6 +14,7 @@ import CopyToClipboard from '@/components/CopyToClipboard';
 import PageLayout from '@/components/PageLayout';
 import { Button } from '@/components/ui/button';
 import { Text } from '@/components/ui/text';
+import { AGENT_PROMPT_TEMPLATE } from '@/constants/agentPromptTemplate';
 import {
   useAgentApiKeys,
   useAgentBalance,
@@ -51,13 +55,15 @@ const VALID_OVERRIDES: AgentStatusOverride[] = [
 const DEMO_AGENT_ADDRESS = '0x0000000000000000000000000000000000000000';
 const DEMO_BALANCE_USDC = 12_345_670n; // $12.34
 
-const handleDepositComingSoon = () =>
+const handleCopyPrompt = async () => {
+  await Clipboard.setStringAsync(AGENT_PROMPT_TEMPLATE);
   Toast.show({
-    type: 'info',
-    text1: 'Deposit flow coming soon',
-    text2: 'Will mirror borrow-against-savings: Aave borrow USDC on Fuse + Stargate to Base.',
-    props: { badgeText: 'Soon' },
+    type: 'success',
+    text1: 'Prompt template copied',
+    text2: 'Paste into Claude Desktop or ChatGPT instructions',
+    props: { badgeText: 'Copied' },
   });
+};
 
 export default function AgentPage() {
   const { status } = useLocalSearchParams<{ status?: string }>();
@@ -76,9 +82,6 @@ export default function AgentPage() {
   const liveAgent = agentQuery.data;
   const liveIsProvisioned = !!liveAgent?.agentEoaAddress;
 
-  // Derived view-model: the override wins when set, otherwise we use live
-  // backend data. Keeping the live hooks running unconditionally so the
-  // override can be toggled on/off without remounting.
   const isLoading =
     statusOverride === 'loading' || (statusOverride === undefined && agentQuery.isLoading);
   const isProvisioned =
@@ -98,6 +101,7 @@ export default function AgentPage() {
   const balanceLoading = statusOverride === undefined ? balanceQuery.isLoading : false;
 
   const [revealedKey, setRevealedKey] = useState<string | null>(null);
+  const [depositOpen, setDepositOpen] = useState(false);
 
   const handleProvision = async () => {
     try {
@@ -135,8 +139,6 @@ export default function AgentPage() {
           </View>
         ) : !isProvisioned ? (
           <View className="items-center rounded-2xl bg-[#1C1C1C] px-6 pb-8 pt-10">
-            {/* Placeholder for hero artwork — keep the height stable so the
-                later swap to a real Image doesn't shift the layout. */}
             <View className="mb-6 h-[268px] w-full rounded-xl bg-white/5" />
             <Text className="mt-2 text-center text-2xl font-bold text-white">
               Set up your Agent Wallet
@@ -161,21 +163,18 @@ export default function AgentPage() {
             <ProvisionedHeader
               isScreenMedium={isScreenMedium}
               isGenerating={generateApiKey.isPending}
-              onDeposit={handleDepositComingSoon}
+              onDeposit={() => setDepositOpen(true)}
               onGenerateApiKey={handleGenerate}
+              onCopyPrompt={handleCopyPrompt}
             />
 
-            {/* Wallet + API keys side-by-side on desktop, stacked on mobile */}
             <View className="flex-col gap-6 md:flex-row">
               <View className="flex-1">
-                <WalletAddressCard
-                  address={agentEoaAddress}
-                  balance={balance}
-                  balanceLoading={balanceLoading}
-                />
+                <BalanceCard balance={balance} balanceLoading={balanceLoading} />
               </View>
               <View className="flex-1">
                 <ApiKeysCard
+                  address={agentEoaAddress}
                   apiKeys={apiKeysQuery.data}
                   isLoading={apiKeysQuery.isLoading}
                   onRevoke={id => revokeApiKey.mutate(id)}
@@ -198,6 +197,11 @@ export default function AgentPage() {
           onClose={() => setRevealedKey(null)}
           apiKey={revealedKey}
         />
+        <AgentDepositModal
+          open={depositOpen}
+          onClose={() => setDepositOpen(false)}
+          agentEoaAddress={agentEoaAddress}
+        />
       </View>
     </PageLayout>
   );
@@ -208,6 +212,7 @@ interface ProvisionedHeaderProps {
   isGenerating: boolean;
   onDeposit: () => void;
   onGenerateApiKey: () => void;
+  onCopyPrompt: () => void;
 }
 
 function ProvisionedHeader({
@@ -215,6 +220,7 @@ function ProvisionedHeader({
   isGenerating,
   onDeposit,
   onGenerateApiKey,
+  onCopyPrompt,
 }: ProvisionedHeaderProps) {
   if (isScreenMedium) {
     return (
@@ -224,6 +230,16 @@ function ProvisionedHeader({
           <Text className="text-base text-muted-foreground">Your Solid Wallet is now Agentic</Text>
         </View>
         <View className="flex-row items-center gap-2">
+          <Button
+            variant="secondary"
+            className="h-12 rounded-xl border-0 bg-[#303030] px-6"
+            onPress={onCopyPrompt}
+          >
+            <View className="flex-row items-center gap-2">
+              <FileText size={18} color="white" />
+              <Text className="text-base font-bold text-white">Copy prompt</Text>
+            </View>
+          </Button>
           <Button
             variant="secondary"
             className="h-12 rounded-xl border-0 bg-[#303030] px-6"
@@ -252,8 +268,6 @@ function ProvisionedHeader({
     );
   }
 
-  // Mobile: title above, circular action buttons below — same shape as
-  // the spendable-balance hero on /card/details.
   return (
     <View className="gap-6">
       <View className="gap-1">
@@ -270,10 +284,16 @@ function ProvisionedHeader({
               <KeyRound size={22} color="white" />
             )
           }
-          label="Generate key"
+          label="API key"
           onPress={onGenerateApiKey}
           variant="dark"
           disabled={isGenerating}
+        />
+        <CircleAction
+          icon={<FileText size={22} color="white" />}
+          label="Prompt"
+          onPress={onCopyPrompt}
+          variant="dark"
         />
       </View>
     </View>
@@ -304,32 +324,38 @@ function CircleAction({ icon, label, onPress, variant = 'brand', disabled }: Cir
   );
 }
 
-interface WalletAddressCardProps {
-  address?: string;
+interface BalanceCardProps {
   balance?: bigint;
   balanceLoading: boolean;
 }
 
-function WalletAddressCard({ address, balance, balanceLoading }: WalletAddressCardProps) {
+/**
+ * Mirrors /card/details `SpendingBalanceCard` styling — green LinearGradient
+ * over a rounded-[20px] base, big balance up top, secondary stat under it.
+ */
+function BalanceCard({ balance, balanceLoading }: BalanceCardProps) {
+  const formatted = balanceLoading ? null : formatUsdc(balance);
   return (
-    <View className="h-full gap-4 rounded-2xl bg-[#1C1C1C] p-6">
-      <View>
-        <Text className="text-sm text-white/60">USDC balance on Base</Text>
-        {balanceLoading ? (
-          <ActivityIndicator size="small" color="white" className="mt-2 self-start" />
-        ) : (
-          <Text className="text-[40px] font-semibold leading-tight text-white">
-            {formatUsdc(balance)}
-          </Text>
-        )}
-      </View>
-      <View>
-        <Text className="text-sm text-white/60">Agent wallet address</Text>
-        <View className="mt-1 flex-row items-center gap-2">
-          <Text className="font-mono text-base text-white" selectable>
-            {address ? eclipseAddress(address, 8, 6) : ''}
-          </Text>
-          <CopyToClipboard text={address ?? ''} />
+    <View className="relative h-full overflow-hidden rounded-[20px] px-[36px] py-[30px]">
+      <LinearGradient
+        colors={['rgba(104, 216, 82, 1)', 'rgba(104, 216, 82, 0.4)']}
+        start={{ x: 0.5, y: 0 }}
+        end={{ x: 0.6, y: 1 }}
+        pointerEvents="none"
+        style={{ position: 'absolute', top: 0, left: 0, right: 0, bottom: 0 }}
+      />
+      <View className="flex-1 justify-between">
+        <View>
+          <Text className="mb-2 text-base text-white/60">USDC balance on Base</Text>
+          {balanceLoading ? (
+            <ActivityIndicator color="white" />
+          ) : (
+            <Text className="text-[50px] font-semibold text-white">{formatted}</Text>
+          )}
+        </View>
+        <View>
+          <Text className="mb-1 text-lg font-medium text-white/50">Earning</Text>
+          <Text className="text-2xl font-semibold text-white">Yield on idle USDC</Text>
         </View>
       </View>
     </View>
@@ -337,13 +363,14 @@ function WalletAddressCard({ address, balance, balanceLoading }: WalletAddressCa
 }
 
 interface ApiKeysCardProps {
+  address?: string;
   apiKeys: Parameters<typeof ApiKeyList>[0]['apiKeys'];
   isLoading: boolean;
   onRevoke: (id: string) => void;
   revokingId?: string;
 }
 
-function ApiKeysCard({ apiKeys, isLoading, onRevoke, revokingId }: ApiKeysCardProps) {
+function ApiKeysCard({ address, apiKeys, isLoading, onRevoke, revokingId }: ApiKeysCardProps) {
   return (
     <View className="h-full gap-3 rounded-2xl bg-[#1C1C1C] p-6">
       <View className="gap-1">
@@ -352,6 +379,17 @@ function ApiKeysCard({ apiKeys, isLoading, onRevoke, revokingId }: ApiKeysCardPr
           Authenticate AI tools that pay through your agent wallet.
         </Text>
       </View>
+      {address ? (
+        <View className="rounded-xl bg-[#262626] p-3">
+          <Text className="text-xs uppercase text-white/60">Agent wallet address</Text>
+          <View className="mt-1 flex-row items-center gap-2">
+            <Text className="font-mono text-sm text-white" selectable>
+              {eclipseAddress(address, 8, 6)}
+            </Text>
+            <CopyToClipboard text={address} />
+          </View>
+        </View>
+      ) : null}
       <ApiKeyList
         apiKeys={apiKeys}
         isLoading={isLoading}

--- a/components/Agent/AgentDepositModal.tsx
+++ b/components/Agent/AgentDepositModal.tsx
@@ -1,0 +1,146 @@
+import { useEffect, useMemo, useState } from 'react';
+import { ActivityIndicator, TextInput, View } from 'react-native';
+import Toast from 'react-native-toast-message';
+
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Text } from '@/components/ui/text';
+import { useAaveBorrowPosition } from '@/hooks/useAaveBorrowPosition';
+import useBorrowAndDepositToAgent from '@/hooks/useBorrowAndDepositToAgent';
+import { Status } from '@/lib/types';
+
+const SO_USD_LTV = 0.7; // mirror SO_USD_LTV in lib/utils/borrowAndBridge.ts
+const MIN_BORROW_USDC = 1; // smallest amount worth a userOp + Stargate fee
+
+type Props = {
+  open: boolean;
+  onClose: () => void;
+  agentEoaAddress?: string;
+};
+
+const AgentDepositModal = ({ open, onClose, agentEoaAddress }: Props) => {
+  const [amount, setAmount] = useState('');
+  const { totalSupplied, totalBorrowed, isLoading: positionLoading } = useAaveBorrowPosition();
+  const { borrowAndDeposit, bridgeStatus } = useBorrowAndDepositToAgent(agentEoaAddress);
+
+  const maxBorrowable = useMemo(
+    () => Math.max(0, totalSupplied * SO_USD_LTV - totalBorrowed),
+    [totalSupplied, totalBorrowed],
+  );
+
+  useEffect(() => {
+    if (!open) setAmount('');
+  }, [open]);
+
+  const parsedAmount = Number(amount);
+  const amountValid =
+    !Number.isNaN(parsedAmount) && parsedAmount >= MIN_BORROW_USDC && parsedAmount <= maxBorrowable;
+  const submitting = bridgeStatus === Status.PENDING;
+
+  const handleSubmit = async () => {
+    if (!amountValid || !agentEoaAddress) return;
+    try {
+      await borrowAndDeposit(amount);
+      Toast.show({
+        type: 'success',
+        text1: 'Deposit submitted',
+        text2:
+          'Borrowed against soUSD on Fuse and sent via Stargate. Funds arrive on Base in ~1–5 min.',
+        props: { badgeText: 'Success' },
+      });
+      onClose();
+    } catch (err) {
+      Toast.show({
+        type: 'error',
+        text1: 'Deposit failed',
+        text2: err instanceof Error ? err.message : 'Unknown error',
+        props: { badgeText: 'Error' },
+      });
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={isOpen => !isOpen && !submitting && onClose()}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Deposit to Agent Wallet</DialogTitle>
+          <DialogDescription>
+            Borrow USDC against your soUSD savings on Fuse and bridge it to your agent EOA on Base
+            via Stargate. Idle savings keep earning yield.
+          </DialogDescription>
+        </DialogHeader>
+
+        <View className="gap-4">
+          <View className="rounded-xl bg-[#262626] p-4">
+            <Text className="text-xs uppercase text-white/60">Available to borrow</Text>
+            {positionLoading ? (
+              <ActivityIndicator size="small" color="white" className="mt-2 self-start" />
+            ) : (
+              <Text className="text-2xl font-semibold text-white">
+                ${maxBorrowable.toLocaleString(undefined, { maximumFractionDigits: 2 })}
+              </Text>
+            )}
+            <Text className="mt-1 text-xs text-white/60">
+              Currently borrowed: $
+              {totalBorrowed.toLocaleString(undefined, { maximumFractionDigits: 2 })} · Supplied: $
+              {totalSupplied.toLocaleString(undefined, { maximumFractionDigits: 2 })} soUSD
+            </Text>
+          </View>
+
+          <View className="gap-2">
+            <Text className="text-xs uppercase text-white/60">Amount (USDC)</Text>
+            <TextInput
+              value={amount}
+              onChangeText={setAmount}
+              keyboardType="decimal-pad"
+              placeholder="0.00"
+              placeholderTextColor="#7A7A7A"
+              editable={!submitting}
+              className="rounded-xl bg-[#262626] px-4 py-3 text-2xl font-semibold text-white"
+            />
+            <View className="flex-row justify-end">
+              <Button
+                variant="ghost"
+                size="sm"
+                onPress={() =>
+                  setAmount(
+                    maxBorrowable > 0 ? maxBorrowable.toFixed(2) : MIN_BORROW_USDC.toString(),
+                  )
+                }
+                disabled={positionLoading || submitting}
+              >
+                <Text className="text-xs text-white/60">Max</Text>
+              </Button>
+            </View>
+          </View>
+
+          <Button
+            variant="brand"
+            className="h-12 w-full rounded-xl"
+            disabled={!amountValid || submitting}
+            onPress={handleSubmit}
+          >
+            <View className="flex-row items-center gap-2">
+              {submitting ? <ActivityIndicator size="small" color="black" /> : null}
+              <Text className="text-base font-bold text-primary-foreground">
+                {submitting
+                  ? 'Borrowing + bridging…'
+                  : amountValid
+                    ? `Borrow $${parsedAmount.toFixed(2)}`
+                    : 'Enter an amount'}
+              </Text>
+            </View>
+          </Button>
+        </View>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default AgentDepositModal;

--- a/components/Agent/IntegrationSnippet.tsx
+++ b/components/Agent/IntegrationSnippet.tsx
@@ -1,29 +1,16 @@
 import { View } from 'react-native';
-import Toast from 'react-native-toast-message';
-import * as Clipboard from 'expo-clipboard';
 
 import CopyToClipboard from '@/components/CopyToClipboard';
-import { Button } from '@/components/ui/button';
 import { Text } from '@/components/ui/text';
-import { AGENT_INTEGRATION_CURL, AGENT_PROMPT_TEMPLATE } from '@/constants/agentPromptTemplate';
-
-const handleCopyPrompt = async () => {
-  await Clipboard.setStringAsync(AGENT_PROMPT_TEMPLATE);
-  Toast.show({
-    type: 'success',
-    text1: 'Prompt template copied',
-    text2: 'Paste into Claude Desktop or ChatGPT instructions',
-    props: { badgeText: 'Copied' },
-  });
-};
+import { AGENT_INTEGRATION_CURL } from '@/constants/agentPromptTemplate';
 
 const IntegrationSnippet = () => {
   const snippet = AGENT_INTEGRATION_CURL();
   return (
     <View className="gap-3">
-      <Text className="text-sm text-muted-foreground">
-        Use these to wire up your AI tool. Paste the prompt template into Claude Desktop or ChatGPT
-        custom GPTs, and the curl example into a script or n8n node.
+      <Text className="text-sm text-white/60">
+        Paste this curl example into a script or n8n node, or copy the AI prompt template from the
+        page header to wire up Claude Desktop / ChatGPT instructions.
       </Text>
       <View className="rounded-xl bg-[#262626] p-3">
         <View className="flex-row items-start justify-between gap-2">
@@ -33,9 +20,6 @@ const IntegrationSnippet = () => {
           <CopyToClipboard text={snippet} />
         </View>
       </View>
-      <Button variant="secondary" onPress={handleCopyPrompt}>
-        <Text>Copy AI prompt template</Text>
-      </Button>
     </View>
   );
 };

--- a/hooks/useBorrowAndDepositToAgent.ts
+++ b/hooks/useBorrowAndDepositToAgent.ts
@@ -1,0 +1,97 @@
+import { useCallback, useState } from 'react';
+import * as Sentry from '@sentry/react-native';
+import { Address } from 'abitype';
+import { TransactionReceipt } from 'viem';
+import { base } from 'viem/chains';
+
+import { useActivityActions } from '@/hooks/useActivityActions';
+import { USER_CANCELLED_TRANSACTION } from '@/lib/execute';
+import { Status, TransactionType } from '@/lib/types';
+import { executeBorrowAndBridge } from '@/lib/utils/borrowAndBridge';
+import { getStargateToken } from '@/lib/utils/stargate';
+
+import useUser from './useUser';
+
+type AgentDepositResult = {
+  borrowAndDeposit: (amount: string) => Promise<TransactionReceipt>;
+  bridgeStatus: Status;
+  error: string | null;
+};
+
+const useBorrowAndDepositToAgent = (agentEoaAddress?: string): AgentDepositResult => {
+  const { user, safeAA } = useUser();
+  const { trackTransaction } = useActivityActions();
+  const [bridgeStatus, setBridgeStatus] = useState<Status>(Status.IDLE);
+  const [error, setError] = useState<string | null>(null);
+
+  const borrowAndDeposit = useCallback(
+    async (amountToBorrow: string) => {
+      try {
+        if (!user) throw new Error('User is not selected');
+        if (!agentEoaAddress) throw new Error('Agent wallet not provisioned');
+        const baseUsdc = getStargateToken(base.id);
+        if (!baseUsdc) throw new Error('Base USDC not configured for Stargate');
+
+        setBridgeStatus(Status.PENDING);
+        setError(null);
+
+        const transactionResult = await executeBorrowAndBridge({
+          user: {
+            safeAddress: user.safeAddress,
+            suborgId: user.suborgId,
+            signWith: user.signWith,
+            userId: user.userId,
+          },
+          destinationAddress: agentEoaAddress as Address,
+          destinationChainId: base.id,
+          destinationChainKey: 'base',
+          destinationToken: baseUsdc as Address,
+          amountToBorrow,
+          safeAA,
+          trackTransaction,
+          activityType: TransactionType.AGENT_WALLET_DEPOSIT,
+          activityTitle: 'Deposit to Agent Wallet',
+          flowTag: 'borrow_and_deposit_to_agent',
+        });
+
+        if (transactionResult === USER_CANCELLED_TRANSACTION) {
+          throw new Error('User cancelled transaction');
+        }
+
+        Sentry.addBreadcrumb({
+          message: 'Borrow + deposit to Agent successful',
+          category: 'bridge',
+          data: {
+            amount: amountToBorrow,
+            transactionHash: transactionResult.transactionHash,
+            userAddress: user.safeAddress,
+            destinationAddress: agentEoaAddress,
+            destinationChainId: base.id,
+          },
+        });
+
+        setBridgeStatus(Status.SUCCESS);
+        return transactionResult;
+      } catch (err) {
+        console.error(err);
+        Sentry.captureException(err, {
+          tags: { operation: 'borrow_and_deposit_to_agent' },
+          extra: {
+            amount: amountToBorrow,
+            userAddress: user?.safeAddress,
+            agentEoaAddress,
+          },
+          user: user ? { id: user.userId, address: user.safeAddress } : undefined,
+        });
+        setBridgeStatus(Status.ERROR);
+        setError(err instanceof Error ? err.message : 'Unknown error');
+        throw err;
+      }
+    },
+    [user, agentEoaAddress, safeAA, trackTransaction],
+  );
+
+  return { borrowAndDeposit, bridgeStatus, error };
+};
+
+export default useBorrowAndDepositToAgent;

--- a/hooks/useBorrowAndDepositToCard.ts
+++ b/hooks/useBorrowAndDepositToCard.ts
@@ -1,58 +1,31 @@
 import { useCallback, useState } from 'react';
 import * as Sentry from '@sentry/react-native';
 import { Address } from 'abitype';
-import { erc20Abi, pad, TransactionReceipt } from 'viem';
-import { readContract } from 'viem/actions';
-import { fuse, mainnet } from 'viem/chains';
-import { encodeFunctionData, parseUnits } from 'viem/utils';
+import { TransactionReceipt } from 'viem';
+import { fuse } from 'viem/chains';
 
-import { USDC_STARGATE } from '@/constants/addresses';
 import { TRACKING_EVENTS } from '@/constants/tracking-events';
 import { useActivityActions } from '@/hooks/useActivityActions';
-import { AaveV3Pool_ABI } from '@/lib/abis/AaveV3Pool';
-import BridgePayamster_ABI from '@/lib/abis/BridgePayamster';
-import { CardDepositManager_ABI } from '@/lib/abis/CardDepositManager';
 import { track } from '@/lib/analytics';
 import {
-  ADDRESSES,
   EXPO_PUBLIC_CARD_FUNDING_CHAIN_ID,
   EXPO_PUBLIC_CARD_FUNDING_CHAIN_KEY,
 } from '@/lib/config';
-import { executeTransactions, USER_CANCELLED_TRANSACTION } from '@/lib/execute';
-import { StargateQuoteParams, Status, TransactionType } from '@/lib/types';
+import { USER_CANCELLED_TRANSACTION } from '@/lib/execute';
+import { Status, TransactionType } from '@/lib/types';
 import { getCardDepositTokenAddress, getCardFundingAddress } from '@/lib/utils';
-import { getStargateChainId, getStargateQuote } from '@/lib/utils/stargate';
-import { publicClient } from '@/lib/wagmi';
+import { executeBorrowAndBridge } from '@/lib/utils/borrowAndBridge';
 
 import { useCardContracts } from './useCardContracts';
 import { useCardDetails } from './useCardDetails';
 import { useCardProvider } from './useCardProvider';
 import useUser from './useUser';
 
-// ABI for AccountantWithRateProviders getRate function
-const ACCOUNTANT_ABI = [
-  {
-    inputs: [],
-    name: 'getRate',
-    outputs: [
-      {
-        internalType: 'uint256',
-        name: 'rate',
-        type: 'uint256',
-      },
-    ],
-    stateMutability: 'view',
-    type: 'function',
-  },
-] as const;
-
 type BridgeResult = {
   borrowAndDeposit: (amount: string) => Promise<TransactionReceipt>;
   bridgeStatus: Status;
   error: string | null;
 };
-
-const soUSDLTV = 70n; // 80% LTV for soUSD (79% to avoid rounding errors)
 
 const useBorrowAndDepositToCard = (): BridgeResult => {
   const { user, safeAA } = useUser();
@@ -67,27 +40,19 @@ const useBorrowAndDepositToCard = (): BridgeResult => {
     async (amountToBorrow: string) => {
       try {
         if (!user) {
-          const error = new Error('User is not selected');
+          const err = new Error('User is not selected');
           track(TRACKING_EVENTS.BRIDGE_TO_ARBITRUM_ERROR, {
             amount: amountToBorrow,
             error: 'User not found',
             step: 'validation',
             source: 'useBridgeToCard',
           });
-          Sentry.captureException(error, {
-            tags: {
-              operation: 'bridge_to_card',
-              step: 'validation',
-            },
-            extra: {
-              amount: amountToBorrow,
-              hasUser: !!user,
-            },
+          Sentry.captureException(err, {
+            tags: { operation: 'bridge_to_card', step: 'validation' },
+            extra: { amount: amountToBorrow, hasUser: !!user },
           });
-          throw error;
+          throw err;
         }
-
-        // Get card's Arbitrum funding address (Rain: from contracts, Bridge: from card details)
         if (!cardDetails) {
           throw new Error('Card details not found');
         }
@@ -97,26 +62,19 @@ const useBorrowAndDepositToCard = (): BridgeResult => {
           provider,
           contracts ?? undefined,
         );
-
         if (!arbitrumFundingAddress) {
-          const error = new Error('Arbitrum funding address not found for card');
+          const err = new Error('Arbitrum funding address not found for card');
           track(TRACKING_EVENTS.BRIDGE_TO_ARBITRUM_ERROR, {
             amount: amountToBorrow,
             error: 'Arbitrum funding address not found',
             step: 'validation',
             source: 'useBridgeToCard',
           });
-          Sentry.captureException(error, {
-            tags: {
-              operation: 'bridge_to_card',
-              step: 'validation',
-            },
-            extra: {
-              amount: amountToBorrow,
-              hasCardDetails: !!cardDetails,
-            },
+          Sentry.captureException(err, {
+            tags: { operation: 'bridge_to_card', step: 'validation' },
+            extra: { amount: amountToBorrow, hasCardDetails: !!cardDetails },
           });
-          throw error;
+          throw err;
         }
 
         track(TRACKING_EVENTS.BRIDGE_TO_ARBITRUM_INITIATED, {
@@ -129,193 +87,36 @@ const useBorrowAndDepositToCard = (): BridgeResult => {
         setBridgeStatus(Status.PENDING);
         setError(null);
 
-        const rate = await readContract(publicClient(mainnet.id), {
-          address: ADDRESSES.ethereum.accountant,
-          abi: ACCOUNTANT_ABI,
-          functionName: 'getRate',
+        const transactionResult = await executeBorrowAndBridge({
+          user: {
+            safeAddress: user.safeAddress,
+            suborgId: user.suborgId,
+            signWith: user.signWith,
+            userId: user.userId,
+          },
+          destinationAddress: arbitrumFundingAddress as Address,
+          destinationChainId: EXPO_PUBLIC_CARD_FUNDING_CHAIN_ID,
+          destinationChainKey: EXPO_PUBLIC_CARD_FUNDING_CHAIN_KEY,
+          destinationToken: getCardDepositTokenAddress(
+            EXPO_PUBLIC_CARD_FUNDING_CHAIN_ID,
+          ) as Address,
+          amountToBorrow,
+          safeAA,
+          trackTransaction,
+          activityType: TransactionType.BORROW_AND_DEPOSIT_TO_CARD,
+          activityTitle: 'Borrow and deposit to Card',
+          flowTag: 'bridge_to_card',
         });
 
-        const destinationAddress = arbitrumFundingAddress;
-        const borrowAmountWei = parseUnits(amountToBorrow, 6);
-        const supplyAmountWei = (borrowAmountWei * 100n * 1000000n) / (soUSDLTV * rate);
-
-        const supplyApproveCalldata = encodeFunctionData({
-          abi: erc20Abi,
-          functionName: 'approve',
-          args: [ADDRESSES.fuse.aaveV3Pool, supplyAmountWei],
-        });
-
-        const supplyCalldata = encodeFunctionData({
-          abi: AaveV3Pool_ABI,
-          functionName: 'supply',
-          args: [ADDRESSES.fuse.vault, supplyAmountWei, user.safeAddress as Address, 0],
-        });
-
-        const borrowCalldata = encodeFunctionData({
-          abi: AaveV3Pool_ABI,
-          functionName: 'borrow',
-          args: [USDC_STARGATE, borrowAmountWei, 2, 0, user.safeAddress as Address],
-        });
-
-        Sentry.addBreadcrumb({
-          message: 'Starting bridge to Card transaction',
-          category: 'bridge',
-          data: {
-            amount: amountToBorrow,
-            amountWei: borrowAmountWei.toString(),
-            userAddress: user.safeAddress,
-            destinationAddress,
-            chainId: fuse.id,
-          },
-        });
-
-        // Get Stargate quote for taxi route
-        // Calculate minimum destination amount (95% of source amount for 5% slippage tolerance)
-        const dstAmountMin = (borrowAmountWei * 95n) / 100n;
-
-        const dstToken = getCardDepositTokenAddress(EXPO_PUBLIC_CARD_FUNDING_CHAIN_ID);
-        const quoteParams: StargateQuoteParams = {
-          srcToken: USDC_STARGATE,
-          srcChainKey: 'fuse',
-          dstToken,
-          dstChainKey: EXPO_PUBLIC_CARD_FUNDING_CHAIN_KEY,
-          srcAddress: ADDRESSES.fuse.bridgePaymasterAddress,
-          dstAddress: destinationAddress,
-          srcAmount: borrowAmountWei.toString(),
-          dstAmountMin: dstAmountMin.toString(),
-        };
-        const quote = await getStargateQuote(quoteParams);
-        const taxiQuote = quote.quotes.find(q => q.route.includes('taxi'));
-
-        if (!taxiQuote) {
-          throw new Error('Taxi route not available from Stargate');
-        }
-
-        if (taxiQuote.error) {
-          throw new Error(`Stargate quote error: ${taxiQuote.error}`);
-        }
-
-        // Get the transaction from the first step (should be the bridge step)
-        const bridgeStep = taxiQuote.steps.find(step => step.type === 'bridge');
-
-        if (!bridgeStep) {
-          throw new Error('No bridge step found in Stargate quote');
-        }
-
-        const { transaction } = bridgeStep;
-        const nativeFeeAmount = BigInt(transaction.value);
-
-        const sendParam = {
-          dstEid: getStargateChainId(EXPO_PUBLIC_CARD_FUNDING_CHAIN_ID) as number,
-          to: pad(destinationAddress as `0x${string}`, {
-            size: 32,
-          }),
-          amountLD: borrowAmountWei,
-          minAmountLD: dstAmountMin,
-          extraOptions: '0x',
-          composeMsg: '0x',
-          oftCmd: '0x',
-        };
-
-        const calldata = encodeFunctionData({
-          abi: CardDepositManager_ABI,
-          functionName: 'depositUsingStargate',
-          args: [
-            transaction.to as Address,
-            user.safeAddress as Address,
-            sendParam,
-            nativeFeeAmount,
-            ADDRESSES.fuse.bridgePaymasterAddress,
-          ],
-        });
-
-        const transactions = [
-          {
-            to: ADDRESSES.fuse.vault,
-            data: supplyApproveCalldata,
-            value: 0n,
-          },
-          {
-            to: ADDRESSES.fuse.aaveV3Pool,
-            data: supplyCalldata,
-            value: 0n,
-          },
-          {
-            to: ADDRESSES.fuse.aaveV3Pool,
-            data: borrowCalldata,
-            value: 0n,
-          },
-          // 1) Approve USDC.e from Safe to DepositManager
-          {
-            to: USDC_STARGATE,
-            data: encodeFunctionData({
-              abi: erc20Abi,
-              functionName: 'approve',
-              args: [ADDRESSES.fuse.cardDepositManager, borrowAmountWei],
-            }),
-            value: 0n,
-          },
-          // 2) Perform the Stargate taxi call via BridgePaymaster and DepositManager, forwarding the fee it now holds
-          {
-            to: ADDRESSES.fuse.bridgePaymasterAddress,
-            data: encodeFunctionData({
-              abi: BridgePayamster_ABI,
-              functionName: 'callWithValue',
-              args: [
-                ADDRESSES.fuse.cardDepositManager,
-                '0x37fe667d', // depositUsingStargate function selector
-                calldata,
-                nativeFeeAmount, // the native to forward
-              ],
-            }),
-            value: 0n,
-          },
-        ];
-
-        const smartAccountClient = await safeAA(fuse, user.suborgId, user.signWith);
-
-        const result = await trackTransaction(
-          {
-            type: TransactionType.BORROW_AND_DEPOSIT_TO_CARD,
-            title: `Borrow and deposit to Card`,
-            shortTitle: `Borrow and deposit to Card`,
-            amount: amountToBorrow,
-            symbol: 'USDC.e', // Source symbol - bridging USDC.e
-            chainId: fuse.id,
-            fromAddress: user.safeAddress,
-            toAddress: arbitrumFundingAddress,
-            metadata: {
-              description: `Borrow and deposit ${amountToBorrow} USDC from Fuse to Card on Arbitrum`,
-              fee: transaction.value,
-              sourceSymbol: 'USDC.e', // Track source symbol for display
-              tokenAddress: USDC_STARGATE,
-            },
-          },
-          onUserOpHash =>
-            executeTransactions(
-              smartAccountClient,
-              transactions,
-              'Borrow and deposit to Card failed',
-              fuse,
-              onUserOpHash,
-            ),
-        );
-
-        const transaction_result =
-          result && typeof result === 'object' && 'transaction' in result
-            ? result.transaction
-            : result;
-
-        if (transaction_result === USER_CANCELLED_TRANSACTION) {
-          const error = new Error('User cancelled transaction');
+        if (transactionResult === USER_CANCELLED_TRANSACTION) {
+          const err = new Error('User cancelled transaction');
           track(TRACKING_EVENTS.BRIDGE_TO_ARBITRUM_CANCELLED, {
             amount: amountToBorrow,
-            fee: transaction.value,
             from_chain: fuse.id,
             to_chain: EXPO_PUBLIC_CARD_FUNDING_CHAIN_ID,
             source: 'useBridgeToCard',
           });
-          Sentry.captureException(error, {
+          Sentry.captureException(err, {
             tags: {
               operation: 'bridge_to_card',
               step: 'execution',
@@ -324,22 +125,17 @@ const useBorrowAndDepositToCard = (): BridgeResult => {
             extra: {
               amount: amountToBorrow,
               userAddress: user.safeAddress,
-              destinationAddress,
+              destinationAddress: arbitrumFundingAddress,
               chainId: fuse.id,
-              fee: transaction.value,
             },
-            user: {
-              id: user?.userId,
-              address: user?.safeAddress,
-            },
+            user: { id: user.userId, address: user.safeAddress },
           });
-          throw error;
+          throw err;
         }
 
         track(TRACKING_EVENTS.BRIDGE_TO_ARBITRUM_COMPLETED, {
           amount: amountToBorrow,
-          transaction_hash: transaction_result.transactionHash,
-          fee: transaction.value,
+          transaction_hash: transactionResult.transactionHash,
           from_chain: fuse.id,
           to_chain: EXPO_PUBLIC_CARD_FUNDING_CHAIN_ID,
           source: 'useBridgeToCard',
@@ -350,49 +146,40 @@ const useBorrowAndDepositToCard = (): BridgeResult => {
           category: 'bridge',
           data: {
             amount: amountToBorrow,
-            transactionHash: transaction_result.transactionHash,
+            transactionHash: transactionResult.transactionHash,
             userAddress: user.safeAddress,
-            destinationAddress,
+            destinationAddress: arbitrumFundingAddress,
             chainId: fuse.id,
           },
         });
 
         setBridgeStatus(Status.SUCCESS);
-        return transaction_result;
-      } catch (error) {
-        console.error(error);
-
+        return transactionResult;
+      } catch (err) {
+        console.error(err);
         track(TRACKING_EVENTS.BRIDGE_TO_ARBITRUM_ERROR, {
           amount: amountToBorrow,
           from_chain: fuse.id,
           to_chain: EXPO_PUBLIC_CARD_FUNDING_CHAIN_ID,
-          error: error instanceof Error ? error.message : 'Unknown error',
-          user_cancelled: String(error).includes('cancelled'),
+          error: err instanceof Error ? err.message : 'Unknown error',
+          user_cancelled: String(err).includes('cancelled'),
           step: 'execution',
           source: 'useBridgeToCard',
         });
-
-        Sentry.captureException(error, {
-          tags: {
-            operation: 'bridge_to_card',
-            step: 'execution',
-          },
+        Sentry.captureException(err, {
+          tags: { operation: 'bridge_to_card', step: 'execution' },
           extra: {
             amount: amountToBorrow,
             userAddress: user?.safeAddress,
             chainId: fuse.id,
-            errorMessage: error instanceof Error ? error.message : 'Unknown error',
+            errorMessage: err instanceof Error ? err.message : 'Unknown error',
             bridgeStatus,
           },
-          user: {
-            id: user?.suborgId,
-            address: user?.safeAddress,
-          },
+          user: { id: user?.suborgId, address: user?.safeAddress },
         });
-
         setBridgeStatus(Status.ERROR);
-        setError(error instanceof Error ? error.message : 'Unknown error');
-        throw error;
+        setError(err instanceof Error ? err.message : 'Unknown error');
+        throw err;
       }
     },
     [user, cardDetails, provider, contracts, safeAA, trackTransaction, bridgeStatus],

--- a/lib/utils/borrowAndBridge.ts
+++ b/lib/utils/borrowAndBridge.ts
@@ -1,0 +1,256 @@
+import * as Sentry from '@sentry/react-native';
+import { Address } from 'abitype';
+import { Chain, erc20Abi, pad, TransactionReceipt } from 'viem';
+import { readContract } from 'viem/actions';
+import { fuse, mainnet } from 'viem/chains';
+import { encodeFunctionData, parseUnits } from 'viem/utils';
+
+import { USDC_STARGATE } from '@/constants/addresses';
+import { useActivityActions } from '@/hooks/useActivityActions';
+import { AaveV3Pool_ABI } from '@/lib/abis/AaveV3Pool';
+import BridgePayamster_ABI from '@/lib/abis/BridgePayamster';
+import { CardDepositManager_ABI } from '@/lib/abis/CardDepositManager';
+import { ADDRESSES } from '@/lib/config';
+import { executeTransactions, USER_CANCELLED_TRANSACTION } from '@/lib/execute';
+import { StargateQuoteParams, TransactionType } from '@/lib/types';
+import { getStargateChainId, getStargateQuote } from '@/lib/utils/stargate';
+import { publicClient } from '@/lib/wagmi';
+
+import type { SmartAccountClient } from 'permissionless';
+
+// EIP-3009 / Aave LTV — keep one source of truth shared by every flow that
+// borrows USDC against soUSD on Fuse and bridges via Stargate to a chosen
+// destination address.
+const SO_USD_LTV = 70n;
+
+// AccountantWithRateProviders.getRate() — shared between card + agent flows.
+const ACCOUNTANT_ABI = [
+  {
+    inputs: [],
+    name: 'getRate',
+    outputs: [{ internalType: 'uint256', name: 'rate', type: 'uint256' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+] as const;
+
+export interface BorrowAndBridgeUser {
+  safeAddress: string;
+  suborgId: string;
+  signWith: string;
+  userId: string;
+}
+
+export interface BorrowAndBridgeParams {
+  /** Connected user (must have safeAddress + AA signer context). */
+  user: BorrowAndBridgeUser;
+  /** Receiver of bridged USDC on the destination chain. */
+  destinationAddress: Address;
+  /** EVM chain id of the destination (e.g. base.id, arbitrum.id). */
+  destinationChainId: number;
+  /** Stargate's chain key for the destination ('base', 'arbitrum', ...). */
+  destinationChainKey: string;
+  /** USDC contract on the destination chain. */
+  destinationToken: Address;
+  /** Borrow amount as a human-readable USDC string (e.g. '10.5'). */
+  amountToBorrow: string;
+  /** AA signer factory used by the card flow (`useUser().safeAA`). */
+  safeAA: (chain: Chain, suborgId: string, signWith: string) => Promise<SmartAccountClient>;
+  /** Activity tracking — wires receipt + status into the in-app feed. */
+  trackTransaction: ReturnType<typeof useActivityActions>['trackTransaction'];
+  /** Activity payload metadata. */
+  activityType: TransactionType;
+  activityTitle: string;
+  /** Optional Sentry/analytics breadcrumb tag (purely cosmetic). */
+  flowTag?: string;
+}
+
+/**
+ * Core "borrow USDC.e against soUSD on Fuse → Stargate-bridge to a
+ * destination" flow used by both the card-funding and agent-wallet
+ * deposit paths. The CardDepositManager is destination-agnostic (the
+ * receiver allowlist is gated by `isWhitelistEnabled` which is off in
+ * prod), so the same on-chain plumbing handles both.
+ */
+export async function executeBorrowAndBridge(
+  params: BorrowAndBridgeParams,
+): Promise<TransactionReceipt | typeof USER_CANCELLED_TRANSACTION> {
+  const {
+    user,
+    destinationAddress,
+    destinationChainId,
+    destinationChainKey,
+    destinationToken,
+    amountToBorrow,
+    safeAA,
+    trackTransaction,
+    activityType,
+    activityTitle,
+    flowTag = 'borrow_and_bridge',
+  } = params;
+
+  const rate = await readContract(publicClient(mainnet.id), {
+    address: ADDRESSES.ethereum.accountant,
+    abi: ACCOUNTANT_ABI,
+    functionName: 'getRate',
+  });
+
+  const borrowAmountWei = parseUnits(amountToBorrow, 6);
+  const supplyAmountWei = (borrowAmountWei * 100n * 1000000n) / (SO_USD_LTV * rate);
+
+  const supplyApproveCalldata = encodeFunctionData({
+    abi: erc20Abi,
+    functionName: 'approve',
+    args: [ADDRESSES.fuse.aaveV3Pool, supplyAmountWei],
+  });
+
+  const supplyCalldata = encodeFunctionData({
+    abi: AaveV3Pool_ABI,
+    functionName: 'supply',
+    args: [ADDRESSES.fuse.vault, supplyAmountWei, user.safeAddress as Address, 0],
+  });
+
+  const borrowCalldata = encodeFunctionData({
+    abi: AaveV3Pool_ABI,
+    functionName: 'borrow',
+    args: [USDC_STARGATE, borrowAmountWei, 2, 0, user.safeAddress as Address],
+  });
+
+  Sentry.addBreadcrumb({
+    message: `Starting ${flowTag} transaction`,
+    category: 'bridge',
+    data: {
+      amount: amountToBorrow,
+      amountWei: borrowAmountWei.toString(),
+      userAddress: user.safeAddress,
+      destinationAddress,
+      destinationChainId,
+      chainId: fuse.id,
+    },
+  });
+
+  // 5% slippage envelope on the destination amount.
+  const dstAmountMin = (borrowAmountWei * 95n) / 100n;
+
+  const quoteParams: StargateQuoteParams = {
+    srcToken: USDC_STARGATE,
+    srcChainKey: 'fuse',
+    dstToken: destinationToken,
+    dstChainKey: destinationChainKey,
+    srcAddress: ADDRESSES.fuse.bridgePaymasterAddress,
+    dstAddress: destinationAddress,
+    srcAmount: borrowAmountWei.toString(),
+    dstAmountMin: dstAmountMin.toString(),
+  };
+  const quote = await getStargateQuote(quoteParams);
+  const taxiQuote = quote.quotes.find(q => q.route.includes('taxi'));
+  if (!taxiQuote) throw new Error('Taxi route not available from Stargate');
+  if (taxiQuote.error) throw new Error(`Stargate quote error: ${taxiQuote.error}`);
+
+  const bridgeStep = taxiQuote.steps.find(step => step.type === 'bridge');
+  if (!bridgeStep) throw new Error('No bridge step found in Stargate quote');
+
+  const { transaction } = bridgeStep;
+  const nativeFeeAmount = BigInt(transaction.value);
+
+  const sendParam = {
+    dstEid: getStargateChainId(destinationChainId) as number,
+    to: pad(destinationAddress, { size: 32 }),
+    amountLD: borrowAmountWei,
+    minAmountLD: dstAmountMin,
+    extraOptions: '0x' as `0x${string}`,
+    composeMsg: '0x' as `0x${string}`,
+    oftCmd: '0x' as `0x${string}`,
+  };
+
+  const calldata = encodeFunctionData({
+    abi: CardDepositManager_ABI,
+    functionName: 'depositUsingStargate',
+    args: [
+      transaction.to as Address,
+      user.safeAddress as Address,
+      sendParam,
+      nativeFeeAmount,
+      ADDRESSES.fuse.bridgePaymasterAddress,
+    ],
+  });
+
+  const transactions = [
+    {
+      to: ADDRESSES.fuse.vault,
+      data: supplyApproveCalldata,
+      value: 0n,
+    },
+    {
+      to: ADDRESSES.fuse.aaveV3Pool,
+      data: supplyCalldata,
+      value: 0n,
+    },
+    {
+      to: ADDRESSES.fuse.aaveV3Pool,
+      data: borrowCalldata,
+      value: 0n,
+    },
+    // Approve USDC.e from Safe to CardDepositManager (manager is destination-agnostic).
+    {
+      to: USDC_STARGATE,
+      data: encodeFunctionData({
+        abi: erc20Abi,
+        functionName: 'approve',
+        args: [ADDRESSES.fuse.cardDepositManager, borrowAmountWei],
+      }),
+      value: 0n,
+    },
+    // Forward the LZ native fee from BridgePaymaster (which is sponsored
+    // for the depositUsingStargate selector) and let the manager call
+    // Stargate's send().
+    {
+      to: ADDRESSES.fuse.bridgePaymasterAddress,
+      data: encodeFunctionData({
+        abi: BridgePayamster_ABI,
+        functionName: 'callWithValue',
+        args: [
+          ADDRESSES.fuse.cardDepositManager,
+          '0x37fe667d', // depositUsingStargate selector
+          calldata,
+          nativeFeeAmount,
+        ],
+      }),
+      value: 0n,
+    },
+  ];
+
+  const smartAccountClient = await safeAA(fuse, user.suborgId, user.signWith);
+
+  const result = await trackTransaction(
+    {
+      type: activityType,
+      title: activityTitle,
+      shortTitle: activityTitle,
+      amount: amountToBorrow,
+      symbol: 'USDC.e',
+      chainId: fuse.id,
+      fromAddress: user.safeAddress,
+      toAddress: destinationAddress,
+      metadata: {
+        description: `${activityTitle} ${amountToBorrow} USDC from Fuse to ${destinationAddress} on chain ${destinationChainId}`,
+        fee: transaction.value,
+        sourceSymbol: 'USDC.e',
+        tokenAddress: USDC_STARGATE,
+      },
+    },
+    onUserOpHash =>
+      executeTransactions(
+        smartAccountClient,
+        transactions,
+        `${activityTitle} failed`,
+        fuse,
+        onUserOpHash,
+      ),
+  );
+
+  const transactionResult =
+    result && typeof result === 'object' && 'transaction' in result ? result.transaction : result;
+
+  return transactionResult as TransactionReceipt | typeof USER_CANCELLED_TRANSACTION;
+}


### PR DESCRIPTION
…lance gradient

Borrow flow:
- Extract the heavy lifting of useBorrowAndDepositToCard into a shared inner async helper at lib/utils/borrowAndBridge.ts. The function takes destinationAddress + destinationChainId/Key + destinationToken so the same on-chain transaction batch (approve soUSD → Aave supply → borrow USDC.e → approve CardDepositManager → BridgePaymaster callWithValue) handles any Stargate destination.
- useBorrowAndDepositToCard becomes a thin wrapper that resolves the card-funding address and forwards to the helper. Existing tracking events + Sentry breadcrumbs preserved.
- New useBorrowAndDepositToAgent wraps the same helper with the agent EOA + base.id + Stargate Base USDC, and emits AGENT_WALLET_DEPOSIT activities.
- The CardDepositManager forwards regardless of receiver because isWhitelistEnabled is off in prod (verified: no caller of authorizeCards or setWhitelistEnabled in this repo or boring-vault), so we reuse the existing manager + sponsorship path on BridgePaymaster — no new contract, no new sponsor tx.

Modal:
- New AgentDepositModal: amount input, live borrow position (useAaveBorrowPosition), Max button capped at totalSupplied * LTV - totalBorrowed, brand-variant Borrow CTA. On submit invokes the new hook; toast on success/failure; modal closes on success.
- Bound to the Agent page Deposit button (replaces the 'coming soon' toast). Mobile circular Deposit button opens the same modal.

Page header:
- Copy prompt button moved out of IntegrationSnippet and into the page-header button group, alongside Generate API key + Deposit. Uses the same secondary 'h-12 rounded-xl bg-[#303030] px-6' styling as Generate API key, with a FileText icon. Mobile gets a third dark CircleAction labelled 'Prompt'.
- IntegrationSnippet now only renders the curl example + copy affordance and points users at the header for the prompt template.

Balance card:
- Replace the bg-[#1C1C1C] balance box with a /card/details-style SpendingBalanceCard: rounded-[20px], green LinearGradient overlay (rgba(104,216,82,…)), 50px USDC balance up top, 'Earning yield on idle USDC' caption underneath. Address moves into the API keys card so the balance card stays a hero panel.