### PR TITLE
Update international card terms link to new consumer program article

### DIFF
--- a/app/(protected)/(tabs)/card/ready.tsx
+++ b/app/(protected)/(tabs)/card/ready.tsx
@@ -39,7 +39,8 @@ const ACCOUNT_OPENING_PRIVACY_URL =
   'https://support.solid.xyz/en/articles/14285527-account-opening-privacy-notice-fuse-network-lt-solid-xyz';
 const US_CARD_TERMS_URL =
   'https://support.solid.xyz/en/articles/14285503-fuse-network-ltd-card-terms-for-u-s-consumer-program';
-const INTL_CARD_TERMS_URL = 'https://support.solid.xyz/en/articles/14167026-solid-user-terms';
+const INTL_CARD_TERMS_URL =
+  'https://support.solid.xyz/en/articles/14167076-card-terms-for-international-consumer-program';
 const ISSUER_PRIVACY_URL = 'https://www.third-national.com/privacypolicy';
 
 const underlineProps = {


### PR DESCRIPTION
## Summary
- Replace deprecated `solid-user-terms` link with the dedicated `card-terms-for-international-consumer-program` article so non-US users see the correct terms during card activation.
- Cherry-picked from qa (PR #2057, commit a466973).

## Test plan
- [ ] Verify non-US user sees the updated international card terms link on card activation screen.
- [ ] Verify US user still sees the existing US card terms link (unchanged).

https://claude.ai/code/session_011Y3KdhvK3pEKb5Kd2v8gxA

---
_Generated by [Claude Code](https://claude.ai/code/session_011Y3KdhvK3pEKb5Kd2v8gxA)_