### PR TITLE
refactor(agent): session-stamped provisioning flow

### DIFF
--- a/hooks/useAgent.ts
+++ b/hooks/useAgent.ts
@@ -1,5 +1,6 @@
 import Toast from 'react-native-toast-message';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { StamperType, useTurnkey } from '@turnkey/react-native-wallet-kit';
 import { Address, erc20Abi } from 'viem';
 import { base } from 'viem/chains';
 
@@ -8,8 +9,12 @@ import {
   fetchAgentApiKeys,
   fetchAgentHasDeposited,
   generateAgentApiKey,
-  provisionAgent,
+  provisionAgentInit,
+  provisionAgentPolicy,
+  provisionAgentUser,
+  provisionAgentWalletAccount,
   revokeAgentApiKey,
+  type SignedTurnkeyRequest,
 } from '@/lib/api';
 import { AgentApiKeySummary, AgentSummary, GenerateAgentApiKeyResponse } from '@/lib/types';
 import { withRefreshToken } from '@/lib/utils';
@@ -75,10 +80,68 @@ export const useAgentDeposited = (enabled: boolean) =>
     gcTime: 24 * 60 * 60 * 1000,
   });
 
+/**
+ * Drives the four-step session-stamped provisioning flow:
+ *   init → walletAccount → user → policy
+ *
+ * Each step's body is built by the backend; the user's Turnkey session API
+ * key signs them via `httpClient.stampX(body, StamperType.ApiKey)`. We mint
+ * (or refresh) the session up front with one passkey gesture, then every
+ * subsequent stamp is silent.
+ */
 export const useProvisionAgent = () => {
   const queryClient = useQueryClient();
+  const { httpClient, loginWithPasskey, refreshSession, getSession } = useTurnkey();
+
   return useMutation({
-    mutationFn: () => withRefreshToken(() => provisionAgent()),
+    mutationFn: async () => {
+      // 1. Backend mints the provisioning record + first activity body.
+      const { provisioningId, activity: walletAcctActivity } = await withRefreshToken(() =>
+        provisionAgentInit(),
+      );
+
+      // 2. Establish a Turnkey read-write session — one passkey gesture if
+      //    we don't already have a live session with enough headroom.
+      await ensureSession({ getSession, refreshSession, loginWithPasskey });
+
+      if (!httpClient) {
+        throw new Error('Turnkey httpClient is not initialized');
+      }
+
+      // 3. Stamp + relay createWalletAccounts (silent; uses session API key).
+      const signed1 = await httpClient.stampCreateWalletAccounts(
+        walletAcctActivity.body as Parameters<typeof httpClient.stampCreateWalletAccounts>[0],
+        StamperType.ApiKey,
+      );
+      if (!signed1) throw new Error('Failed to stamp createWalletAccounts');
+      const { activity: usersActivity } = await provisionAgentWalletAccount({
+        provisioningId,
+        signed: signed1 as SignedTurnkeyRequest,
+      });
+
+      // 4. Stamp + relay createUsers.
+      const signed2 = await httpClient.stampCreateUsers(
+        usersActivity.body as Parameters<typeof httpClient.stampCreateUsers>[0],
+        StamperType.ApiKey,
+      );
+      if (!signed2) throw new Error('Failed to stamp createUsers');
+      const { activity: policyActivity } = await provisionAgentUser({
+        provisioningId,
+        signed: signed2 as SignedTurnkeyRequest,
+      });
+
+      // 5. Stamp + relay createPolicy. Backend has now baked
+      //    agentTurnkeyUserId into the CEL.
+      const signed3 = await httpClient.stampCreatePolicy(
+        policyActivity.body as Parameters<typeof httpClient.stampCreatePolicy>[0],
+        StamperType.ApiKey,
+      );
+      if (!signed3) throw new Error('Failed to stamp createPolicy');
+      return provisionAgentPolicy({
+        provisioningId,
+        signed: signed3 as SignedTurnkeyRequest,
+      });
+    },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: AGENT_QUERY_KEY });
       queryClient.invalidateQueries({ queryKey: ['user'] });
@@ -89,14 +152,41 @@ export const useProvisionAgent = () => {
         props: { badgeText: 'Success' },
       });
     },
