### PR TITLE
Add welcome popup for newly activated cards

### DIFF
--- a/app/(protected)/(tabs)/card/details.tsx
+++ b/app/(protected)/(tabs)/card/details.tsx
@@ -13,17 +13,11 @@ import * as Clipboard from 'expo-clipboard';
 import { Image } from 'expo-image';
 import { LinearGradient } from 'expo-linear-gradient';
 import { useRouter } from 'expo-router';
-import {
-  ChevronDown,
-  ChevronRight,
-  Copy,
-  KeyRound,
-  Plus,
-  Settings,
-} from 'lucide-react-native';
+import { ChevronDown, ChevronRight, Copy, KeyRound, Plus, Settings } from 'lucide-react-native';
 
 import AddToWalletModal from '@/components/Card/AddToWalletModal';
 import { BorrowPositionCard } from '@/components/Card/BorrowPositionCard';
+import CardWelcomePopup from '@/components/Card/CardWelcomePopup';
 import { CircularActionButton } from '@/components/Card/CircularActionButton';
 import DepositToCardModal from '@/components/Card/DepositToCardModal';
 import ManagePinModal from '@/components/Card/ManagePinModal';
@@ -52,6 +46,7 @@ import { EXPO_PUBLIC_ENVIRONMENT } from '@/lib/config';
 import { CardHolderName, CardProvider, CardStatus, FreezeInitiator, KycStatus } from '@/lib/types';
 import { cn } from '@/lib/utils/utils';
 import { CardDepositSource, useCardDepositStore } from '@/store/useCardDepositStore';
+import { useCardWelcomePopupStore } from '@/store/useCardWelcomePopupStore';
 
 export default function CardDetails() {
   const { data: cardDetails, isLoading, refetch } = useCardDetails();
@@ -67,6 +62,15 @@ export default function CardDetails() {
   const [shouldRevealDetails, setShouldRevealDetails] = useState(false);
   const [isAddToWalletModalOpen, setIsAddToWalletModalOpen] = useState(false);
   const flipAnimation = useRef(new Animated.Value(0)).current;
+
+  const shouldShowWelcomePopup = useCardWelcomePopupStore(state => state.shouldShowWelcomePopup);
+  const setShouldShowWelcomePopup = useCardWelcomePopupStore(
+    state => state.setShouldShowWelcomePopup,
+  );
+  const handleCloseWelcomePopup = useCallback(
+    () => setShouldShowWelcomePopup(false),
+    [setShouldShowWelcomePopup],
+  );
 
   const availableBalance = cardDetails?.balances.available;
   const availableAmount = Number(availableBalance?.amount || '0').toString();
@@ -200,6 +204,8 @@ export default function CardDetails() {
           onOpenChange={setIsAddToWalletModalOpen}
           trigger={null}
         />
+
+        <CardWelcomePopup isOpen={shouldShowWelcomePopup} onClose={handleCloseWelcomePopup} />
       </PageLayout>
     );
   }
@@ -245,6 +251,8 @@ export default function CardDetails() {
         onOpenChange={setIsAddToWalletModalOpen}
         trigger={null}
       />
+
+      <CardWelcomePopup isOpen={shouldShowWelcomePopup} onClose={handleCloseWelcomePopup} />
     </PageLayout>
   );
 }

--- a/app/(protected)/(tabs)/card/ready.tsx
+++ b/app/(protected)/(tabs)/card/ready.tsx
@@ -14,6 +14,7 @@ import { CARD_STATUS_QUERY_KEY } from '@/hooks/useCardStatus';
 import { createCard, submitCardConsents } from '@/lib/api';
 import { CardStatus } from '@/lib/types';
 import { withRefreshToken } from '@/lib/utils';
+import { useCardWelcomePopupStore } from '@/store/useCardWelcomePopupStore';
 import { useCountryStore } from '@/store/useCountryStore';
 
 type ConsentKey =
