### PR TITLE
Handle reverted transactions in wallet transfer flow

### DIFF
--- a/hooks/useTransferToWallet.ts
+++ b/hooks/useTransferToWallet.ts
@@ -184,7 +184,21 @@ const useTransferToWallet = (
       waitForTransactionReceipt(publicClient(srcChainId), {
         hash: txHash as `0x${string}`,
       })
-        .then(() => {
+        .then(receipt => {
+          // viem resolves with the receipt regardless of execution outcome.
+          // A reverted on-chain transaction is `status: 'reverted'` — treat
+          // that as FAILED, not SUCCESS.
+          if (receipt.status !== 'success') {
+            updateActivity(capturedTrackingId!, {
+              status: TransactionStatus.FAILED,
+              metadata: {
+                error: 'Transaction reverted on-chain',
+                failedAt: new Date().toISOString(),
+              },
+            });
+            return;
+          }
+
           updateActivity(capturedTrackingId!, { status: TransactionStatus.SUCCESS });
 
           track(TRACKING_EVENTS.DEPOSIT_COMPLETED, {


### PR DESCRIPTION
## Summary
Fixed a bug in the wallet transfer flow where reverted on-chain transactions were incorrectly marked as successful. The code now properly checks the transaction receipt status and marks transactions as failed when they revert on-chain.

## Key Changes
- Modified `useTransferToWallet` hook to inspect the transaction receipt status returned by `waitForTransactionReceipt`
- Added validation to check if `receipt.status !== 'success'` before marking transaction as successful
- When a transaction is reverted on-chain, the activity is now correctly updated with `TransactionStatus.FAILED` status and includes error metadata with the failure reason and timestamp
- Early return prevents the success status update from being applied to failed transactions

## Implementation Details
- The viem library's `waitForTransactionReceipt` resolves with the receipt regardless of execution outcome, so explicit status checking is required
- Reverted transactions have `status: 'reverted'` in the receipt object
- Error metadata includes both the failure reason and a timestamp for debugging purposes

https://claude.ai/code/session_01RxjZ6dUk9zmVbuPEXcvqaX