### PR TITLE
fix(card-deposit): surface zod v4 validation errors in deposit form

### DIFF
--- a/components/Card/CardDepositInternalForm.tsx
+++ b/components/Card/CardDepositInternalForm.tsx
@@ -1162,8 +1162,9 @@ export default function CardDepositInternalForm() {
     try {
       schema.parse({ amount: watchedAmount });
       return null;
-    } catch (error: any) {
-      return error.errors?.[0]?.message || null;
+    } catch (error: unknown) {
+      const err = error as { issues?: { message?: string }[] };
+      return err.issues?.[0]?.message ?? null;
     }
   }, [watchedAmount, schema]);
 


### PR DESCRIPTION
Zod 4 exposes parse failures via error.issues, but the deposit form was reading error.errors (the v3 shape), so validationError always resolved to null and the balance / borrow / invalid-amount messages never reached ErrorDisplay. Switch to err.issues[0].message, matching the extraction used in CardWithdrawForm, so users see the actual reason the button is disabled.

https://claude.ai/code/session_015A1KTGTkLJht3CZWifFKZN