@@ -55,6 +56,9 @@ export default function CardReady() {
   const [consents, setConsents] = useState<ConsentState>(initialConsents);
 
   const countryCode = useCountryStore(state => state.countryInfo?.countryCode);
+  const setShouldShowWelcomePopup = useCardWelcomePopupStore(
+    state => state.setShouldShowWelcomePopup,
+  );
   const isUS = countryCode?.toUpperCase() === 'US';
   const cardTermsUrl = isUS ? US_CARD_TERMS_URL : INTL_CARD_TERMS_URL;
 
@@ -104,6 +108,7 @@ export default function CardReady() {
       queryClient.invalidateQueries({ queryKey: [CARD_STATUS_QUERY_KEY] });
 
       if (card.status !== CardStatus.PENDING) {
+        setShouldShowWelcomePopup(true);
         router.replace(path.CARD_DETAILS);
       } else {
         Toast.show({

--- a/components/Card/CardWelcomePopup.tsx
+++ b/components/Card/CardWelcomePopup.tsx
@@ -1,0 +1,54 @@
+import { View } from 'react-native';
+import { Image } from 'expo-image';
+
+import { Button } from '@/components/ui/button';
+import { Dialog, DialogCloseButton, DialogContent } from '@/components/ui/dialog';
+import { Text } from '@/components/ui/text';
+import { getAsset } from '@/lib/assets';
+
+interface CardWelcomePopupProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+const CardWelcomePopup = ({ isOpen, onClose }: CardWelcomePopupProps) => {
+  return (
+    <Dialog open={isOpen} onOpenChange={open => !open && onClose()}>
+      <DialogContent
+        showCloseButton={false}
+        className="w-[90vw] max-w-[480px] overflow-hidden border-0 border-none bg-[#1C1C1E] p-0"
+      >
+        <View className="relative">
+          <View className="h-64 w-full items-center justify-center bg-[#7CE672]">
+            <Image
+              source={getAsset('images/card_details.png')}
+              style={{ width: 160, height: 220 }}
+              contentFit="contain"
+            />
+          </View>
+
+          <DialogCloseButton className="absolute left-4 top-4 z-10 bg-black/40" />
+
+          <View className="px-6 pt-6">
+            <Text className="mb-4 text-2xl font-semibold text-white">
+              Welcome to the solid card
+            </Text>
+            <Text className="text-base font-medium text-white/70">
+              Your account is verified and your virtual Solid card is officially live. You can now
+              view your card details, add it to your digital wallet, and start spending online
+              instantly while your physical card is on its way.
+            </Text>
+          </View>
+
+          <View className="flex-row items-center justify-end px-6 pb-6 pt-6">
+            <Button onPress={onClose} variant="brand" className="h-10 rounded-[12px] px-6">
+              <Text className="font-bold text-black">Continue</Text>
+            </Button>
+          </View>
+        </View>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default CardWelcomePopup;

--- a/store/useCardWelcomePopupStore.ts
+++ b/store/useCardWelcomePopupStore.ts
@@ -1,0 +1,24 @@
+import { create } from 'zustand';
+import { createJSONStorage, persist } from 'zustand/middleware';
+
+import mmkvStorage from '@/lib/mmvkStorage';
+
+interface CardWelcomePopupState {
+  shouldShowWelcomePopup: boolean;
+  setShouldShowWelcomePopup: (value: boolean) => void;
+}
+
+const CARD_WELCOME_POPUP_STORAGE_KEY = 'card-welcome-popup-storage';
+
+export const useCardWelcomePopupStore = create<CardWelcomePopupState>()(
+  persist(
+    set => ({
+      shouldShowWelcomePopup: false,
+      setShouldShowWelcomePopup: (value: boolean) => set({ shouldShowWelcomePopup: value }),
+    }),
+    {
+      name: CARD_WELCOME_POPUP_STORAGE_KEY,
+      storage: createJSONStorage(() => mmkvStorage(CARD_WELCOME_POPUP_STORAGE_KEY)),
+    },
+  ),
+);


### PR DESCRIPTION
## Summary
This PR adds a welcome popup that displays when a user's card is successfully activated and ready to use. The popup provides information about the card's status and next steps.

## Key Changes
- **New Component**: Created `CardWelcomePopup` component that displays a welcome message with card imagery when a card becomes active
- **New Store**: Implemented `useCardWelcomePopupStore` using Zustand with persistence to track whether the welcome popup should be displayed
- **Card Details Integration**: Integrated the welcome popup into the card details page, displaying it when the store state indicates it should be shown
- **Card Ready Flow**: Updated the card activation flow in `ready.tsx` to trigger the welcome popup when card creation is successful and the card status is not pending

## Implementation Details
- The welcome popup uses a dialog component with a green header section displaying a card image
- The popup state is persisted to local storage using MMKV, preventing it from showing repeatedly
- The popup is triggered automatically after successful card activation in the `CardReady` screen
- Users can dismiss the popup by clicking the "Continue" button or the close button
- The popup is conditionally rendered on both the loading and loaded states of the card details page

https://claude.ai/code/session_01H8Us7xftKEEa5Abdrv2QFe