### PR TITLE
Improve card funding address retrieval and validation logic

### DIFF
--- a/hooks/useCardContracts.ts
+++ b/hooks/useCardContracts.ts
@@ -15,6 +15,6 @@ export function useCardContracts() {
     queryKey: [CARD_CONTRACTS_KEY],
     queryFn: () => withRefreshToken(() => getCardContracts()),
     enabled: provider === CardProvider.RAIN,
-    retry: false,
+    retry: 2,
   });
 }

--- a/lib/utils/utils.ts
+++ b/lib/utils/utils.ts
@@ -333,12 +333,15 @@ export const parseStampHeaderValueCredentialId = (stampHeaderValue: string) => {
 export const getArbitrumFundingAddress = (cardDetails: CardResponse) => {
   const ARBITRUM_CHAIN = 'arbitrum';
 
-  if (cardDetails?.funding_instructions?.chain === ARBITRUM_CHAIN) {
-    return cardDetails?.funding_instructions?.address;
+  if (
+    cardDetails?.funding_instructions?.chain === ARBITRUM_CHAIN &&
+    cardDetails?.funding_instructions?.address
+  ) {
+    return cardDetails.funding_instructions.address;
   }
 
   return cardDetails?.additional_funding_instructions?.find(
-    instruction => instruction.chain === ARBITRUM_CHAIN,
+    instruction => instruction.chain === ARBITRUM_CHAIN && instruction.address,
   )?.address;
 };
 
@@ -370,9 +373,12 @@ export function getCardFundingAddress(
   provider: CardProvider | null | undefined,
   contracts: RainContractResponseDto[] | null | undefined,
 ): string | undefined {
-  if (provider === CardProvider.RAIN && contracts?.length) {
-    const rainContract = contracts.find(c => c.chainId === EXPO_PUBLIC_CARD_FUNDING_CHAIN_ID);
-    if (rainContract?.depositAddress) return rainContract.depositAddress;
+  if (provider === CardProvider.RAIN) {
+    if (!contracts?.length) return undefined;
+    const rainContract = contracts.find(
+      c => Number(c.chainId) === EXPO_PUBLIC_CARD_FUNDING_CHAIN_ID,
+    );
+    return rainContract?.depositAddress || undefined;
   }
   return cardDetails ? getArbitrumFundingAddress(cardDetails) : undefined;
 }


### PR DESCRIPTION
## Summary
This PR enhances the robustness of card funding address retrieval by adding stricter validation checks and improving error handling in the funding address lookup functions.

## Key Changes
- **Enhanced `getArbitrumFundingAddress` validation**: Added explicit checks to ensure the address exists before returning it, preventing potential undefined values from being returned
- **Refactored `getCardFundingAddress` logic**: 
  - Restructured the RAIN provider check to handle missing contracts more explicitly
  - Added numeric type coercion for `chainId` comparison to ensure proper chain matching
  - Simplified return logic with explicit undefined fallback
- **Improved retry behavior**: Changed `useCardContracts` query retry policy from `false` to `2` to provide better resilience for card contract fetching

## Implementation Details
- The validation improvements ensure that address fields are checked for existence before being returned, reducing the risk of undefined values propagating through the application
- The `chainId` comparison now explicitly converts to `Number` type to handle potential string/number type mismatches
- The retry count increase (0 → 2) allows transient failures in card contract queries to be retried, improving reliability without aggressive retry behavior

https://claude.ai/code/session_018yioW4wRXd4AJjUrU32QLe