### PR TITLE
fix(add-funds): mark reverted on-chain transfers as FAILED

### DIFF
--- a/hooks/useTransferToWallet.ts
+++ b/hooks/useTransferToWallet.ts
@@ -184,7 +184,21 @@ const useTransferToWallet = (
       waitForTransactionReceipt(publicClient(srcChainId), {
         hash: txHash as `0x${string}`,
       })
-        .then(() => {
+        .then(receipt => {
+          // viem resolves with the receipt regardless of execution outcome.
+          // A reverted on-chain transaction is `status: 'reverted'` — treat
+          // that as FAILED, not SUCCESS.
+          if (receipt.status !== 'success') {
+            updateActivity(capturedTrackingId!, {
+              status: TransactionStatus.FAILED,
+              metadata: {
+                error: 'Transaction reverted on-chain',
+                failedAt: new Date().toISOString(),
+              },
+            });
+            return;
+          }
+
           updateActivity(capturedTrackingId!, { status: TransactionStatus.SUCCESS });
 
           track(TRACKING_EVENTS.DEPOSIT_COMPLETED, {


### PR DESCRIPTION
## Summary
Cherry-pick of #2055 from `qa` to `master` for the connect-wallet "Add funds" activity fix.

`useTransferToWallet`'s background receipt watcher fed the resolved `waitForTransactionReceipt` promise straight to `TransactionStatus.SUCCESS`, but viem resolves with the receipt regardless of execution outcome — a reverted on-chain tx returns `receipt.status === 'reverted'` rather than throwing. Connect-wallet add-funds activities therefore flipped to SUCCESS even when the user's transfer reverted on-chain, masking the failure in the activity list / detail page.

This change inspects `receipt.status` before promoting to SUCCESS; reverted receipts go through the same FAILED + error-metadata path the `.catch()` branch already uses, matching the contract pattern used in `useTransactionReceiptPolling` and other deposit hooks.

## Test plan
- [ ] On the home page, click **Add funds**, connect external wallet (MetaMask), pick a token + amount, submit
- [ ] Verify activity appears as **PENDING** immediately, then **PROCESSING** once the tx hash is returned
- [ ] Verify activity transitions to **SUCCESS** once the tx is mined and confirmed on-chain
- [ ] Force a revert (e.g., insufficient gas / bad data) and verify the activity transitions to **FAILED** rather than SUCCESS
- [ ] Confirm activity persistence by reloading the app — activity should still resolve to its final state via the backend cron / receipt-polling hook

Pairs with backend PR adding the `FUND` activity type to `master`.

https://claude.ai/code/session_01RxjZ6dUk9zmVbuPEXcvqaX

---
_Generated by [Claude Code](https://claude.ai/code/session_01RxjZ6dUk9zmVbuPEXcvqaX)_