### PR TITLE
fix(card-onboard): mobile bottom inset and close fees modal on Get-yo…

### DIFF
--- a/components/CardWaitlist/CardFeesModal.tsx
+++ b/components/CardWaitlist/CardFeesModal.tsx
@@ -134,7 +134,7 @@ const CardFeesModal = ({ isOpen, onOpenChange }: CardFeesModalProps) => {
         </View>
 
         <AuthButton>
-          <GetCardButton className="w-full" />
+          <GetCardButton className="w-full" onPress={() => onOpenChange(false)} />
         </AuthButton>
       </View>
     </ResponsiveModal>

--- a/components/CardWaitlist/CardWaitlistPageMobile.tsx
+++ b/components/CardWaitlist/CardWaitlistPageMobile.tsx
@@ -18,7 +18,7 @@ const CardWaitlistPageMobile = () => {
       scrollable={false}
       additionalContent={<CardFeesModal isOpen={feesOpen} onOpenChange={setFeesOpen} />}
     >
-      <View className="flex-1 px-5 pb-4 pt-2">
+      <View className="flex-1 px-5 pb-24 pt-2">
         <View className="flex-1 items-center justify-center">
           <Image
             source={getAsset('images/cards.png')}

--- a/components/CardWaitlist/GetCardButton.tsx
+++ b/components/CardWaitlist/GetCardButton.tsx
@@ -9,12 +9,14 @@ import { cn } from '@/lib/utils';
 
 interface GetCardButtonProps {
   className?: string;
+  onPress?: () => void;
 }
 
-const GetCardButton = ({ className }: GetCardButtonProps) => {
+const GetCardButton = ({ className, onPress }: GetCardButtonProps) => {
   const router = useRouter();
 
   const handleGetCard = async () => {
+    onPress?.();
     track(TRACKING_EVENTS.CARD_GET_CARD_PRESSED, {
       source: 'card_waitlist',
     });


### PR DESCRIPTION
…ur-card press

- pb-24 on the mobile page so content clears the tab bar
- GetCardButton accepts an optional onPress so callers can run side effects (the fees modal uses it to close itself before navigating)