### PR TITLE
Fix cashback value formatting to preserve decimal precision

### DIFF
--- a/app/(protected)/(tabs)/card/details.tsx
+++ b/app/(protected)/(tabs)/card/details.tsx
@@ -424,7 +424,7 @@ interface SpendingBalanceCardProps {
 
 function SpendingBalanceCard({ amount, cashback }: SpendingBalanceCardProps) {
   const formattedAmount = Number.parseFloat(amount).toFixed(2);
-  const totalUsdValue = cashback?.totalUsdValue ? parseFloat(cashback.totalUsdValue.toFixed(0)) : 0;
+  const totalUsdValue = cashback?.totalUsdValue ? cashback.totalUsdValue.toFixed(2) : '0.00';
   const cashbackPercentage = cashback?.percentage || 0;
 
   return (
@@ -1052,7 +1052,7 @@ interface CashbackDisplayProps {
 }
 
 function CashbackDisplay({ cashback }: CashbackDisplayProps) {
-  const totalUsdValue = cashback?.totalUsdValue ? parseFloat(cashback.totalUsdValue.toFixed(2)) : 0;
+  const totalUsdValue = cashback?.totalUsdValue ? cashback.totalUsdValue.toFixed(2) : '0.00';
 
   const cashbackPercentage = cashback?.percentage || 0;
 


### PR DESCRIPTION
## Summary
Updated cashback value formatting in the card details component to maintain two decimal places consistently, improving precision and display accuracy for monetary values.

## Key Changes
- Modified `SpendingBalanceCard` component to return cashback total USD value as a string with 2 decimal places (`toFixed(2)`) instead of parsing to a number with 0 decimal places
- Modified `CashbackDisplay` component with the same formatting fix for consistency
- Changed fallback value from `0` to `'0.00'` to match the new string format with proper decimal precision

## Implementation Details
- The changes ensure that cashback values are displayed with exactly 2 decimal places, which is the standard for currency formatting
- By keeping the value as a string (via `toFixed(2)`), we preserve the decimal precision without floating-point arithmetic issues
- This maintains consistency across both components that display cashback information

https://claude.ai/code/session_01KbGt2z23Ci4FWrvDcC8pEc