### PR TITLE
feat(agent): QR-only external deposit, non-prod borrow warning, ask-f…

### DIFF
--- a/components/Agent/AgentDepositExternalForm.tsx
+++ b/components/Agent/AgentDepositExternalForm.tsx
@@ -1,246 +1,63 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
-import { Controller, useForm } from 'react-hook-form';
-import { ActivityIndicator, TextInput, View } from 'react-native';
-import Toast from 'react-native-toast-message';
+import { Linking, Pressable, View } from 'react-native';
 import { Image } from 'expo-image';
-import { zodResolver } from '@hookform/resolvers/zod';
-import { Wallet as WalletIcon } from 'lucide-react-native';
-import { useActiveAccount, useSwitchActiveWalletChain } from 'thirdweb/react';
-import { Address, encodeFunctionData, erc20Abi, formatUnits, parseUnits } from 'viem';
-import { useReadContract } from 'wagmi';
-import { z } from 'zod';
+import { ChevronRight, Info } from 'lucide-react-native';
 
-import ConnectedWalletDropdown from '@/components/ConnectedWalletDropdown';
-import Max from '@/components/Max';
-import { Button } from '@/components/ui/button';
-import Skeleton from '@/components/ui/skeleton';
+import DepositPublicAddress from '@/components/DepositOption/DepositPublicAddress';
 import { Text } from '@/components/ui/text';
-import { useActivityActions } from '@/hooks/useActivityActions';
-import { getAsset } from '@/lib/assets';
-import { ADDRESSES } from '@/lib/config';
-import { getChain } from '@/lib/thirdweb';
-import { Status, TransactionStatus, TransactionType } from '@/lib/types';
-import { cn, formatNumber } from '@/lib/utils';
 
-const BASE_CHAIN_ID = 8453;
-const BASE_USDC_ADDRESS = ADDRESSES.base.usdc as Address;
-
-type FormData = { amount: string };
+const SUPPORTED_NETWORKS_URL =
+  'https://support.solid.xyz/en/articles/14431132-supported-networks-and-tokens-on-solid';
+const baseIcon = require('@/assets/images/base.png');
 
 type Props = {
   agentEoaAddress: string;
-  onSuccess: () => void;
 };
 
