### PR TITLE
feat(agent): inline source dropdown in deposit modal, drop options sc…

### DIFF
--- a/components/Agent/AgentDepositBorrowForm.tsx
+++ b/components/Agent/AgentDepositBorrowForm.tsx
@@ -1,0 +1,154 @@
+import { useMemo, useState } from 'react';
+import { ActivityIndicator, Linking, View } from 'react-native';
+import Toast from 'react-native-toast-message';
+
+import { BorrowSlider } from '@/components/Card/BorrowSlider';
+import TokenDetails from '@/components/TokenCard/TokenDetails';
+import { Button } from '@/components/ui/button';
+import Skeleton from '@/components/ui/skeleton';
+import { Text } from '@/components/ui/text';
+import { useAaveBorrowPosition } from '@/hooks/useAaveBorrowPosition';
+import useBorrowAndDepositToAgent from '@/hooks/useBorrowAndDepositToAgent';
+import { isProduction } from '@/lib/config';
+import { Status } from '@/lib/types';
+import { formatNumber } from '@/lib/utils';
+
+const SO_USD_LTV = 70n;
+
+type Props = {
+  agentEoaAddress?: string;
+  onSuccess: () => void;
+};
+
+const AgentDepositBorrowForm = ({ agentEoaAddress, onSuccess }: Props) => {
+  const [sliderValue, setSliderValue] = useState(0);
+  const {
+    totalSupplied,
+    totalBorrowed,
+    borrowAPY,
+    isLoading: positionLoading,
+  } = useAaveBorrowPosition();
+  const { borrowAndDeposit, bridgeStatus } = useBorrowAndDepositToAgent(agentEoaAddress);
+
+  const maxBorrowAmount = useMemo(
+    () => Math.max(0, totalSupplied * 0.69 - totalBorrowed),
+    [totalSupplied, totalBorrowed],
+  );
+
+  const collateralRequired = useMemo(() => {
+    if (sliderValue <= 0) return 0;
+    return (sliderValue * 100) / Number(SO_USD_LTV);
+  }, [sliderValue]);
+
+  const submitting = bridgeStatus === Status.PENDING;
+  const amountValid = sliderValue > 0 && sliderValue <= maxBorrowAmount;
+
+  const handleSubmit = async () => {
+    if (!amountValid || !agentEoaAddress) return;
+    try {
+      await borrowAndDeposit(sliderValue.toString());
+      Toast.show({
+        type: 'success',
+        text1: 'Deposit submitted',
+        text2:
+          'Borrowed against soUSD on Fuse and sent via Stargate. Funds arrive on Base in ~1–5 min.',
+        props: { badgeText: 'Success' },
+      });
+      onSuccess();
+    } catch (err) {
+      Toast.show({
+        type: 'error',
+        text1: 'Deposit failed',
+        text2: err instanceof Error ? err.message : 'Unknown error',
+        props: { badgeText: 'Error' },
+      });
+    }
+  };
+
+  return (
+    <View className="flex-1 gap-3">
+      {!isProduction && (
+        <View className="rounded-2xl border border-yellow-500/40 bg-yellow-500/10 px-4 py-3">
+          <Text className="text-sm font-medium text-yellow-300">
+            Borrow contract available only in production
+          </Text>
+          <Text className="mt-1 text-xs text-yellow-200/70">
+            soUSD and the Aave borrow market aren&apos;t deployed in this environment. The borrow
+            flow will fail — use the external-wallet option to fund the agent on Base for testing.
+          </Text>
+        </View>
+      )}
+
+      <View className="gap-4 px-2">
+        <BorrowSlider
+          value={sliderValue}
+          onValueChange={setSliderValue}
+          min={0}
+          max={maxBorrowAmount}
+        />
+      </View>
+
+      <TokenDetails className="mt-3">
+        <View className="flex-row items-center justify-between gap-2 px-5 py-6 md:gap-10 md:p-5">
+          <Text className="native:text-lg text-base text-muted-foreground">Borrow rate</Text>
+          <View className="ml-auto shrink-0 flex-row items-baseline gap-2">
+            {positionLoading ? (
+              <Skeleton className="h-5 w-16 rounded-md" />
+            ) : (
+              <Text className="native:text-lg text-base font-semibold">
+                {formatNumber(borrowAPY, 2)}%
+              </Text>
+            )}
+          </View>
+        </View>
+        <View className="flex-row items-center justify-between gap-2 px-5 py-6 md:gap-10 md:p-5">
+          <View className="flex-row items-center gap-2">
+            <Text className="native:text-lg text-base text-muted-foreground">
+              Collateral Required
+            </Text>
+          </View>
+          <View className="ml-auto shrink-0 flex-row items-baseline gap-2">
+            {!sliderValue ? (
+              <Skeleton className="h-5 w-20 rounded-md" />
+            ) : (
+              <Text className="native:text-lg text-base font-semibold">
+                {formatNumber(collateralRequired)} soUSD
+              </Text>
+            )}
+          </View>
+        </View>
+        <View className="px-5 py-6 md:p-5">
+          <Text className="native:text-base text-sm text-muted-foreground">
+            Use your soUSD as collateral to borrow USDC and fund your agent wallet on Base while
+            earning yield.{' '}
+            <Text
+              onPress={() => {
+                Linking.openURL(
+                  'https://support.solid.xyz/en/articles/13545322-borrow-against-your-savings',
+                );
+              }}
+              className="text-base font-medium leading-5 text-[#94F27F] web:hover:opacity-70"
+            >
+              Learn more.
+            </Text>
+          </Text>
+        </View>
+      </TokenDetails>
+
+      <Button
+        variant="brand"
+        className="h-12 rounded-2xl"
+        disabled={!amountValid || submitting}
+        onPress={handleSubmit}
+      >
+        {submitting ? (
+          <ActivityIndicator color="black" />
+        ) : (
+          <Text className="native:text-lg text-base font-bold text-black">Deposit</Text>
+        )}
+      </Button>
+    </View>
+  );
+};
+
+export default AgentDepositBorrowForm;

