### PR TITLE
Cherry-pick: keep card deposit button enabled below gasless minimum

### DIFF
--- a/components/Card/CardDepositInternalForm.tsx
+++ b/components/Card/CardDepositInternalForm.tsx
@@ -742,6 +742,11 @@ export default function CardDepositInternalForm() {
   const isCardDepositSponsor = isWalletSourceGaslessGated
     ? Number(watchedAmount || 0) >= Number(cardDepositMinimumAmount)
     : true;
+  const isBelowMinimumDeposit =
+    isWalletSourceGaslessGated &&
+    !!watchedAmount &&
+    Number(watchedAmount) > 0 &&
+    Number(watchedAmount) < Number(cardDepositMinimumAmount);
 
   const schema = useMemo(() => {
     return z.object({
@@ -762,23 +767,9 @@ export default function CardDepositInternalForm() {
                 ? `Maximum borrow amount is ${formatNumber(maxBorrowAmount)} USDC`
                 : `Available balance is ${formatNumber(balanceAmount)} ${tokenSymbol}`,
           },
-        )
-        .refine(
-          val => {
-            if (!isWalletSourceGaslessGated) return true;
-            return Number(val) >= Number(cardDepositMinimumAmount);
-          },
-          { error: `Minimum $${cardDepositMinimumAmount} USDC` },
         ),
     });
-  }, [
-    balanceAmount,
-    tokenSymbol,
-    watchedFrom,
-    maxBorrowAmount,
-    isWalletSourceGaslessGated,
-    cardDepositMinimumAmount,
-  ]);
+  }, [balanceAmount, tokenSymbol, watchedFrom, maxBorrowAmount]);
 
   const formattedBalance = balanceAmount.toString();
 
@@ -1399,8 +1390,17 @@ export default function CardDepositInternalForm() {
 
       {isWalletSourceGaslessGated && (
         <View className="mt-2 flex-row items-start gap-2">
-          <Fuel color="#A1A1A1" size={16} className="mt-0.5" />
-          <Text className="max-w-xs text-sm text-muted-foreground">
+          <Fuel
+            color={isBelowMinimumDeposit ? '#EF4444' : '#A1A1A1'}
+            size={16}
+            className="mt-0.5"
+          />
+          <Text
+            className={cn(
+              'max-w-xs text-sm',
+              isBelowMinimumDeposit ? 'text-red-500' : 'text-muted-foreground',
+            )}
+          >
             {isCardDepositSponsor
               ? 'Gasless deposit'
               : `Gasless deposit - Please deposit above $${cardDepositMinimumAmount} USDC so we can cover your fees`}


### PR DESCRIPTION
## Summary
- Cherry-picks the card deposit minimum validation fix from qa (originally merged via #2031) onto master.
- Drops the minimum-amount refine from the deposit form schema so amounts under the gasless threshold no longer disable the "Deposit to Card" button.
- Turns the existing gasless hint red when the entered amount is below the minimum, surfacing the requirement without blocking the action.

## Test plan
- [ ] Open Deposit to Card with Wallet source in production build
- [ ] Enter an amount below the gasless minimum (e.g. $2) and confirm the gasless hint turns red and the button stays enabled
- [ ] Enter an amount at or above the minimum and confirm the hint reverts to "Gasless deposit" in muted color
- [ ] Confirm balance/borrow validation still disables the button when exceeded

https://claude.ai/code/session_015A1KTGTkLJht3CZWifFKZN

---
_Generated by [Claude Code](https://claude.ai/code/session_015A1KTGTkLJht3CZWifFKZN)_