### PR TITLE
fix(card-deposit): remove gasless minimum deposit requirement

### DIFF
--- a/components/Card/CardDepositInternalForm.tsx
+++ b/components/Card/CardDepositInternalForm.tsx
@@ -738,15 +738,6 @@ export default function CardDepositInternalForm() {
 
   const isWalletSourceGaslessGated =
     isProduction && watchedFrom === CardDepositSource.WALLET;
-  const cardDepositMinimumAmount = EXPO_PUBLIC_MINIMUM_SPONSOR_AMOUNT;
-  const isCardDepositSponsor = isWalletSourceGaslessGated
-    ? Number(watchedAmount || 0) >= Number(cardDepositMinimumAmount)
-    : true;
-  const isBelowMinimumDeposit =
-    isWalletSourceGaslessGated &&
-    !!watchedAmount &&
-    Number(watchedAmount) > 0 &&
-    Number(watchedAmount) < Number(cardDepositMinimumAmount);
 
   const schema = useMemo(() => {
     return z.object({
@@ -1393,18 +1384,9 @@ export default function CardDepositInternalForm() {
 
       {isWalletSourceGaslessGated && (
         <View className="mt-2 flex-row items-start gap-2">
-          <Fuel
-            color={isBelowMinimumDeposit ? '#EF4444' : '#A1A1A1'}
-            size={16}
-            className="mt-0.5"
-          />
-          <Text
-            className="max-w-xs text-sm"
-            style={{ color: isBelowMinimumDeposit ? '#EF4444' : '#A1A1A1' }}
-          >
-            {isCardDepositSponsor
-              ? 'Gasless deposit'
-              : `Gasless deposit - Please deposit above $${cardDepositMinimumAmount} USDC so we can cover your fees`}
+          <Fuel color="#A1A1A1" size={16} className="mt-0.5" />
+          <Text className="max-w-xs text-sm" style={{ color: '#A1A1A1' }}>
+            Gasless deposit
           </Text>
         </View>
       )}

--- a/hooks/useDepositFromSolidUsdc.ts
+++ b/hooks/useDepositFromSolidUsdc.ts
@@ -134,7 +134,7 @@ const useDepositFromSolidUsdc = (
 
       const isSponsor = Number(amount) >= Number(minimumAmount);
 
-      if (!isSponsor) {
+      if (!isCard && !isSponsor) {
         throw new Error(`Minimum deposit amount is $${minimumAmount}`);
       }
 


### PR DESCRIPTION
## Summary
Cherry-pick of #2042 from `qa` to `master`.

- Removes the gasless minimum deposit gate in the deposit-to-card modal so any amount can be deposited gaslessly.
- Updates `useDepositFromSolidUsdc` to skip the minimum-amount throw for `DepositCategory.CARD` (savings deposits keep their existing minimum).
- Simplifies the gasless badge UI — no more red warning state below `MINIMUM_SPONSOR_AMOUNT`.

## Test plan
- [ ] Open the deposit-to-card modal in production, confirm gasless badge shows the neutral "Gasless deposit" copy at any non-zero amount.
- [ ] Submit a card deposit below `EXPO_PUBLIC_MINIMUM_SPONSOR_AMOUNT` and confirm the transaction is no longer rejected client-side.
- [ ] Confirm a savings deposit below the minimum still surfaces the original error (unchanged behavior).

https://claude.ai/code/session_019ajaJ3Dc3VrjYR4nQvZKQG

---
_Generated by [Claude Code](https://claude.ai/code/session_019ajaJ3Dc3VrjYR4nQvZKQG)_