--- a/components/Agent/AgentDepositModal.tsx
+++ b/components/Agent/AgentDepositModal.tsx
@@ -1,31 +1,22 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
-import { ActivityIndicator, Linking, View } from 'react-native';
-import Toast from 'react-native-toast-message';
-import { ChevronRight, Wallet } from 'lucide-react-native';
+import { useCallback, useEffect, useState } from 'react';
+import { Platform, Pressable, View } from 'react-native';
+import { ChevronDown, Leaf, Wallet as WalletIcon } from 'lucide-react-native';
 
+import AgentDepositBorrowForm from '@/components/Agent/AgentDepositBorrowForm';
 import AgentDepositExternalForm from '@/components/Agent/AgentDepositExternalForm';
-import { BorrowSlider } from '@/components/Card/BorrowSlider';
 import ResponsiveModal, { ModalState } from '@/components/ResponsiveModal';
-import TokenDetails from '@/components/TokenCard/TokenDetails';
-import { Button } from '@/components/ui/button';
-import Skeleton from '@/components/ui/skeleton';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
 import { Text } from '@/components/ui/text';
-import { useAaveBorrowPosition } from '@/hooks/useAaveBorrowPosition';
-import useBorrowAndDepositToAgent from '@/hooks/useBorrowAndDepositToAgent';
-import { isProduction } from '@/lib/config';
-import { Status } from '@/lib/types';
-import { formatNumber } from '@/lib/utils';
 
-const SO_USD_LTV = 70n;
-
-type Step = 'options' | 'borrow' | 'external';
-
-const STEP_NUMBER: Record<Step, number> = { options: 1, borrow: 2, external: 2 };
-const stepState = (step: Step): ModalState => ({
-  name: `agent-deposit-${step}`,
-  number: STEP_NUMBER[step],
-});
+const MODAL_OPEN: ModalState = { name: 'agent-deposit', number: 1 };
 const CLOSE_STATE: ModalState = { name: 'close', number: 0 };
