### PR TITLE
style(agent): restore flex-row justify-between in desktop header

### DIFF
--- a/app/(protected)/agent/index.tsx
+++ b/app/(protected)/agent/index.tsx
@@ -224,8 +224,8 @@ function ProvisionedHeader({
 }: ProvisionedHeaderProps) {
   if (isScreenMedium) {
     return (
-      <View className="items-center gap-6">
-        <View className="items-center gap-1">
+      <View className="mx-auto flex-row items-end justify-between">
+        <View className="gap-1">
           <Text className="text-5xl font-semibold">Agent Wallet</Text>
           <Text className="text-base text-muted-foreground">Your Solid Wallet is now Agentic</Text>
         </View>


### PR DESCRIPTION
Revert the items-center stack to the original layout (title left, buttons right) with mx-auto on the row so the whole header still sits centered within the max-w-7xl page wrapper.