### PR TITLE
feat(agent): ResponsiveModal deposit flow + centered header + blue ba…

### DIFF
--- a/app/(protected)/agent/index.tsx
+++ b/app/(protected)/agent/index.tsx
@@ -129,7 +129,7 @@ export default function AgentPage() {
       <View
         className={
           isProvisioned
-            ? 'mx-auto w-full max-w-5xl gap-6 px-4 py-6 md:py-10'
+            ? 'mx-auto w-full max-w-7xl gap-10 px-4 py-6 md:gap-12 md:py-12'
             : 'mx-auto w-full max-w-lg gap-6 px-4 pt-8'
         }
       >
@@ -224,8 +224,8 @@ function ProvisionedHeader({
 }: ProvisionedHeaderProps) {
   if (isScreenMedium) {
     return (
-      <View className="flex-row items-end justify-between">
-        <View className="gap-1">
+      <View className="items-center gap-6">
+        <View className="items-center gap-1">
           <Text className="text-5xl font-semibold">Agent Wallet</Text>
           <Text className="text-base text-muted-foreground">Your Solid Wallet is now Agentic</Text>
         </View>
@@ -330,31 +330,33 @@ interface BalanceCardProps {
 }
 
 /**
- * Mirrors /card/details `SpendingBalanceCard` styling — green LinearGradient
- * over a rounded-[20px] base, big balance up top, secondary stat under it.
+ * Mirrors /card/details `SpendingBalanceCard` shape — rounded-[20px] base
+ * with a LinearGradient overlay, big balance up top, secondary stat under
+ * it. Blue palette so the agent page reads distinctly from the green card
+ * page, purple savings, and yellow rewards.
  */
 function BalanceCard({ balance, balanceLoading }: BalanceCardProps) {
   const formatted = balanceLoading ? null : formatUsdc(balance);
   return (
-    <View className="relative h-full overflow-hidden rounded-[20px] px-[36px] py-[30px]">
+    <View className="relative h-full min-h-[260px] overflow-hidden rounded-[20px] px-[36px] py-[30px]">
       <LinearGradient
-        colors={['rgba(104, 216, 82, 1)', 'rgba(104, 216, 82, 0.4)']}
+        colors={['rgba(74, 144, 226, 1)', 'rgba(120, 192, 250, 0.55)']}
         start={{ x: 0.5, y: 0 }}
         end={{ x: 0.6, y: 1 }}
         pointerEvents="none"
         style={{ position: 'absolute', top: 0, left: 0, right: 0, bottom: 0 }}
       />
-      <View className="flex-1 justify-between">
+      <View className="flex-1 justify-between gap-12">
         <View>
-          <Text className="mb-2 text-base text-white/60">USDC balance on Base</Text>
+          <Text className="mb-2 text-base text-white/70">Spendable balance</Text>
           {balanceLoading ? (
             <ActivityIndicator color="white" />
           ) : (
-            <Text className="text-[50px] font-semibold text-white">{formatted}</Text>
+            <Text className="text-[50px] font-semibold leading-tight text-white">{formatted}</Text>
           )}
         </View>
         <View>
-          <Text className="mb-1 text-lg font-medium text-white/50">Earning</Text>
+          <Text className="mb-1 text-lg font-medium text-white/60">Earning</Text>
           <Text className="text-2xl font-semibold text-white">Yield on idle USDC</Text>
         </View>
       </View>

--- a/components/Agent/AgentDepositModal.tsx
+++ b/components/Agent/AgentDepositModal.tsx
@@ -1,22 +1,21 @@
 import { useEffect, useMemo, useState } from 'react';
 import { ActivityIndicator, TextInput, View } from 'react-native';
 import Toast from 'react-native-toast-message';
+import { Image } from 'expo-image';
 
+import ResponsiveModal from '@/components/ResponsiveModal';
 import { Button } from '@/components/ui/button';
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogHeader,
-  DialogTitle,
-} from '@/components/ui/dialog';
 import { Text } from '@/components/ui/text';
 import { useAaveBorrowPosition } from '@/hooks/useAaveBorrowPosition';
 import useBorrowAndDepositToAgent from '@/hooks/useBorrowAndDepositToAgent';
+import { getAsset } from '@/lib/assets';
 import { Status } from '@/lib/types';
 
 const SO_USD_LTV = 0.7; // mirror SO_USD_LTV in lib/utils/borrowAndBridge.ts
 const MIN_BORROW_USDC = 1; // smallest amount worth a userOp + Stargate fee
+
+const MODAL_OPEN = { name: 'agent-deposit', number: 1 } as const;
+const MODAL_CLOSE = { name: 'close', number: 0 } as const;
 
 type Props = {
   open: boolean;
@@ -66,80 +65,102 @@ const AgentDepositModal = ({ open, onClose, agentEoaAddress }: Props) => {
   };
 
   return (
-    <Dialog open={open} onOpenChange={isOpen => !isOpen && !submitting && onClose()}>
-      <DialogContent className="max-w-lg">
-        <DialogHeader>
-          <DialogTitle>Deposit to Agent Wallet</DialogTitle>
-          <DialogDescription>
-            Borrow USDC against your soUSD savings on Fuse and bridge it to your agent EOA on Base
-            via Stargate. Idle savings keep earning yield.
-          </DialogDescription>
-        </DialogHeader>
+    <ResponsiveModal
+      currentModal={open ? MODAL_OPEN : MODAL_CLOSE}
+      previousModal={open ? MODAL_CLOSE : MODAL_OPEN}
+      isOpen={open}
+      onOpenChange={value => {
+        if (!value && !submitting) onClose();
+      }}
+      trigger={null}
+      title="Deposit to Agent Wallet"
+      containerClassName="min-h-[42rem] overflow-y-auto flex-1"
+      contentKey="agent-deposit"
+    >
+      <View className="gap-4">
+        <Text className="font-medium opacity-50">Borrow against Savings</Text>
 
-        <View className="gap-4">
-          <View className="rounded-xl bg-[#262626] p-4">
-            <Text className="text-xs uppercase text-white/60">Available to borrow</Text>
+        {/* Amount input — same shape as Card's AmountInput */}
+        <View className="gap-2">
+          <Text className="font-medium opacity-50">Amount to borrow</Text>
+          <View className="w-full flex-row items-center justify-between gap-4 rounded-2xl bg-accent px-5 py-3">
+            <TextInput
+              keyboardType="decimal-pad"
+              className="text-2xl font-semibold text-white web:w-full web:focus:outline-none"
+              value={amount}
+              placeholder="0.0"
+              placeholderTextColor="#666"
+              onChangeText={setAmount}
+              editable={!submitting}
+            />
+            <View className="flex-row items-center gap-2">
+              <Image
+                source={getAsset('images/usdc-4x.png')}
+                alt="USDC"
+                style={{ width: 34, height: 34 }}
+              />
+              <Text className="text-lg font-semibold text-white">USDC</Text>
+            </View>
+          </View>
+        </View>
+
+        {/* Borrow position summary — mirror BalanceDisplay */}
+        <View className="flex-row items-center justify-between rounded-2xl bg-accent px-5 py-4">
+          <View className="gap-1">
+            <Text className="text-sm opacity-50">Available to borrow</Text>
             {positionLoading ? (
-              <ActivityIndicator size="small" color="white" className="mt-2 self-start" />
+              <ActivityIndicator size="small" color="white" />
             ) : (
-              <Text className="text-2xl font-semibold text-white">
+              <Text className="text-xl font-semibold text-white">
                 ${maxBorrowable.toLocaleString(undefined, { maximumFractionDigits: 2 })}
               </Text>
             )}
-            <Text className="mt-1 text-xs text-white/60">
-              Currently borrowed: $
-              {totalBorrowed.toLocaleString(undefined, { maximumFractionDigits: 2 })} · Supplied: $
-              {totalSupplied.toLocaleString(undefined, { maximumFractionDigits: 2 })} soUSD
-            </Text>
           </View>
-
-          <View className="gap-2">
-            <Text className="text-xs uppercase text-white/60">Amount (USDC)</Text>
-            <TextInput
-              value={amount}
-              onChangeText={setAmount}
-              keyboardType="decimal-pad"
-              placeholder="0.00"
-              placeholderTextColor="#7A7A7A"
-              editable={!submitting}
-              className="rounded-xl bg-[#262626] px-4 py-3 text-2xl font-semibold text-white"
-            />
-            <View className="flex-row justify-end">
-              <Button
-                variant="ghost"
-                size="sm"
-                onPress={() =>
-                  setAmount(
-                    maxBorrowable > 0 ? maxBorrowable.toFixed(2) : MIN_BORROW_USDC.toString(),
-                  )
-                }
-                disabled={positionLoading || submitting}
-              >
-                <Text className="text-xs text-white/60">Max</Text>
-              </Button>
-            </View>
-          </View>
-
           <Button
-            variant="brand"
-            className="h-12 w-full rounded-xl"
-            disabled={!amountValid || submitting}
-            onPress={handleSubmit}
+            variant="ghost"
+            size="sm"
+            disabled={positionLoading || submitting || maxBorrowable <= 0}
+            onPress={() => setAmount(maxBorrowable.toFixed(2))}
           >
-            <View className="flex-row items-center gap-2">
-              {submitting ? <ActivityIndicator size="small" color="black" /> : null}
-              <Text className="text-base font-bold text-primary-foreground">
-                {submitting
-                  ? 'Borrowing + bridging…'
-                  : amountValid
-                    ? `Borrow $${parsedAmount.toFixed(2)}`
-                    : 'Enter an amount'}
-              </Text>
-            </View>
+            <Text className="text-sm font-semibold opacity-70">Max</Text>
           </Button>
         </View>
-      </DialogContent>
-    </Dialog>
+
+        {/* Position breakdown */}
+        <View className="rounded-2xl bg-accent px-5 py-4">
+          <View className="flex-row items-center justify-between">
+            <Text className="text-sm opacity-50">Currently borrowed</Text>
+            <Text className="text-sm font-medium text-white">
+              ${totalBorrowed.toLocaleString(undefined, { maximumFractionDigits: 2 })}
+            </Text>
+          </View>
+          <View className="mt-2 flex-row items-center justify-between">
+            <Text className="text-sm opacity-50">Supplied as collateral</Text>
+            <Text className="text-sm font-medium text-white">
+              ${totalSupplied.toLocaleString(undefined, { maximumFractionDigits: 2 })} soUSD
+            </Text>
+          </View>
+        </View>
+
+        <Button
+          variant="brand"
+          className="mt-2 h-12 w-full rounded-xl"
+          disabled={!amountValid || submitting}
+          onPress={handleSubmit}
+        >
+          <View className="flex-row items-center gap-2">
+            {submitting ? <ActivityIndicator size="small" color="black" /> : null}
+            <Text className="text-base font-bold text-primary-foreground">
+              {submitting
+                ? 'Borrowing + bridging…'
+                : amountValid
+                  ? `Borrow $${parsedAmount.toFixed(2)}`
+                  : 'Enter an amount'}
+            </Text>
+          </View>
+        </Button>
+      </View>
+    </ResponsiveModal>
   );
 };
 

--- a/components/Agent/IntegrationSnippet.tsx
+++ b/components/Agent/IntegrationSnippet.tsx
@@ -8,7 +8,7 @@ const IntegrationSnippet = () => {
   const snippet = AGENT_INTEGRATION_CURL();
   return (
     <View className="gap-3">
-      <Text className="text-sm text-white/60">
+      <Text className="max-w-xl text-sm text-white/60">
         Paste this curl example into a script or n8n node, or copy the AI prompt template from the
         page header to wire up Claude Desktop / ChatGPT instructions.
       </Text>


### PR DESCRIPTION
…lance card

Modal:
- Rebuild AgentDepositModal on top of ResponsiveModal with the same containerClassName='min-h-[42rem] overflow-y-auto flex-1' that the card deposit uses, so size + animation + header back-button behavior match. Inner content adopts CardDepositInternalForm primitives: bg-accent rounded-2xl px-5 py-{3,4} blocks, 'Amount to borrow' label
  + USDC token icon + 2xl input, 'Available to borrow / Max' row, and a small position breakdown (Currently borrowed, Supplied as collateral). Brand-variant Borrow CTA at the bottom.

Provisioned page:
- Bump max-width from max-w-5xl to max-w-7xl to match /card/details:150.
- Center the desktop header (title block + button row stacked, both items-center) instead of the previous flex-row justify-between.
- Bump page-level gap from gap-6 to gap-10 (gap-12 on md) so the header breathes above the boxes.
- Add max-w-xl to IntegrationSnippet's description so the line length isn't card-wide on desktop.

Balance card:
- Switch the LinearGradient palette from green rgba(104,216,82,…) to blue rgba(74,144,226,1) → rgba(120,192,250,0.55) so the agent page reads distinctly from the green card surface, purple savings, and yellow rewards.
- Rename label from 'USDC balance on Base' to 'Spendable balance' to match /card/details copy.
- Add gap-12 between the balance and 'Earning' rows so the two blocks are visually separated, with min-h-[260px] floor to match the card card's minimum hero height.