### PR TITLE
Remove minimum deposit validation for gasless card deposits

### DIFF
--- a/components/Card/CardDepositInternalForm.tsx
+++ b/components/Card/CardDepositInternalForm.tsx
@@ -738,15 +738,6 @@ export default function CardDepositInternalForm() {
 
   const isWalletSourceGaslessGated =
     isProduction && watchedFrom === CardDepositSource.WALLET;
-  const cardDepositMinimumAmount = EXPO_PUBLIC_MINIMUM_SPONSOR_AMOUNT;
-  const isCardDepositSponsor = isWalletSourceGaslessGated
-    ? Number(watchedAmount || 0) >= Number(cardDepositMinimumAmount)
-    : true;
-  const isBelowMinimumDeposit =
-    isWalletSourceGaslessGated &&
-    !!watchedAmount &&
-    Number(watchedAmount) > 0 &&
-    Number(watchedAmount) < Number(cardDepositMinimumAmount);
 
   const schema = useMemo(() => {
     return z.object({
@@ -1393,18 +1384,9 @@ export default function CardDepositInternalForm() {
 
       {isWalletSourceGaslessGated && (
         <View className="mt-2 flex-row items-start gap-2">
-          <Fuel
-            color={isBelowMinimumDeposit ? '#EF4444' : '#A1A1A1'}
-            size={16}
-            className="mt-0.5"
-          />
-          <Text
-            className="max-w-xs text-sm"
-            style={{ color: isBelowMinimumDeposit ? '#EF4444' : '#A1A1A1' }}
-          >
-            {isCardDepositSponsor
-              ? 'Gasless deposit'
-              : `Gasless deposit - Please deposit above $${cardDepositMinimumAmount} USDC so we can cover your fees`}
+          <Fuel color="#A1A1A1" size={16} className="mt-0.5" />
+          <Text className="max-w-xs text-sm" style={{ color: '#A1A1A1' }}>
+            Gasless deposit
           </Text>
         </View>
       )}

--- a/hooks/useDepositFromSolidUsdc.ts
+++ b/hooks/useDepositFromSolidUsdc.ts
@@ -134,7 +134,7 @@ const useDepositFromSolidUsdc = (
 
       const isSponsor = Number(amount) >= Number(minimumAmount);
 
-      if (!isSponsor) {
+      if (!isCard && !isSponsor) {
         throw new Error(`Minimum deposit amount is $${minimumAmount}`);
       }
 


### PR DESCRIPTION
## Summary
This PR removes the minimum deposit amount validation and UI messaging for gasless card deposits, simplifying the deposit flow for card sources while maintaining the validation for other deposit sources.

## Key Changes
- **CardDepositInternalForm.tsx**: 
  - Removed `cardDepositMinimumAmount`, `isCardDepositSponsor`, and `isBelowMinimumDeposit` state variables
  - Simplified the gasless deposit info message to always display "Gasless deposit" without conditional minimum amount warnings
  - Removed dynamic color changes on the Fuel icon and text based on minimum deposit validation

- **useDepositFromSolidUsdc.ts**:
  - Updated minimum deposit validation to skip the check for card deposits (`!isCard && !isSponsor`)
  - Card deposits are now exempt from the minimum sponsor amount requirement

## Implementation Details
The changes allow card deposits to proceed without meeting the minimum deposit threshold, while wallet deposits still enforce the minimum amount validation. This streamlines the user experience for card-based deposits by removing the minimum amount barrier and associated warning messaging.

https://claude.ai/code/session_019ajaJ3Dc3VrjYR4nQvZKQG