### PR TITLE
fix(card-deposit): drop Onchain badge from card-deposit error toasts

### DIFF
--- a/components/Card/CardDepositExternalForm.tsx
+++ b/components/Card/CardDepositExternalForm.tsx
@@ -158,6 +158,7 @@ export default function CardDepositExternalForm() {
             type: 'error',
             text1: 'External deposits not available',
             text2: 'This card does not support deposits from external wallet',
+            props: { badgeText: '' },
           });
           return;
         }

--- a/components/Card/CardDepositInternalForm.tsx
+++ b/components/Card/CardDepositInternalForm.tsx
@@ -928,6 +928,7 @@ export default function CardDepositInternalForm() {
             type: 'error',
             text1: 'Deposits not available',
             text2: 'This card does not support deposits to the funding chain',
+            props: { badgeText: '' },
           });
           return;
         }
@@ -1054,6 +1055,7 @@ export default function CardDepositInternalForm() {
             type: 'error',
             text1: 'Deposits not available',
             text2: 'This card does not support deposits to the funding chain',
+            props: { badgeText: '' },
           });
           return;
         }

--- a/hooks/useCardDeposit.ts
+++ b/hooks/useCardDeposit.ts
@@ -76,6 +76,7 @@ const useCardDeposit = (): CardDepositResult => {
           type: 'error',
           text1: 'Deposits not available',
           text2: 'This card does not support deposits',
+          props: { badgeText: '' },
         });
         return;
       }


### PR DESCRIPTION
## Summary

The default toast badge text is `'Onchain'`, which is misleading on the **"Deposits not available"** / **"External deposits not available"** errors that fire from card-deposit forms (the badge appears inside the toast next to the close button — see screenshot in the linked thread). Pass `props: { badgeText: '' }` so no badge is rendered for these toasts.

Sites updated:
- `components/Card/CardDepositInternalForm.tsx` (Borrow + Savings/Wallet submit handlers)
- `components/Card/CardDepositExternalForm.tsx` (External wallet submit)
- `hooks/useCardDeposit.ts` (testnet same-chain deposit)

## Test plan

- [ ] Trigger any of the card-deposit "not available" errors → toast renders without the Onchain badge.
- [ ] Other onchain toasts (transactions etc.) still render the Onchain badge as before.

https://claude.ai/code/session_018yioW4wRXd4AJjUrU32QLe

---
_Generated by [Claude Code](https://claude.ai/code/session_018yioW4wRXd4AJjUrU32QLe)_