-    onError: () => {
+    onError: (err: unknown) => {
+      const message =
+        err && typeof err === 'object' && 'message' in err && typeof err.message === 'string'
+          ? err.message
+          : undefined;
       Toast.show({
         type: 'error',
         text1: 'Failed to provision agent',
+        text2: message?.toLowerCase().includes('cancel')
+          ? 'Passkey prompt was cancelled'
+          : undefined,
         props: { badgeText: 'Error' },
       });
     },
   });
+};
+
+const SESSION_HEADROOM_SECONDS = 60;
+
+const ensureSession = async (deps: {
+  getSession: ReturnType<typeof useTurnkey>['getSession'];
+  refreshSession: ReturnType<typeof useTurnkey>['refreshSession'];
+  loginWithPasskey: ReturnType<typeof useTurnkey>['loginWithPasskey'];
+}) => {
+  const existing = await deps.getSession();
+  const nowSeconds = Date.now() / 1000;
+  if (existing && existing.expiry > nowSeconds + SESSION_HEADROOM_SECONDS) {
+    try {
+      await deps.refreshSession({ expirationSeconds: '900' });
+      return;
+    } catch {
+      // Fall through to a fresh passkey login.
+    }
+  }
+  await deps.loginWithPasskey({ expirationSeconds: '900' });
 };
 
 export const useAgentApiKeys = () =>

--- a/hooks/useAgent.ts
+++ b/hooks/useAgent.ts
@@ -14,9 +14,13 @@ import {
   provisionAgentUser,
   provisionAgentWalletAccount,
   revokeAgentApiKey,
-  type SignedTurnkeyRequest,
 } from '@/lib/api';
-import { AgentApiKeySummary, AgentSummary, GenerateAgentApiKeyResponse } from '@/lib/types';
+import {
+  AgentApiKeySummary,
+  AgentSummary,
+  GenerateAgentApiKeyResponse,
+  SignedTurnkeyRequest,
+} from '@/lib/types';
 import { withRefreshToken } from '@/lib/utils';
 import { getStargateToken } from '@/lib/utils/stargate';
 import { publicClient } from '@/lib/wagmi';

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -2558,15 +2558,53 @@ const agentJsonHeaders = () => {
   };
 };
 
