### PR TITLE
fix(card): use max-uint repay when fully repaying card debt

### DIFF
--- a/hooks/useRepayAndWithdrawCollateral.ts
+++ b/hooks/useRepayAndWithdrawCollateral.ts
@@ -14,7 +14,7 @@ import { publicClient } from '@/lib/wagmi';
 import * as Sentry from '@sentry/react-native';
 import { Address } from 'abitype';
 import { useCallback, useState } from 'react';
-import { erc20Abi, pad, TransactionReceipt } from 'viem';
+import { erc20Abi, maxUint256, pad, TransactionReceipt } from 'viem';
 import { readContract } from 'viem/actions';
 import { fuse, mainnet } from 'viem/chains';
 import { encodeFunctionData, parseUnits } from 'viem/utils';
@@ -48,6 +48,10 @@ type RepayAndWithdrawCollateralResult = {
 const RATE_SCALE = 1_000_000n;
 const LIQ_THRESHOLD_BPS = 8_000n; // 80%
 const TARGET_HEALTH_FACTOR_BPS = 10_200n; // 1.02x
+// Buffer added to the approval when the user is fully repaying their debt.
+// Aave's debt accrues interest every block, so the live debt at execution
+// time is slightly higher than the snapshot the UI shows.
+const REPAY_INTEREST_BUFFER_BPS = 50n; // 0.5%
 
 const useRepayAndWithdrawCollateral = (): RepayAndWithdrawCollateralResult => {
   const { user, safeAA } = useUser();
@@ -94,10 +98,24 @@ const useRepayAndWithdrawCollateral = (): RepayAndWithdrawCollateralResult => {
         const totalBorrowedWei = parseUnits(totalBorrowed.toFixed(6), 6);
         const totalSuppliedSoUSDWei = parseUnits(totalSupplied.toFixed(6), 6);
         const totalSuppliedUsdWei = (totalSuppliedSoUSDWei * rate) / RATE_SCALE;
+        // When the user is repaying the full borrowed snapshot we treat this as a
+        // "max repay": pass MaxUint256 to Aave's repay() so it consumes exactly
+        // the live debt (which has accrued past the snapshot), approve a small
+        // buffer to cover that accrual, and withdraw all collateral. Without this
+        // the repay leaves a tiny dust debt and the bundled withdraw reverts on
+        // the health factor check.
+        const isMaxRepay = repayAmountWei >= totalBorrowedWei && totalBorrowedWei > 0n;
+        const approveAmountWei = isMaxRepay
+          ? totalBorrowedWei + (totalBorrowedWei * REPAY_INTEREST_BUFFER_BPS) / 10_000n
+          : repayAmountWei;
+        const repayCallAmountWei = isMaxRepay ? maxUint256 : repayAmountWei;
         const cappedRepayWei =
           repayAmountWei > totalBorrowedWei ? totalBorrowedWei : repayAmountWei;
-        const remainingBorrowWei =
-          totalBorrowedWei > cappedRepayWei ? totalBorrowedWei - cappedRepayWei : 0n;
+        const remainingBorrowWei = isMaxRepay
+          ? 0n
+          : totalBorrowedWei > cappedRepayWei
+            ? totalBorrowedWei - cappedRepayWei
+            : 0n;
         const requiredCollateralValueWei =
           remainingBorrowWei === 0n
             ? 0n
@@ -115,13 +133,13 @@ const useRepayAndWithdrawCollateral = (): RepayAndWithdrawCollateralResult => {
         const repayApproveCalldata = encodeFunctionData({
           abi: erc20Abi,
           functionName: 'approve',
-          args: [ADDRESSES.fuse.aaveV3Pool, repayAmountWei],
+          args: [ADDRESSES.fuse.aaveV3Pool, approveAmountWei],
         });
 
         const repayCalldata = encodeFunctionData({
           abi: AaveV3Pool_ABI,
           functionName: 'repay',
-          args: [USDC_STARGATE, repayAmountWei, 2, user.safeAddress as Address],
+          args: [USDC_STARGATE, repayCallAmountWei, 2, user.safeAddress as Address],
         });
 
         const withdrawCalldata = encodeFunctionData({


### PR DESCRIPTION
## Summary
Cherry-pick of #2024 onto `qa`.

Fixes "Repay failed (Onchain)" when the user clicks **Max** in the card Repay modal.

Aave's debt accrues interest each block, so by the time the user-op lands the live debt is slightly higher than the snapshot the form uses. Repaying the snapshot exactly leaves a dust debt and the bundled collateral withdraw then reverts on the health-factor check.

When the user repays the full borrowed snapshot:
- pass `MaxUint256` to `pool.repay()` (Aave consumes exactly the live debt),
- approve a 0.5% buffer on top of the snapshot to cover the accrued interest,
- treat remaining debt as zero so all collateral can be withdrawn.

Partial repays are unchanged.

## Test plan
- [ ] Borrow on the card, wait a few minutes, click **Max**, then **Repay** — transaction succeeds and collateral is fully withdrawn.
- [ ] Manual partial repay (amount < borrowed) still works as before.
- [ ] Manual entry equal to displayed borrowed amount also succeeds (treated as max repay).

https://claude.ai/code/session_012wqMv7UKL2mTkwH2DiWjFX

---
_Generated by [Claude Code](https://claude.ai/code/session_012wqMv7UKL2mTkwH2DiWjFX)_