-const AgentDepositExternalForm = ({ agentEoaAddress, onSuccess }: Props) => {
-  const account = useActiveAccount();
-  const switchChain = useSwitchActiveWalletChain();
-  const { createActivity, updateActivity } = useActivityActions();
-  const [sendStatus, setSendStatus] = useState<Status>(Status.IDLE);
-
-  const eoaAddress = account?.address as Address | undefined;
-  const { data: eoaTokenBalance, isLoading: isEOABalanceLoading } = useReadContract({
-    abi: erc20Abi,
-    address: BASE_USDC_ADDRESS,
-    functionName: 'balanceOf',
-    args: [eoaAddress as Address],
-    chainId: BASE_CHAIN_ID,
-    query: { enabled: !!eoaAddress },
-  });
-
-  const formattedBalance = eoaTokenBalance ? formatUnits(eoaTokenBalance, 6) : '0';
-
-  const schema = useMemo(() => {
-    const balanceAmount = Number(formattedBalance);
-    return z.object({
-      amount: z
-        .string()
-        .refine(val => val !== '' && !isNaN(Number(val)), { error: 'Enter a valid amount' })
-        .refine(val => Number(val) > 0, { error: 'Amount must be greater than 0' })
-        .refine(val => Number(val) <= balanceAmount, {
-          error: `Available balance is ${formatNumber(balanceAmount)} USDC`,
-        }),
-    });
-  }, [formattedBalance]);
-
-  const { control, handleSubmit, formState, watch, reset, setValue, trigger } = useForm<FormData>({
-    resolver: zodResolver(schema) as any,
-    mode: 'onChange',
-    defaultValues: { amount: '' },
-  });
-
-  const watchedAmount = watch('amount');
-
-  // Reset form on unmount.
-  useEffect(() => () => reset(), [reset]);
-
-  const onSubmit = useCallback(
-    async (data: FormData) => {
-      if (!account) {
-        Toast.show({
-          type: 'error',
-          text1: 'Wallet not connected',
-          text2: 'Please connect your wallet to continue',
-        });
-        return;
-      }
-      try {
-        setSendStatus(Status.PENDING);
-
-        const baseChain = getChain(BASE_CHAIN_ID);
-        if (baseChain) {
-          try {
-            await switchChain(baseChain);
-          } catch (chainError) {
-            console.error('Failed to switch to Base:', chainError);
-            Toast.show({
-              type: 'error',
-              text1: 'Network switch failed',
-              text2: 'Please manually switch your wallet to Base mainnet.',
-            });
-            setSendStatus(Status.ERROR);
-            return;
-          }
-        }
-
-        const amountWei = parseUnits(data.amount, 6);
-        const clientTxId = await createActivity({
-          type: TransactionType.AGENT_WALLET_DEPOSIT,
-          title: 'Deposit to Agent Wallet',
-          shortTitle: 'Agent Deposit',
-          amount: data.amount,
-          symbol: 'USDC',
-          chainId: BASE_CHAIN_ID,
-          fromAddress: account.address,
-          toAddress: agentEoaAddress,
-          status: TransactionStatus.PENDING,
-          metadata: {
-            description: `Deposit ${data.amount} USDC to agent wallet from external wallet`,
-            tokenAddress: BASE_USDC_ADDRESS,
-          },
-        });
-
-        const tx = await account.sendTransaction({
-          chainId: BASE_CHAIN_ID,
-          to: BASE_USDC_ADDRESS,
-          data: encodeFunctionData({
-            abi: erc20Abi,
-            functionName: 'transfer',
-            args: [agentEoaAddress as Address, amountWei],
-          }),
-          value: 0n,
-        });
-
-        await updateActivity(clientTxId, {
-          status: TransactionStatus.SUCCESS,
-          hash: tx.transactionHash,
-          url: `https://basescan.org/tx/${tx.transactionHash}`,
-          metadata: { txHash: tx.transactionHash },
-        });
-
-        setSendStatus(Status.SUCCESS);
-        Toast.show({
-          type: 'success',
-          text1: 'Deposit sent',
-          text2: 'USDC transferred to your agent wallet on Base.',
-          props: { badgeText: 'Success' },
-        });
-        reset();
-        onSuccess();
-      } catch (error) {
-        setSendStatus(Status.ERROR);
-        console.error('External agent deposit error:', error);
-        Toast.show({
-          type: 'error',
-          text1: 'Deposit failed',
-          text2: 'Please try again or check your wallet balance.',
-        });
-      }
-    },
-    [account, agentEoaAddress, switchChain, createActivity, updateActivity, reset, onSuccess],
-  );
-
-  const submitting = sendStatus === Status.PENDING;
-  const disabled = submitting || !formState.isValid || !watchedAmount || !account;
-
+const AgentDepositExternalForm = ({ agentEoaAddress }: Props) => {
   return (
-    <View className="flex-1 gap-6">
-      <View className="gap-2">
-        <Text className="font-medium opacity-50">From wallet</Text>
-        <ConnectedWalletDropdown chainId={BASE_CHAIN_ID} />
-      </View>
-
-      <View className="gap-2">
-        <Text className="font-medium opacity-50">Deposit amount</Text>
-        <View
-          className={cn(
-            'w-full flex-row items-center justify-between gap-4 rounded-2xl bg-accent px-5 py-3',
-            formState.errors.amount && 'border border-red-500',
-          )}
-        >
-          <Controller
-            control={control}
-            name="amount"
-            render={({ field: { onChange, onBlur, value } }) => (
-              <TextInput
-                keyboardType="decimal-pad"
-                className="min-w-0 flex-1 text-2xl font-semibold text-white web:focus:outline-none"
-                value={value}
-                placeholder="0.0"
-                placeholderTextColor="#666"
-                onChangeText={onChange}
-                onBlur={onBlur}
+    <View className="flex-1 gap-4">
+      <DepositPublicAddress
+        address={agentEoaAddress}
+        description={
+          <>
+            <View className="flex-row items-center justify-center gap-2">
+              <Image
+                source={baseIcon}
+                style={{
+                  width: 24,
+                  height: 24,
+                  borderRadius: 12,
+                  borderWidth: 1.5,
+                  borderColor: '#1C1C1C',
+                }}
+                contentFit="cover"
               />
-            )}
-          />
-          <View className="shrink-0 flex-row items-center gap-2">
-            <Image
-              source={getAsset('images/usdc-4x.png')}
-              alt="USDC"
-              style={{ width: 34, height: 34 }}
-            />
-            <Text className="text-lg font-semibold text-white">USDC</Text>
-          </View>
-        </View>
-        {formState.errors.amount && (
-          <Text className="mt-1 text-sm text-red-500">{formState.errors.amount.message}</Text>
-        )}
-        <View className="flex-row items-center gap-2">
-          <WalletIcon color="#A1A1A1" size={16} />
-          {isEOABalanceLoading ? (
-            <Skeleton className="h-5 w-20 rounded-md" />
-          ) : (
-            <Text className="text-muted-foreground">
-              {formatNumber(Number(formattedBalance))} USDC
+              <Text className="text-sm font-medium text-white">Base</Text>
+            </View>
+            <Text className="max-w-72 text-center text-sm text-muted-foreground">
+              Send only USDC on Base to this address. Other tokens or chains may result in permanent
+              loss of funds.
             </Text>
-          )}
-          <Max
-            onPress={() => {
-              setValue('amount', formattedBalance);
-              trigger('amount');
-            }}
-          />
-        </View>
-        <Text className="text-xs text-muted-foreground">
-          Sends USDC directly on Base. Funds arrive at your agent wallet immediately and do not earn
-          yield — borrow against savings instead if you want to keep yield on the principal.
+            <Pressable
+              onPress={() => Linking.openURL(SUPPORTED_NETWORKS_URL)}
+              className="web:hover:opacity-50"
+            >
+              <View className="flex-row flex-wrap items-center">
+                <Text className="text-sm font-medium text-white">See supported networks</Text>
+                <ChevronRight size={16} color="white" />
+              </View>
+            </Pressable>
+          </>
+        }
+      />
+
+      <View className="flex-row items-start gap-2 rounded-2xl bg-primary/10 px-4 py-3">
+        <Info size={16} color="#A1A1AA" />
+        <Text className="flex-1 text-sm text-muted-foreground">
+          Funds sent here arrive at your agent wallet immediately and do not earn yield. To keep
+          earning yield on the principal, use the Borrow against savings option instead.
         </Text>
       </View>
-
-      <View className="flex-1" />
-
-      <Button
-        variant="brand"
-        className="h-12 rounded-2xl"
-        disabled={disabled}
-        onPress={() => handleSubmit(onSubmit)()}
-      >
-        {submitting ? (
-          <ActivityIndicator color="black" />
-        ) : (
-          <Text className="native:text-lg text-base font-bold text-black">Deposit</Text>
-        )}
-      </Button>
     </View>
   );
 };

--- a/components/Agent/AgentDepositModal.tsx
+++ b/components/Agent/AgentDepositModal.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { ActivityIndicator, Linking, Platform, View } from 'react-native';
+import { ActivityIndicator, Linking, View } from 'react-native';
 import Toast from 'react-native-toast-message';
 import { ChevronRight, Wallet } from 'lucide-react-native';
 
@@ -12,6 +12,7 @@ import Skeleton from '@/components/ui/skeleton';
 import { Text } from '@/components/ui/text';
 import { useAaveBorrowPosition } from '@/hooks/useAaveBorrowPosition';
 import useBorrowAndDepositToAgent from '@/hooks/useBorrowAndDepositToAgent';
+import { isProduction } from '@/lib/config';
 import { Status } from '@/lib/types';
 import { formatNumber } from '@/lib/utils';
 
@@ -33,19 +34,15 @@ type Props = {
 };
 
 const AgentDepositModal = ({ open, onClose, agentEoaAddress }: Props) => {
-  // External-wallet path is web-only — thirdweb's connector flow doesn't run
-  // inside the React Native runtime. Mobile users keep the borrow path.
-  const externalEnabled = Platform.OS === 'web';
-
-  const [step, setStep] = useState<Step>(externalEnabled ? 'options' : 'borrow');
-  const [previousStep, setPreviousStep] = useState<Step>(step);
+  const [step, setStep] = useState<Step>('options');
+  const [previousStep, setPreviousStep] = useState<Step>('options');
 
   useEffect(() => {
     if (!open) {
-      setStep(externalEnabled ? 'options' : 'borrow');
-      setPreviousStep(externalEnabled ? 'options' : 'borrow');
+      setStep('options');
+      setPreviousStep('options');
     }
-  }, [open, externalEnabled]);
+  }, [open]);
 
   const goTo = useCallback(
     (next: Step) => {
@@ -61,7 +58,7 @@ const AgentDepositModal = ({ open, onClose, agentEoaAddress }: Props) => {
     return 'Deposit from external wallet';
   }, [step]);
 
-  const showBack = step !== 'options' && externalEnabled;
+  const showBack = step !== 'options';
 
   return (
     <ResponsiveModal
@@ -78,10 +75,10 @@ const AgentDepositModal = ({ open, onClose, agentEoaAddress }: Props) => {
       showBackButton={showBack}
       onBackPress={() => goTo('options')}
     >
-      {step === 'options' && externalEnabled ? (
+      {step === 'options' ? (
         <DepositOptions onSelect={goTo} />
       ) : step === 'external' && agentEoaAddress ? (
-        <AgentDepositExternalForm agentEoaAddress={agentEoaAddress} onSuccess={onClose} />
+        <AgentDepositExternalForm agentEoaAddress={agentEoaAddress} />
       ) : (
         <AgentDepositBorrowForm agentEoaAddress={agentEoaAddress} onSuccess={onClose} />
       )}
@@ -98,7 +95,7 @@ const DepositOptions = ({ onSelect }: { onSelect: (step: Step) => void }) => (
     />
     <OptionItem
       title="From external wallet"
-      description="Send USDC directly from MetaMask or any other wallet on Base. No yield."
+      description="Send USDC directly from any wallet on Base via QR/address copy. No yield."
       onPress={() => onSelect('external')}
     />
   </View>
@@ -181,6 +178,18 @@ const AgentDepositBorrowForm = ({ agentEoaAddress, onSuccess }: BorrowFormProps)
 
   return (
     <View className="flex-1 gap-3">
+      {!isProduction && (
+        <View className="rounded-2xl border border-yellow-500/40 bg-yellow-500/10 px-4 py-3">
+          <Text className="text-sm font-medium text-yellow-300">
+            Borrow contract available only in production
+          </Text>
+          <Text className="mt-1 text-xs text-yellow-200/70">
+            soUSD and the Aave borrow market aren&apos;t deployed in this environment. The borrow
+            flow will fail — use the external-wallet option to fund the agent on Base for testing.
+          </Text>
+        </View>
+      )}
+
       <View className="gap-4 px-2">
         <BorrowSlider
           value={sliderValue}

--- a/constants/agentPromptTemplate.ts
+++ b/constants/agentPromptTemplate.ts
@@ -54,7 +54,11 @@ A successful response returns \`{ txHash, settledAt, activityId }\` plus the mer
 
 ## First-turn behavior
 
-When the user first hands you this prompt, **do not** dump these instructions back at them or explain the API. Instead, write a short reply (3–4 sentences max) that:
+When the user first hands you this prompt, **do not** dump these instructions back at them or explain the API.
+
+**Step 1 — confirm you have the key.** If the user has not already given you their Solid API key (i.e. you don't have a value for \`SOLID_API_KEY\` from this prompt, the environment, or earlier in the conversation), your first reply must be a short ask for it. Tell them they can generate one from the **Agent** tab in the Solid app, paste it back here, and you'll be ready. Stop there — don't continue with anything else until you have the key.
+
+**Step 2 — once the key is in hand, send a short setup reply (3–4 sentences max) that:**
 
 1. Confirms you're set up to pay through their Solid agent wallet.
 2. Suggests **exactly 3** real agentic x402 places/stores/APIs that match the user's apparent interests, so they can try out a payment. Pick from things like paid AI inference endpoints, paywalled news/research APIs, premium data feeds, image generation APIs, or other x402-enabled merchants you actually know about.


### PR DESCRIPTION
…or-key first

External deposit:
- Drop the thirdweb connect-wallet flow. The new screen reuses DepositPublicAddress to render the agent EOA as a copyable string + QR code, scoped to Base USDC. Works on both web and native.
- Removes the ~200-line transfer/activity-creation code and the thirdweb dependency for this surface.

Borrow form:
- Yellow warning banner above the slider when isProduction is false: the soUSD/Aave market isn't deployed in QA so the borrow flow can't actually execute. Points users at the external-wallet option for testing.

Prompt template:
- New first-turn step zero: if the AI doesn't have SOLID_API_KEY yet, it must ask the user to paste one (and tell them where to generate it — the Agent tab) before doing anything else.