### PR TITLE
fix(card-deposit): block bogus Arbitrum fallback for Rain cards (qa)

### DIFF
--- a/hooks/useCardContracts.ts
+++ b/hooks/useCardContracts.ts
@@ -15,6 +15,6 @@ export function useCardContracts() {
     queryKey: [CARD_CONTRACTS_KEY],
     queryFn: () => withRefreshToken(() => getCardContracts()),
     enabled: provider === CardProvider.RAIN,
-    retry: false,
+    retry: 2,
   });
 }

--- a/lib/utils/utils.ts
+++ b/lib/utils/utils.ts
@@ -333,12 +333,15 @@ export const parseStampHeaderValueCredentialId = (stampHeaderValue: string) => {
 export const getArbitrumFundingAddress = (cardDetails: CardResponse) => {
   const ARBITRUM_CHAIN = 'arbitrum';
 
-  if (cardDetails?.funding_instructions?.chain === ARBITRUM_CHAIN) {
-    return cardDetails?.funding_instructions?.address;
+  if (
+    cardDetails?.funding_instructions?.chain === ARBITRUM_CHAIN &&
+    cardDetails?.funding_instructions?.address
+  ) {
+    return cardDetails.funding_instructions.address;
   }
 
   return cardDetails?.additional_funding_instructions?.find(
-    instruction => instruction.chain === ARBITRUM_CHAIN,
+    instruction => instruction.chain === ARBITRUM_CHAIN && instruction.address,
   )?.address;
 };
 
@@ -370,9 +373,12 @@ export function getCardFundingAddress(
   provider: CardProvider | null | undefined,
   contracts: RainContractResponseDto[] | null | undefined,
 ): string | undefined {
-  if (provider === CardProvider.RAIN && contracts?.length) {
-    const rainContract = contracts.find(c => c.chainId === EXPO_PUBLIC_CARD_FUNDING_CHAIN_ID);
-    if (rainContract?.depositAddress) return rainContract.depositAddress;
+  if (provider === CardProvider.RAIN) {
+    if (!contracts?.length) return undefined;
+    const rainContract = contracts.find(
+      c => Number(c.chainId) === EXPO_PUBLIC_CARD_FUNDING_CHAIN_ID,
+    );
+    return rainContract?.depositAddress || undefined;
   }
   return cardDetails ? getArbitrumFundingAddress(cardDetails) : undefined;
 }


### PR DESCRIPTION
## Summary

Cherry-pick of #2025 onto `qa`.

For Rain cards the backend mapper hardcodes `funding_instructions = { chain: 'arbitrum', address: '' }`. When `useCardContracts` hadn't returned a matching contract — because it was still loading, had failed (`retry: false`), or didn't include `EXPO_PUBLIC_CARD_FUNDING_CHAIN_ID` — `getCardFundingAddress` fell back to `getArbitrumFundingAddress(cardDetails)` and returned `''`, which the deposit form treated as a missing address and surfaced as **"Deposits not available — This card does not support deposits to the funding chain"** on Borrow / Savings submit.

- `getCardFundingAddress`: for Rain provider, resolve only via the contracts API; never fall through to Arbitrum funding instructions. Coerce `chainId` via `Number()` for resilience.
- `getArbitrumFundingAddress`: skip funding entries with empty `address`.
- `useCardContracts`: `retry: 2` so transient failures self-heal.

## Test plan

- [ ] Open Card → Deposit to card → Borrow against savings, submit, verify the toast no longer appears and the borrow+bridge flow proceeds.
- [ ] Same flow from "Deposit from savings".
- [ ] Wallet (production) deposit still works.
- [ ] Card withdraw still resolves the funding contract.
- [ ] Simulate a `/cards/contracts` failure → query retries instead of failing immediately.

https://claude.ai/code/session_018yioW4wRXd4AJjUrU32QLe

---
_Generated by [Claude Code](https://claude.ai/code/session_018yioW4wRXd4AJjUrU32QLe)_