+
+type AgentDepositSource = 'borrow' | 'external';
 
 type Props = {
   open: boolean;
@@ -34,230 +25,164 @@ type Props = {
 };
 
 const AgentDepositModal = ({ open, onClose, agentEoaAddress }: Props) => {
-  const [step, setStep] = useState<Step>('options');
-  const [previousStep, setPreviousStep] = useState<Step>('options');
+  const [source, setSource] = useState<AgentDepositSource>('borrow');
 
   useEffect(() => {
-    if (!open) {
-      setStep('options');
-      setPreviousStep('options');
-    }
+    if (!open) setSource('borrow');
   }, [open]);
-
-  const goTo = useCallback(
-    (next: Step) => {
-      setPreviousStep(step);
-      setStep(next);
-    },
-    [step],
-  );
-
-  const title = useMemo(() => {
-    if (step === 'options') return 'Deposit to Agent Wallet';
-    if (step === 'borrow') return 'Borrow against savings';
-    return 'Deposit from external wallet';
-  }, [step]);
-
-  const showBack = step !== 'options';
 
   return (
     <ResponsiveModal
-      currentModal={open ? stepState(step) : CLOSE_STATE}
-      previousModal={open ? stepState(previousStep) : CLOSE_STATE}
+      currentModal={open ? MODAL_OPEN : CLOSE_STATE}
+      previousModal={open ? CLOSE_STATE : MODAL_OPEN}
       isOpen={open}
       onOpenChange={value => {
         if (!value) onClose();
       }}
       trigger={null}
-      title={title}
-      contentKey={`agent-deposit-${step}`}
+      title="Deposit to Agent Wallet"
+      contentKey="agent-deposit"
       containerClassName="min-h-[42rem] overflow-y-auto flex-1"
-      showBackButton={showBack}
-      onBackPress={() => goTo('options')}
     >
-      {step === 'options' ? (
-        <DepositOptions onSelect={goTo} />
-      ) : step === 'external' && agentEoaAddress ? (
-        <AgentDepositExternalForm agentEoaAddress={agentEoaAddress} />
-      ) : (
-        <AgentDepositBorrowForm agentEoaAddress={agentEoaAddress} onSuccess={onClose} />
-      )}
+      <View className="flex-1 gap-4">
+        <View className="gap-2">
+          <Text className="font-medium opacity-50">From</Text>
+          <SourceSelector value={source} onChange={setSource} />
+        </View>
+
+        {source === 'external' && agentEoaAddress ? (
+          <AgentDepositExternalForm agentEoaAddress={agentEoaAddress} />
+        ) : (
+          <AgentDepositBorrowForm agentEoaAddress={agentEoaAddress} onSuccess={onClose} />
+        )}
+      </View>
     </ResponsiveModal>
   );
 };
 
-const DepositOptions = ({ onSelect }: { onSelect: (step: Step) => void }) => (
-  <View className="gap-y-2.5">
-    <OptionItem
-      title="Borrow against savings"
-      description="Borrow USDC against your soUSD on Fuse — keeps the principal earning yield."
-      onPress={() => onSelect('borrow')}
-    />
-    <OptionItem
-      title="From external wallet"
-      description="Send USDC directly from any wallet on Base via QR/address copy. No yield."
-      onPress={() => onSelect('external')}
-    />
-  </View>
-);
-
-const OptionItem = ({
-  title,
-  description,
-  onPress,
-}: {
-  title: string;
-  description: string;
-  onPress: () => void;
-}) => (
-  <Button
-    variant="ghost"
-    className="h-auto flex-row items-center justify-between rounded-2xl bg-primary/10 px-5 py-4 disabled:opacity-100 disabled:web:hover:opacity-100"
-    onPress={onPress}
-  >
-    <View className="flex-row items-center gap-3">
-      <Wallet color="white" size={24} />
-      <View className="max-w-[16rem] gap-1">
-        <Text className="text-lg font-semibold">{title}</Text>
-        <Text className="text-sm text-muted-foreground">{description}</Text>
-      </View>
-    </View>
-    <ChevronRight color="white" size={20} />
-  </Button>
-);
-
-type BorrowFormProps = {
-  agentEoaAddress?: string;
-  onSuccess: () => void;
+const SOURCE_LABEL: Record<AgentDepositSource, string> = {
+  borrow: 'Borrow against Savings',
+  external: 'External Wallet',
 };
 
-const AgentDepositBorrowForm = ({ agentEoaAddress, onSuccess }: BorrowFormProps) => {
-  const [sliderValue, setSliderValue] = useState(0);
-  const {
-    totalSupplied,
-    totalBorrowed,
-    borrowAPY,
-    isLoading: positionLoading,
-  } = useAaveBorrowPosition();
-  const { borrowAndDeposit, bridgeStatus } = useBorrowAndDepositToAgent(agentEoaAddress);
+const SOURCE_TOKEN: Record<AgentDepositSource, string> = {
+  borrow: '',
+  external: 'USDC',
+};
 
-  const maxBorrowAmount = useMemo(
-    () => Math.max(0, totalSupplied * 0.69 - totalBorrowed),
-    [totalSupplied, totalBorrowed],
+const SourceIcon = ({ value }: { value: AgentDepositSource }) =>
+  value === 'borrow' ? (
+    <Leaf color="#A1A1A1" size={24} />
+  ) : (
+    <WalletIcon color="#A1A1A1" size={24} />
   );
 
-  const collateralRequired = useMemo(() => {
-    if (sliderValue <= 0) return 0;
-    return (sliderValue * 100) / Number(SO_USD_LTV);
-  }, [sliderValue]);
+const SourceSelector = ({
+  value,
+  onChange,
+}: {
+  value: AgentDepositSource;
+  onChange: (next: AgentDepositSource) => void;
+}) =>
+  Platform.OS === 'web' ? (
+    <SourceSelectorWeb value={value} onChange={onChange} />
+  ) : (
+    <SourceSelectorNative value={value} onChange={onChange} />
+  );
 
-  const submitting = bridgeStatus === Status.PENDING;
-  const amountValid = sliderValue > 0 && sliderValue <= maxBorrowAmount;
+const SourceSelectorWeb = ({
+  value,
+  onChange,
+}: {
+  value: AgentDepositSource;
+  onChange: (next: AgentDepositSource) => void;
+}) => (
+  <DropdownMenu>
+    <DropdownMenuTrigger asChild>
+      <Pressable className="flex-row items-center justify-between rounded-2xl bg-accent p-4">
+        <View className="flex-row items-center gap-2">
+          <SourceIcon value={value} />
+          <Text className="text-lg font-semibold">{SOURCE_LABEL[value]}</Text>
+        </View>
+        <View className="flex-row items-center gap-2">
+          {SOURCE_TOKEN[value] ? (
+            <Text className="text-sm text-muted-foreground">{SOURCE_TOKEN[value]}</Text>
+          ) : null}
+          <ChevronDown color="#A1A1A1" size={20} />
+        </View>
+      </Pressable>
+    </DropdownMenuTrigger>
+    <DropdownMenuContent className="-mt-4 w-full min-w-[380px] rounded-b-2xl rounded-t-none border-0">
+      <DropdownMenuItem
+        onPress={() => onChange('borrow')}
+        className="flex-row items-center gap-2 px-4 py-3 web:cursor-pointer"
+      >
+        <Leaf color="#A1A1A1" size={20} />
+        <Text className="text-lg">Borrow against Savings</Text>
+      </DropdownMenuItem>
+      <DropdownMenuItem
+        onPress={() => onChange('external')}
+        className="flex-row items-center gap-2 px-4 py-3 web:cursor-pointer"
+      >
+        <WalletIcon color="#A1A1A1" size={20} />
+        <Text className="text-lg">External Wallet</Text>
+      </DropdownMenuItem>
+    </DropdownMenuContent>
+  </DropdownMenu>
+);
 
-  const handleSubmit = async () => {
-    if (!amountValid || !agentEoaAddress) return;
-    try {
-      await borrowAndDeposit(sliderValue.toString());
-      Toast.show({
-        type: 'success',
-        text1: 'Deposit submitted',
-        text2:
-          'Borrowed against soUSD on Fuse and sent via Stargate. Funds arrive on Base in ~1–5 min.',
-        props: { badgeText: 'Success' },
-      });
-      onSuccess();
-    } catch (err) {
-      Toast.show({
-        type: 'error',
-        text1: 'Deposit failed',
-        text2: err instanceof Error ? err.message : 'Unknown error',
-        props: { badgeText: 'Error' },
-      });
-    }
-  };
+const SourceSelectorNative = ({
+  value,
+  onChange,
+}: {
+  value: AgentDepositSource;
+  onChange: (next: AgentDepositSource) => void;
+}) => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const select = useCallback(
+    (next: AgentDepositSource) => {
+      onChange(next);
+      setIsOpen(false);
+    },
+    [onChange],
+  );
 
   return (
-    <View className="flex-1 gap-3">
-      {!isProduction && (
-        <View className="rounded-2xl border border-yellow-500/40 bg-yellow-500/10 px-4 py-3">
-          <Text className="text-sm font-medium text-yellow-300">
-            Borrow contract available only in production
-          </Text>
-          <Text className="mt-1 text-xs text-yellow-200/70">
-            soUSD and the Aave borrow market aren&apos;t deployed in this environment. The borrow
-            flow will fail — use the external-wallet option to fund the agent on Base for testing.
-          </Text>
+    <View>
+      <Pressable
+        className="flex-row items-center justify-between rounded-2xl bg-accent p-4"
+        onPress={() => setIsOpen(open => !open)}
+      >
+        <View className="flex-row items-center gap-2">
+          <SourceIcon value={value} />
+          <Text className="text-lg font-semibold">{SOURCE_LABEL[value]}</Text>
+        </View>
+        <View className="flex-row items-center gap-2">
+          {SOURCE_TOKEN[value] ? (
+            <Text className="text-sm text-muted-foreground">{SOURCE_TOKEN[value]}</Text>
+          ) : null}
+          <ChevronDown color="#A1A1A1" size={20} />
+        </View>
+      </Pressable>
+      {isOpen && (
+        <View className="mt-1 overflow-hidden rounded-2xl bg-accent">
+          <Pressable
+            className="flex-row items-center gap-2 px-4 py-3"
+            onPress={() => select('borrow')}
+          >
+            <Leaf color="#A1A1A1" size={20} />
+            <Text className="text-lg">Borrow against Savings</Text>
+          </Pressable>
+          <Pressable
+            className="flex-row items-center gap-2 px-4 py-3"
+            onPress={() => select('external')}
+          >
+            <WalletIcon color="#A1A1A1" size={20} />
+            <Text className="text-lg">External Wallet</Text>
+          </Pressable>
         </View>
       )}
-
-      <View className="gap-4 px-2">
-        <BorrowSlider
-          value={sliderValue}
-          onValueChange={setSliderValue}
-          min={0}
-          max={maxBorrowAmount}
-        />
-      </View>
-
-      <TokenDetails className="mt-3">
-        <View className="flex-row items-center justify-between gap-2 px-5 py-6 md:gap-10 md:p-5">
-          <Text className="native:text-lg text-base text-muted-foreground">Borrow rate</Text>
-          <View className="ml-auto shrink-0 flex-row items-baseline gap-2">
-            {positionLoading ? (
-              <Skeleton className="h-5 w-16 rounded-md" />
-            ) : (
-              <Text className="native:text-lg text-base font-semibold">
-                {formatNumber(borrowAPY, 2)}%
-              </Text>
-            )}
-          </View>
-        </View>
-        <View className="flex-row items-center justify-between gap-2 px-5 py-6 md:gap-10 md:p-5">
-          <View className="flex-row items-center gap-2">
-            <Text className="native:text-lg text-base text-muted-foreground">
-              Collateral Required
-            </Text>
-          </View>
-          <View className="ml-auto shrink-0 flex-row items-baseline gap-2">
-            {!sliderValue ? (
-              <Skeleton className="h-5 w-20 rounded-md" />
-            ) : (
-              <Text className="native:text-lg text-base font-semibold">
-                {formatNumber(collateralRequired)} soUSD
-              </Text>
-            )}
-          </View>
-        </View>
-        <View className="px-5 py-6 md:p-5">
-          <Text className="native:text-base text-sm text-muted-foreground">
-            Use your soUSD as collateral to borrow USDC and fund your agent wallet on Base while
-            earning yield.{' '}
-            <Text
-              onPress={() => {
-                Linking.openURL(
-                  'https://support.solid.xyz/en/articles/13545322-borrow-against-your-savings',
-                );
-              }}
-              className="text-base font-medium leading-5 text-[#94F27F] web:hover:opacity-70"
-            >
-              Learn more.
-            </Text>
-          </Text>
-        </View>
-      </TokenDetails>
-
-      <Button
-        variant="brand"
-        className="h-12 rounded-2xl"
-        disabled={!amountValid || submitting}
-        onPress={handleSubmit}
-      >
-        {submitting ? (
-          <ActivityIndicator color="black" />
-        ) : (
-          <Text className="native:text-lg text-base font-bold text-black">Deposit</Text>
-        )}
-      </Button>
     </View>
   );
 };


### PR DESCRIPTION
…reen

Mirror the card deposit modal's source selector. The agent deposit modal is now a single screen with a 'From' dropdown at the top (Borrow against Savings / External Wallet) and the matching form rendered inline below. Removes the prior options-step indirection, the back-button bookkeeping, and the per-option descriptions.

- Web: real DropdownMenu (radix) — same -mt-4 rounded-b-2xl pattern.
- Native: inline expanding section (Pressable + isOpen) — same as the card flow's SourceSelectorNative.
- AgentDepositBorrowForm extracted into its own file for symmetry with AgentDepositExternalForm.