### PR TITLE
fix(card): show cashback to two decimals on details

### DIFF
--- a/app/(protected)/(tabs)/card/details.tsx
+++ b/app/(protected)/(tabs)/card/details.tsx
@@ -424,7 +424,7 @@ interface SpendingBalanceCardProps {
 
 function SpendingBalanceCard({ amount, cashback }: SpendingBalanceCardProps) {
   const formattedAmount = Number.parseFloat(amount).toFixed(2);
-  const totalUsdValue = cashback?.totalUsdValue ? parseFloat(cashback.totalUsdValue.toFixed(0)) : 0;
+  const totalUsdValue = cashback?.totalUsdValue ? cashback.totalUsdValue.toFixed(2) : '0.00';
   const cashbackPercentage = cashback?.percentage || 0;
 
   return (
@@ -1052,7 +1052,7 @@ interface CashbackDisplayProps {
 }
 
 function CashbackDisplay({ cashback }: CashbackDisplayProps) {
-  const totalUsdValue = cashback?.totalUsdValue ? parseFloat(cashback.totalUsdValue.toFixed(2)) : 0;
+  const totalUsdValue = cashback?.totalUsdValue ? cashback.totalUsdValue.toFixed(2) : '0.00';
 
   const cashbackPercentage = cashback?.percentage || 0;
 


### PR DESCRIPTION
Cherry-pick of #2046 from `qa` to `master`.

## Summary
- Desktop `SpendingBalanceCard` was rounding `totalUsdValue` to whole dollars via `.toFixed(0)`, so any cashback under $0.50 rendered as `"$0"`.
- Mobile `CashbackDisplay` used `.toFixed(2)` but then `parseFloat`'d the result, dropping trailing zeros (e.g. `$0.30` → `$0.3`).
- Both now produce a `"$X.XX"` string consistently.

## Test plan
- [ ] Card details (desktop): cashback amounts under $1 render with cents, e.g. `$0.42` instead of `$0`.
- [ ] Card details (mobile): cashback like `$0.30` renders with the trailing zero, not `$0.3`.
- [ ] When backend returns `totalUsdValue: 0`, both views render `$0.00`.

https://claude.ai/code/session_01KbGt2z23Ci4FWrvDcC8pEc

---
_Generated by [Claude Code](https://claude.ai/code/session_01KbGt2z23Ci4FWrvDcC8pEc)_