### PR TITLE
fix(card-deposit): keep gasless hint icon and text color in sync

### DIFF
--- a/components/Card/CardDepositInternalForm.tsx
+++ b/components/Card/CardDepositInternalForm.tsx
@@ -1396,10 +1396,8 @@ export default function CardDepositInternalForm() {
             className="mt-0.5"
           />
           <Text
-            className={cn(
-              'max-w-xs text-sm',
-              isBelowMinimumDeposit ? 'text-red-500' : 'text-muted-foreground',
-            )}
+            className="max-w-xs text-sm"
+            style={{ color: isBelowMinimumDeposit ? '#EF4444' : '#A1A1A1' }}
           >
             {isCardDepositSponsor
               ? 'Gasless deposit'


### PR DESCRIPTION
Switch the gasless hint Text from a className-based color to an inline style. The Text component's wrapper applies its own cn merge with text-foreground, and twMerge does not recognize text-muted-foreground as a color token, so toggling between text-red-500 and text-muted-foreground left stale color rules and the text stayed red after the amount cleared or rose above the minimum. Driving the color via the style prop matches how the Fuel icon's color prop is wired and keeps the two visually in sync.

https://claude.ai/code/session_015A1KTGTkLJht3CZWifFKZN