### PR TITLE
refactor(card-onboard): adjust icon sizing and gradient height

### DIFF
--- a/components/CardWaitlist/CardFeesModal.tsx
+++ b/components/CardWaitlist/CardFeesModal.tsx
@@ -26,9 +26,7 @@ type DetailItemProps = {
 
 const DetailItem = ({ icon, title, description }: DetailItemProps) => (
   <View className="flex-row gap-3">
-    <View className="h-12 w-12 items-center justify-center rounded-full bg-[#94F27F26]">
-      <Image source={icon} style={{ width: 28, height: 28 }} contentFit="contain" />
-    </View>
+    <Image source={icon} style={{ width: 50, height: 50 }} contentFit="contain" />
     <View className="flex-1 gap-1">
       <Text className="text-base font-semibold">{title}</Text>
       {typeof description === 'string' ? (

--- a/components/CardWaitlist/CardWaitlistContainer.tsx
+++ b/components/CardWaitlist/CardWaitlistContainer.tsx
@@ -17,7 +17,7 @@ const CardWaitlistContainer = ({ children }: CardWaitlistContainerProps) => {
       start={isScreenMedium ? { x: 0.5, y: 0 } : { x: 0, y: 0.5 }}
       end={isScreenMedium ? { x: 0.6, y: 1 } : { x: 1, y: 0.7 }}
       className="overflow-hidden rounded-twice web:md:flex web:md:flex-row"
-      style={{ minHeight: 500, ...(Platform.OS === 'web' ? {} : { borderRadius: 20 }) }}
+      style={{ minHeight: 450, ...(Platform.OS === 'web' ? {} : { borderRadius: 20 }) }}
     >
       {isScreenMedium ? (
         <ImageBackground

--- a/components/CardWaitlist/SolidCardSummary.tsx
+++ b/components/CardWaitlist/SolidCardSummary.tsx
@@ -11,7 +11,7 @@ type FeatureItemProps = {
 
 const FeatureItem = ({ icon, label }: FeatureItemProps) => (
   <View className="flex-row items-center gap-2">
-    <View className="h-7 w-7 items-center justify-center rounded-md bg-[#94F27F26]">{icon}</View>
+    <View className="h-9 w-9 items-center justify-center rounded-full bg-[#94F27F26]">{icon}</View>
     <Text className="text-base font-medium">{label}</Text>
   </View>
 );


### PR DESCRIPTION
- Increase summary feature icons from 28px square to 36px round
- Reduce CardWaitlistContainer minHeight from 500 to 450
- Drop the wrapper circle around fees-modal detail icons; render the 50px image directly since the assets already include their own background