### PR TITLE
chore(balances): attribute source and on-chain balance in Base diagno…

### DIFF
--- a/hooks/useBalances.ts
+++ b/hooks/useBalances.ts
@@ -7,7 +7,10 @@ import { base, fuse, mainnet } from 'viem/chains';
 import { NATIVE_COINGECKO_TOKENS, NATIVE_TOKENS } from '@/constants/tokens';
 import { fetchCoinSimplePrice, fetchTokenList, fetchTokenPriceUsd } from '@/lib/api';
 import { ADDRESSES } from '@/lib/config';
-import { fetchTokenBalancesWithFallback } from '@/lib/data-source';
+import {
+  fetchTokenBalancesWithFallback,
+  getLastTokenBalancesTrace,
+} from '@/lib/data-source';
 import { PromiseStatus, SwapTokenResponse, TokenBalance, TokenType } from '@/lib/types';
 import { isSoFUSEToken, isSoUSDToken, isWalletCardExcludedToken } from '@/lib/utils';
 import { publicClient } from '@/lib/wagmi';
@@ -583,6 +586,35 @@ const fetchTokenBalances = async (safeAddress: string) => {
     const baseRejected = baseResponse.status === PromiseStatus.REJECTED;
     if (baseRejected || Date.now() - lastBaseDiagnosticAt > BASE_DIAGNOSTIC_THROTTLE_MS) {
       lastBaseDiagnosticAt = Date.now();
+
+      const baseTrace = getLastTokenBalancesTrace(BASE_CHAIN_ID);
+
+      // Ground-truth: read Base USDC balance directly on-chain so we can
+      // tell the difference between "user has no USDC" and "Alchemy/Blockscout
+      // hide it for some reason". One extra eth_call per minute is acceptable
+      // for the diagnostic window.
+      let baseUsdcOnChainBalance: string | null = null;
+      let baseUsdcOnChainError: string | undefined;
+      try {
+        const balance = await readContract(publicClient(base.id), {
+          address: ADDRESSES.base.usdc,
+          abi: [
+            {
+              inputs: [{ name: 'account', type: 'address' }],
+              name: 'balanceOf',
+              outputs: [{ name: '', type: 'uint256' }],
+              stateMutability: 'view',
+              type: 'function',
+            },
+          ] as const,
+          functionName: 'balanceOf',
+          args: [safeAddress as `0x${string}`],
+        });
+        baseUsdcOnChainBalance = balance.toString();
+      } catch (e) {
+        baseUsdcOnChainError = e instanceof Error ? e.message : String(e);
+      }
+
       Sentry.captureMessage('balances.diagnostic.base', {
         level: 'info',
         tags: { type: 'balances_diagnostic', chain: 'base' },
@@ -618,6 +650,15 @@ const fetchTokenBalances = async (safeAddress: string) => {
             .filter(t => t.chainId === BASE_CHAIN_ID)
             .map(t => t.address?.toLowerCase()),
           baseError: baseRejected ? String(baseResponse.reason) : undefined,
+          // Which provider actually answered, and why Alchemy was bypassed if it was.
+          baseFetchSource: baseTrace?.source ?? 'unknown',
+          baseAlchemyError: baseTrace?.alchemyError,
+          baseBlockscoutError: baseTrace?.blockscoutError,
+          baseTraceRawCount: baseTrace?.rawCount,
+          // On-chain ground truth for Base USDC at the same safeAddress.
+          baseUsdcOnChainBalance,
+          baseUsdcOnChainError,
+          baseUsdcConfiguredAddress: ADDRESSES.base.usdc.toLowerCase(),
         },
       });
     }

--- a/lib/data-source.ts
+++ b/lib/data-source.ts
@@ -13,6 +13,29 @@ import type { BlockscoutTokenBalance } from '@/hooks/useBalances';
  * Fuse (122) is always Blockscout (not supported by Alchemy).
  */
 
+/**
+ * Source attribution for the most recent token-balances fetch per chain.
+ * Read by the Sentry diagnostic in useBalances to attribute empty results
+ * to either Alchemy or the Blockscout fallback. Updated by
+ * `fetchTokenBalancesWithFallback` on every call.
+ * TODO: remove together with the balances diagnostics after fix.
+ */
+export type TokenBalancesFetchSource = 'alchemy' | 'blockscout' | 'none';
+
+export interface TokenBalancesFetchTrace {
+  source: TokenBalancesFetchSource;
+  alchemyError?: string;
+  blockscoutError?: string;
+  rawCount: number;
+  timestamp: number;
+}
+
+const lastTokenBalancesTrace = new Map<number, TokenBalancesFetchTrace>();
+
+export const getLastTokenBalancesTrace = (
+  chainId: number,
+): TokenBalancesFetchTrace | undefined => lastTokenBalancesTrace.get(chainId);
+
 const BLOCKSCOUT_URLS: Record<number, string> = {
   [mainnet.id]: 'https://eth.blockscout.com',
   [base.id]: 'https://base.blockscout.com',
@@ -65,17 +88,56 @@ export const fetchTokenBalancesWithFallback = async (
   chainId: number,
   address: string,
 ): Promise<BlockscoutTokenBalance[]> => {
+  const recordTrace = (trace: TokenBalancesFetchTrace) => {
+    lastTokenBalancesTrace.set(chainId, trace);
+  };
+
   if (!isAlchemyChain(chainId)) {
-    return fetchBlockscoutTokenBalances(chainId, address);
+    try {
+      const result = await fetchBlockscoutTokenBalances(chainId, address);
+      recordTrace({ source: 'blockscout', rawCount: result.length, timestamp: Date.now() });
+      return result;
+    } catch (err) {
+      recordTrace({
+        source: 'none',
+        blockscoutError: err instanceof Error ? err.message : String(err),
+        rawCount: 0,
+        timestamp: Date.now(),
+      });
+      throw err;
+    }
   }
+
   try {
-    return await fetchAlchemyTokenBalances(chainId, address);
-  } catch (err) {
+    const result = await fetchAlchemyTokenBalances(chainId, address);
+    recordTrace({ source: 'alchemy', rawCount: result.length, timestamp: Date.now() });
+    return result;
+  } catch (alchemyErr) {
+    const alchemyMessage = alchemyErr instanceof Error ? alchemyErr.message : String(alchemyErr);
     console.warn(
       `[data-source] alchemy balances failed for chain ${chainId}, falling back to blockscout`,
-      err,
+      alchemyErr,
     );
-    return fetchBlockscoutTokenBalances(chainId, address);
+    try {
+      const result = await fetchBlockscoutTokenBalances(chainId, address);
+      recordTrace({
+        source: 'blockscout',
+        alchemyError: alchemyMessage,
+        rawCount: result.length,
+        timestamp: Date.now(),
+      });
+      return result;
+    } catch (blockscoutErr) {
+      recordTrace({
+        source: 'none',
+        alchemyError: alchemyMessage,
+        blockscoutError:
+          blockscoutErr instanceof Error ? blockscoutErr.message : String(blockscoutErr),
+        rawCount: 0,
+        timestamp: Date.now(),
+      });
+      throw blockscoutErr;
+    }
   }
 };
 


### PR DESCRIPTION
…stic

Previous Sentry payload couldn't distinguish 'Alchemy returned empty' from 'Alchemy threw and Blockscout fallback returned empty'. Track the attempted source plus any provider error in a small module-level map in data-source.ts and surface it in the Base diagnostic, alongside a direct on-chain balanceOf call for ADDRESSES.base.usdc so we have ground truth to compare against.