-export const provisionAgent = async (): Promise<{ agentEoaAddress: string }> => {
-  const response = await fetch(agentEndpoint('/provision'), {
+/**
+ * Envelope returned by the Turnkey SDK's `stampX` methods. `body` is the
+ * exact stringified bytes the SDK signed — we MUST forward it verbatim;
+ * re-serializing on the server changes key order and breaks the stamp.
+ */
+export type SignedTurnkeyRequest = {
+  url: string;
+  body: string;
+  stamp: { stampHeaderName: string; stampHeaderValue: string };
+};
+
+export type ProvisioningActivity = {
+  url: string;
+  body: Record<string, unknown>;
+};
+
+const postAgentJson = async <T>(path: string, body?: unknown): Promise<T> => {
+  const response = await fetch(agentEndpoint(path), {
     method: 'POST',
     headers: agentJsonHeaders(),
     credentials: 'include',
+    body: body === undefined ? undefined : JSON.stringify(body),
   });
   if (!response.ok) throw response;
   return response.json();
 };
+
+export const provisionAgentInit = (): Promise<{
+  provisioningId: string;
+  activity: ProvisioningActivity;
+}> => postAgentJson('/provision/init');
+
+export const provisionAgentWalletAccount = (input: {
+  provisioningId: string;
+  signed: SignedTurnkeyRequest;
+}): Promise<{ activity: ProvisioningActivity }> =>
+  postAgentJson('/provision/wallet-account', input);
+
+export const provisionAgentUser = (input: {
+  provisioningId: string;
+  signed: SignedTurnkeyRequest;
+}): Promise<{ activity: ProvisioningActivity }> => postAgentJson('/provision/user', input);
+
+export const provisionAgentPolicy = (input: {
+  provisioningId: string;
+  signed: SignedTurnkeyRequest;
+}): Promise<{ agentEoaAddress: string }> => postAgentJson('/provision/policy', input);
 
 export const fetchAgent = async (): Promise<AgentSummary> => {
   const response = await fetch(agentEndpoint('/me'), {

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -76,8 +76,11 @@ import {
   MppCredentialsResponse,
   Points,
   PromotionsBannerResponse,
+  ProvisioningActivity,
+  ProvisioningInitResponse,
   ProvisioningSessionRequest,
   ProvisioningSessionResponse,
+  ProvisioningStepInput,
   RainConsumerType,
   RainContractResponseDto,
   RainKycSubmitResponse,
@@ -2558,22 +2561,6 @@ const agentJsonHeaders = () => {
   };
 };
 
-/**
- * Envelope returned by the Turnkey SDK's `stampX` methods. `body` is the
- * exact stringified bytes the SDK signed — we MUST forward it verbatim;
- * re-serializing on the server changes key order and breaks the stamp.
- */
-export type SignedTurnkeyRequest = {
-  url: string;
-  body: string;
-  stamp: { stampHeaderName: string; stampHeaderValue: string };
-};
-
-export type ProvisioningActivity = {
-  url: string;
-  body: Record<string, unknown>;
-};
-
 const postAgentJson = async <T>(path: string, body?: unknown): Promise<T> => {
   const response = await fetch(agentEndpoint(path), {
     method: 'POST',
@@ -2585,26 +2572,20 @@ const postAgentJson = async <T>(path: string, body?: unknown): Promise<T> => {
   return response.json();
 };
 
-export const provisionAgentInit = (): Promise<{
-  provisioningId: string;
-  activity: ProvisioningActivity;
-}> => postAgentJson('/provision/init');
+export const provisionAgentInit = (): Promise<ProvisioningInitResponse> =>
+  postAgentJson('/provision/init');
 
-export const provisionAgentWalletAccount = (input: {
-  provisioningId: string;
-  signed: SignedTurnkeyRequest;
-}): Promise<{ activity: ProvisioningActivity }> =>
-  postAgentJson('/provision/wallet-account', input);
+export const provisionAgentWalletAccount = (
+  input: ProvisioningStepInput,
+): Promise<{ activity: ProvisioningActivity }> => postAgentJson('/provision/wallet-account', input);
 
-export const provisionAgentUser = (input: {
-  provisioningId: string;
-  signed: SignedTurnkeyRequest;
-}): Promise<{ activity: ProvisioningActivity }> => postAgentJson('/provision/user', input);
+export const provisionAgentUser = (
+  input: ProvisioningStepInput,
+): Promise<{ activity: ProvisioningActivity }> => postAgentJson('/provision/user', input);
 
-export const provisionAgentPolicy = (input: {
-  provisioningId: string;
-  signed: SignedTurnkeyRequest;
-}): Promise<{ agentEoaAddress: string }> => postAgentJson('/provision/policy', input);
+export const provisionAgentPolicy = (
+  input: ProvisioningStepInput,
+): Promise<{ agentEoaAddress: string }> => postAgentJson('/provision/policy', input);
 
 export const fetchAgent = async (): Promise<AgentSummary> => {
   const response = await fetch(agentEndpoint('/me'), {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1548,6 +1548,32 @@ export type AgentApiKeySummary = {
 
 export type GenerateAgentApiKeyResponse = AgentApiKeySummary & { key: string };
 
+/**
+ * Envelope returned by the Turnkey SDK's `stampX` methods. `body` is the
+ * exact stringified bytes the SDK signed — we MUST forward it verbatim;
+ * re-serializing on the server changes key order and breaks the stamp.
+ */
+export type SignedTurnkeyRequest = {
+  url: string;
+  body: string;
+  stamp: { stampHeaderName: string; stampHeaderValue: string };
+};
+
+export type ProvisioningActivity = {
+  url: string;
+  body: Record<string, unknown>;
+};
+
+export type ProvisioningInitResponse = {
+  provisioningId: string;
+  activity: ProvisioningActivity;
+};
+
+export type ProvisioningStepInput = {
+  provisioningId: string;
+  signed: SignedTurnkeyRequest;
+};
+
 export interface WhatsNewStep {
   imageUrl: string;
   title: string;


### PR DESCRIPTION
Replaces the single POST /v1/agents/provision call with the four-step init → walletAccount → user → policy chain. We mint (or refresh) a Turnkey read-write session up front with one passkey gesture, then each step silently API-key-stamps the unsigned activity body the backend hands us and posts the signed envelope back. Backend relays the signed bytes to Turnkey verbatim, so the stamp still validates.

This fixes the ORGANIZATION_MISMATCH error users hit on Set up Agent — the parent-org admin can't sign writes against existing sub-orgs.