### PR TITLE
Deprecate Bridge card provider, support Rain only

### DIFF
--- a/components/DepositOption/DepositPublicAddress.tsx
+++ b/components/DepositOption/DepositPublicAddress.tsx
@@ -1,5 +1,5 @@
 import { ReactNode, useMemo } from 'react';
-import { Linking, Pressable, View } from 'react-native';
+import { ActivityIndicator, Linking, Pressable, View } from 'react-native';
 import QRCode from 'react-native-qrcode-svg';
 import { Image } from 'expo-image';
 import { ChevronRight } from 'lucide-react-native';
@@ -56,20 +56,29 @@ const DepositPublicAddress = ({ address, description }: DepositPublicAddressProp
           <Text className="text-lg font-medium text-white">
             {resolvedAddress ? eclipseAddress(resolvedAddress, 6, 6) : ''}
           </Text>
-          <CopyToClipboard text={resolvedAddress} className="text-primary" />
+          {resolvedAddress ? (
+            <CopyToClipboard text={resolvedAddress} className="text-primary" />
+          ) : null}
         </View>
 
         <View className="items-center justify-center px-4 py-4">
-          <View className="overflow-hidden rounded-xl">
-            <QRCode
-              value={resolvedAddress}
-              size={200}
-              color="white"
-              backgroundColor="#181A1A"
-              logo={solidLogo}
-              logoSize={50}
-              logoBackgroundColor="transparent"
-            />
+          <View
+            className="items-center justify-center overflow-hidden rounded-xl"
+            style={{ width: 200, height: 200, backgroundColor: '#181A1A' }}
+          >
+            {resolvedAddress ? (
+              <QRCode
+                value={resolvedAddress}
+                size={200}
+                color="white"
+                backgroundColor="#181A1A"
+                logo={solidLogo}
+                logoSize={50}
+                logoBackgroundColor="transparent"
+              />
+            ) : (
+              <ActivityIndicator color="white" />
+            )}
           </View>
         </View>
 

--- a/hooks/useCardProvider.ts
+++ b/hooks/useCardProvider.ts
@@ -1,20 +1,17 @@
 import { useQuery } from '@tanstack/react-query';
 
-import { getCardBalance } from '@/lib/api';
 import { EXPO_PUBLIC_CARD_ISSUER } from '@/lib/config';
 import { CardProvider } from '@/lib/types';
-import { hasCard, withRefreshToken } from '@/lib/utils';
+import { hasCard } from '@/lib/utils';
 
 import { cardDetailsQueryOptions } from './cardDetailsQueryOptions';
 import { useCardStatus } from './useCardStatus';
 
-const CARD_PROVIDER_PROBE_KEY = 'cardProviderProbe';
-
 /**
- * Resolves card issuer (bridge vs rain). Uses, in order:
- * 1. EXPO_PUBLIC_CARD_ISSUER if set
- * 2. provider from GET /cards/details or GET /cards/status when backend sends it
- * 3. Probe: GET /cards/balance → 200 = rain, 400 = bridge (cached)
+ * Resolves card issuer. Bridge is deprecated — Rain is the only supported provider.
+ * Uses, in order:
+ * 1. EXPO_PUBLIC_CARD_ISSUER if set (test/override)
+ * 2. Rain when the user has an active Rain card (Bridge-only users are treated as no card)
  */
 export function useCardProvider(): {
   provider: CardProvider | null;
@@ -22,41 +19,14 @@ export function useCardProvider(): {
 } {
   const { data: cardDetails } = useQuery(cardDetailsQueryOptions());
   const { data: cardStatus } = useCardStatus();
-  const hasCardData =
-    hasCard(cardStatus) || (!!cardDetails?.id && cardDetails?.provider !== CardProvider.BRIDGE);
-
-  const providerFromResponse = cardDetails?.provider ?? cardStatus?.provider ?? undefined;
-
-  const probeQuery = useQuery({
-    queryKey: [CARD_PROVIDER_PROBE_KEY],
-    queryFn: async (): Promise<CardProvider> => {
-      try {
-        await withRefreshToken(() => getCardBalance());
-        return CardProvider.RAIN;
-      } catch (e: unknown) {
-        if (e instanceof Response && e.status === 400) return CardProvider.BRIDGE;
-        throw e;
-      }
-    },
-    enabled: hasCardData && !providerFromResponse && !EXPO_PUBLIC_CARD_ISSUER,
-    retry: false,
-    staleTime: 5 * 60 * 1000,
-  });
 
   if (EXPO_PUBLIC_CARD_ISSUER) {
     return { provider: EXPO_PUBLIC_CARD_ISSUER, isLoading: false };
   }
-  if (providerFromResponse) {
-    return { provider: providerFromResponse, isLoading: false };
-  }
-  if (!hasCardData) {
-    return { provider: null, isLoading: false };
-  }
-  if (probeQuery.isLoading || probeQuery.isFetching) {
-    return { provider: null, isLoading: true };
-  }
-  if (probeQuery.data) {
-    return { provider: probeQuery.data, isLoading: false };
-  }
-  return { provider: null, isLoading: false };
+
+  const hasRainCard =
+    hasCard(cardStatus) ||
+    (!!cardDetails?.id && cardDetails?.provider !== CardProvider.BRIDGE);
+
+  return { provider: hasRainCard ? CardProvider.RAIN : null, isLoading: false };
 }

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -2248,46 +2248,14 @@ export const revealCardDetailsCompleteRain = async (): Promise<CardDetailsReveal
 };
 
 /**
- * Complete card details reveal flow.
- * When a provider is supplied the correct path is used directly.
- * Otherwise falls back to the previous heuristic (try Rain first when PEM is
- * configured, then Bridge on 400).
+ * Complete card details reveal flow. Rain is the only supported provider;
+ * Bridge is deprecated and no longer dispatched, even if the caller passes it.
  */
 export const revealCardDetailsComplete = async (
-  provider?: CardProvider,
+  _provider?: CardProvider,
 ): Promise<CardDetailsRevealResponse> => {
-  if (provider === CardProvider.RAIN) {
-    return revealCardDetailsCompleteRain();
-  }
-  if (provider === CardProvider.BRIDGE) {
-    return revealCardDetailsCompleteBridge();
-  }
-
-  // Fallback when provider is unknown: try Rain if PEM configured, else Bridge
-  if (EXPO_PUBLIC_RAIN_CARD_PUBLIC_KEY_PEM) {
-    try {
-      return await revealCardDetailsCompleteRain();
-    } catch (e: unknown) {
-      if (e instanceof Response && e.status === 400) {
-        return revealCardDetailsCompleteBridge();
-      }
-      throw e;
-    }
-  }
-  return revealCardDetailsCompleteBridge();
+  return revealCardDetailsCompleteRain();
 };
-
-function revealCardDetailsCompleteBridge(): Promise<CardDetailsRevealResponse> {
-  return (async () => {
-    const nonceData = await generateClientNonceData();
-    const ephemeralKeyResponse = await requestEphemeralKey(nonceData.nonce);
-    return revealCardDetails(
-      ephemeralKeyResponse.ephemeral_key,
-      nonceData.clientSecret,
-      nonceData.clientTimestamp,
-    );
-  })();
-}
 
 export const fetchAPYs = async (): Promise<APYsByAsset> => {
   const response = await axios.get<APYsByAsset>(


### PR DESCRIPTION
## Summary
This PR removes support for the deprecated Bridge card provider and simplifies the codebase to support Rain as the only card issuer. This includes removing the card provider probe logic and updating related components to handle the simplified provider resolution.

## Key Changes

- **Card Provider Resolution**: Simplified `useCardProvider()` hook to remove the probe mechanism that attempted to detect the card provider via API calls. Now directly returns Rain as the provider when a user has an active card, or null otherwise.

- **Card Details Reveal Flow**: Updated `revealCardDetailsComplete()` in `lib/api.ts` to always use the Rain flow. Removed the fallback logic that attempted Bridge as a secondary option and the `revealCardDetailsCompleteBridge()` function entirely.

- **Removed Dependencies**: Eliminated usage of `getCardBalance()` and `withRefreshToken()` from the card provider hook, as they were only used for the Bridge detection probe.

- **UI Improvements**: Enhanced `DepositPublicAddress` component to show loading state (ActivityIndicator) while the address is being resolved, and conditionally render the QR code and copy button only when the address is available.

## Implementation Details

- The card provider is now determined by checking if the user has an active card via `cardStatus` or `cardDetails`, with Bridge-only users treated as having no card.
- The `EXPO_PUBLIC_CARD_ISSUER` environment variable can still be used to override the provider for testing purposes.
- The probe query that cached provider detection results has been completely removed, reducing unnecessary API calls.
- Loading states in the deposit flow are now properly handled with visual feedback during address resolution.

https://claude.ai/code/session_015xGWKAnL8dP3zmEJwXR85W