### PR TITLE
Update international card terms URL

### DIFF
--- a/app/(protected)/(tabs)/card/ready.tsx
+++ b/app/(protected)/(tabs)/card/ready.tsx
@@ -39,7 +39,8 @@ const ACCOUNT_OPENING_PRIVACY_URL =
   'https://support.solid.xyz/en/articles/14285527-account-opening-privacy-notice-fuse-network-lt-solid-xyz';
 const US_CARD_TERMS_URL =
   'https://support.solid.xyz/en/articles/14285503-fuse-network-ltd-card-terms-for-u-s-consumer-program';
-const INTL_CARD_TERMS_URL = 'https://support.solid.xyz/en/articles/14167026-solid-user-terms';
+const INTL_CARD_TERMS_URL =
+  'https://support.solid.xyz/en/articles/14167076-card-terms-for-international-consumer-program';
 const ISSUER_PRIVACY_URL = 'https://www.third-national.com/privacypolicy';
 
 const underlineProps = {


### PR DESCRIPTION
## Summary
Updated the international card terms URL to point to the correct support article for the international consumer program.

## Changes
- Updated `INTL_CARD_TERMS_URL` constant to reference the correct support article (`14167076-card-terms-for-international-consumer-program` instead of `14167026-solid-user-terms`)
- Reformatted the constant declaration across multiple lines for better readability

## Details
This change ensures users are directed to the appropriate card terms documentation specific to the international consumer program rather than the general user terms article.

https://claude.ai/code/session_011Y3KdhvK3pEKb5Kd2v8gxA