### PR TITLE
Wire React Query to native app lifecycle and connectivity

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,7 +1,7 @@
 import '@/global.css';
 
 import { useCallback, useEffect, useState } from 'react';
-import { Appearance, Platform } from 'react-native';
+import { Appearance, AppState, Platform } from 'react-native';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 import Toast from 'react-native-toast-message';
@@ -23,9 +23,15 @@ import {
   useFonts,
 } from '@expo-google-fonts/mona-sans';
 import { BottomSheetModalProvider } from '@gorhom/bottom-sheet';
+import NetInfo from '@react-native-community/netinfo';
 import { PortalHost } from '@rn-primitives/portal';
 import * as Sentry from '@sentry/react-native';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import {
+  focusManager,
+  onlineManager,
+  QueryClient,
+  QueryClientProvider,
+} from '@tanstack/react-query';
 import { injectSpeedInsights } from '@vercel/speed-insights';
 import { WagmiProvider } from 'wagmi';
 
@@ -151,6 +157,27 @@ function WhatsNewWrapper() {
   if (!whatsNew) return null;
 
   return <LazyWhatsNewModal whatsNew={whatsNew} isOpen={isVisible} onClose={closeWhatsNew} />;
+}
+
+// On native, React Query's focus and online managers have no default wiring:
+// `refetchOnWindowFocus` listens to `visibilitychange` (web-only) and
+// `refetchOnReconnect` has no transport to detect connectivity. Without this
+// bridge, a query with `refetchOnWindowFocus: true` (e.g. tokenBalances)
+// never fires when the app returns from background, and queries don't recover
+// after a network drop. Wire AppState → focusManager and NetInfo → onlineManager.
+if (Platform.OS !== 'web') {
+  focusManager.setEventListener(handleFocus => {
+    const subscription = AppState.addEventListener('change', status => {
+      handleFocus(status === 'active');
+    });
+    return () => subscription.remove();
+  });
+
+  onlineManager.setEventListener(setOnline => {
+    return NetInfo.addEventListener(state => {
+      setOnline(!!state.isConnected);
+    });
+  });
 }
 
 export const queryClient = new QueryClient({

--- a/hooks/useBalances.ts
+++ b/hooks/useBalances.ts
@@ -1,3 +1,4 @@
+import * as Sentry from '@sentry/react-native';
 import { useQuery } from '@tanstack/react-query';
 import { formatUnits, parseUnits, zeroAddress } from 'viem';
 import { getBalance, readContract } from 'viem/actions';
@@ -12,6 +13,12 @@ import { isSoFUSEToken, isSoUSDToken, isWalletCardExcludedToken } from '@/lib/ut
 import { publicClient } from '@/lib/wagmi';
 
 import useUser from './useUser';
+
+// Throttle for the Arbitrum diagnostic Sentry message — emit at most once
+// per minute per session so we don't flood Sentry from the 5s poll cadence.
+// TODO: remove together with the captureMessage call after diagnosis.
+let lastArbitrumDiagnosticAt = 0;
+const ARBITRUM_DIAGNOSTIC_THROTTLE_MS = 60_000;
 
 // Blockscout response structure for both Ethereum and Fuse
 export interface BlockscoutTokenBalance {
@@ -519,6 +526,52 @@ const fetchTokenBalances = async (safeAddress: string) => {
   const polygonTokensFinal = allTokens.filter(t => t.chainId === POLYGON_CHAIN_ID);
   const baseTokensFinal = allTokens.filter(t => t.chainId === BASE_CHAIN_ID);
   const arbitrumTokensFinal = allTokens.filter(t => t.chainId === ARBITRUM_CHAIN_ID);
+
+  // TODO: remove after diagnosing why Arbitrum USDC isn't visible on native.
+  // Throttled to 1/min per session; always emitted on Arbitrum fetch rejection.
+  try {
+    const arbRejected = arbitrumResponse.status === PromiseStatus.REJECTED;
+    if (
+      arbRejected ||
+      Date.now() - lastArbitrumDiagnosticAt > ARBITRUM_DIAGNOSTIC_THROTTLE_MS
+    ) {
+      lastArbitrumDiagnosticAt = Date.now();
+      Sentry.captureMessage('balances.diagnostic.arbitrum', {
+        level: 'info',
+        tags: { type: 'balances_diagnostic', chain: 'arbitrum' },
+        extra: {
+          safeAddress,
+          arbitrumStatus: arbitrumResponse.status,
+          arbitrumRawCount:
+            arbitrumResponse.status === PromiseStatus.FULFILLED
+              ? arbitrumResponse.value.length
+              : 0,
+          arbitrumRawSymbols:
+            arbitrumResponse.status === PromiseStatus.FULFILLED
+              ? arbitrumResponse.value.map(t => t.token.symbol)
+              : [],
+          arbitrumRawAddresses:
+            arbitrumResponse.status === PromiseStatus.FULFILLED
+              ? arbitrumResponse.value.map(t =>
+                  (t.token.address || t.token.address_hash || '').toLowerCase(),
+                )
+              : [],
+          arbitrumFilteredCount: arbitrumTokensFinal.length,
+          arbitrumFilteredSymbols: arbitrumTokensFinal.map(t => t.contractTickerSymbol),
+          arbitrumFilteredAddresses: arbitrumTokensFinal.map(t =>
+            (t.contractAddress || '').toLowerCase(),
+          ),
+          tokenListLen: tokenListData.length,
+          tokenListArbitrumCount: tokenListData.filter(
+            t => t.chainId === ARBITRUM_CHAIN_ID,
+          ).length,
+          arbitrumError: arbRejected ? String(arbitrumResponse.reason) : undefined,
+        },
+      });
+    }
+  } catch {
+    // Diagnostic must never break the balance fetch.
+  }
 
   return {
     ...totals,


### PR DESCRIPTION
## Summary
This PR adds proper lifecycle and connectivity management for React Query on native platforms, and includes diagnostic logging for Arbitrum balance fetching issues.

## Key Changes

- **React Query Native Integration**: Wire `AppState` to React Query's `focusManager` and `NetInfo` to `onlineManager` on non-web platforms. This enables:
  - `refetchOnWindowFocus` to work when the app returns from background
  - `refetchOnReconnect` to trigger after network connectivity is restored
  - Previously these features were non-functional on native due to missing event listeners

- **Arbitrum Balance Diagnostics**: Add throttled Sentry logging to diagnose why Arbitrum USDC isn't visible:
  - Captures raw token counts/symbols/addresses from Blockscout
  - Captures filtered token counts/symbols/addresses after processing
  - Includes token list metadata for comparison
  - Throttled to 1 message per minute per session to avoid flooding Sentry
  - Always emitted when Arbitrum fetch fails
  - Wrapped in try-catch to prevent diagnostic code from breaking balance fetches

## Implementation Details

- Added `NetInfo` listener setup in `app/_layout.tsx` alongside existing `AppState` listener
- Diagnostic code is marked with TODO comments for removal after investigation
- The throttling mechanism uses a module-level timestamp to track last diagnostic emission
- All diagnostic data is included in Sentry's `extra` field with descriptive keys for easy analysis

https://claude.ai/code/session_01VC5iFVWihYjNd2LPVSGprz