### PR TITLE
fix(balances): isolate Alchemy axios from global JWT interceptor and drop diagnostics

### DIFF
--- a/hooks/useBalances.ts
+++ b/hooks/useBalances.ts
@@ -1,4 +1,3 @@
-import * as Sentry from '@sentry/react-native';
 import { useQuery } from '@tanstack/react-query';
 import { formatUnits, parseUnits, zeroAddress } from 'viem';
 import { getBalance, readContract } from 'viem/actions';
@@ -13,12 +12,6 @@ import { isSoFUSEToken, isSoUSDToken, isWalletCardExcludedToken } from '@/lib/ut
 import { publicClient } from '@/lib/wagmi';
 
 import useUser from './useUser';
-
-// Throttle for the Arbitrum diagnostic Sentry message — emit at most once
-// per minute per session so we don't flood Sentry from the 5s poll cadence.
-// TODO: remove together with the captureMessage call after diagnosis.
-let lastArbitrumDiagnosticAt = 0;
-const ARBITRUM_DIAGNOSTIC_THROTTLE_MS = 60_000;
 
 // Blockscout response structure for both Ethereum and Fuse
 export interface BlockscoutTokenBalance {
@@ -526,52 +519,6 @@ const fetchTokenBalances = async (safeAddress: string) => {
   const polygonTokensFinal = allTokens.filter(t => t.chainId === POLYGON_CHAIN_ID);
   const baseTokensFinal = allTokens.filter(t => t.chainId === BASE_CHAIN_ID);
   const arbitrumTokensFinal = allTokens.filter(t => t.chainId === ARBITRUM_CHAIN_ID);
-
-  // TODO: remove after diagnosing why Arbitrum USDC isn't visible on native.
-  // Throttled to 1/min per session; always emitted on Arbitrum fetch rejection.
-  try {
-    const arbRejected = arbitrumResponse.status === PromiseStatus.REJECTED;
-    if (
-      arbRejected ||
-      Date.now() - lastArbitrumDiagnosticAt > ARBITRUM_DIAGNOSTIC_THROTTLE_MS
-    ) {
-      lastArbitrumDiagnosticAt = Date.now();
-      Sentry.captureMessage('balances.diagnostic.arbitrum', {
-        level: 'info',
-        tags: { type: 'balances_diagnostic', chain: 'arbitrum' },
-        extra: {
-          safeAddress,
-          arbitrumStatus: arbitrumResponse.status,
-          arbitrumRawCount:
-            arbitrumResponse.status === PromiseStatus.FULFILLED
-              ? arbitrumResponse.value.length
-              : 0,
-          arbitrumRawSymbols:
-            arbitrumResponse.status === PromiseStatus.FULFILLED
-              ? arbitrumResponse.value.map(t => t.token.symbol)
-              : [],
-          arbitrumRawAddresses:
-            arbitrumResponse.status === PromiseStatus.FULFILLED
-              ? arbitrumResponse.value.map(t =>
-                  (t.token.address || t.token.address_hash || '').toLowerCase(),
-                )
-              : [],
-          arbitrumFilteredCount: arbitrumTokensFinal.length,
-          arbitrumFilteredSymbols: arbitrumTokensFinal.map(t => t.contractTickerSymbol),
-          arbitrumFilteredAddresses: arbitrumTokensFinal.map(t =>
-            (t.contractAddress || '').toLowerCase(),
-          ),
-          tokenListLen: tokenListData.length,
-          tokenListArbitrumCount: tokenListData.filter(
-            t => t.chainId === ARBITRUM_CHAIN_ID,
-          ).length,
-          arbitrumError: arbRejected ? String(arbitrumResponse.reason) : undefined,
-        },
-      });
-    }
-  } catch {
-    // Diagnostic must never break the balance fetch.
-  }
 
   return {
     ...totals,

--- a/lib/alchemy.ts
+++ b/lib/alchemy.ts
@@ -5,6 +5,11 @@ import { BlockscoutTransaction, BlockscoutTransactions, TokenType } from '@/lib/
 
 import type { BlockscoutTokenBalance } from '@/hooks/useBalances';
 
+// Dedicated axios instance: the global axios in lib/api.ts has a request
+// interceptor that injects the Solid backend Bearer JWT on iOS/Android, which
+// Alchemy rejects with 401. Using axios.create() bypasses that interceptor.
+const alchemyAxios = axios.create();
+
 /**
  * Thin Alchemy JSON-RPC client plus mappers that shape responses into the
  * existing `BlockscoutTokenBalance` / `BlockscoutTransactions` types so
@@ -60,7 +65,7 @@ interface AlchemyAssetTransfersResult {
 const jsonRpc = async <T>(chainId: number, method: string, params: unknown[]): Promise<T> => {
   const url = ALCHEMY_CHAIN_URLS[chainId];
   if (!url) throw new Error(`No Alchemy URL configured for chain ${chainId}`);
-  const response = await axios.post<JsonRpcResponse<T>>(
+  const response = await alchemyAxios.post<JsonRpcResponse<T>>(
     url,
     { jsonrpc: '2.0', id: 1, method, params },
     { timeout: ALCHEMY_REQUEST_TIMEOUT_MS },
@@ -104,7 +109,7 @@ const alchemyGetTokenMetadataBatch = async (
   }));
 
   try {
-    const response = await axios.post<JsonRpcResponse<AlchemyTokenMetadata>[]>(url, body, {
+    const response = await alchemyAxios.post<JsonRpcResponse<AlchemyTokenMetadata>[]>(url, body, {
       timeout: ALCHEMY_REQUEST_TIMEOUT_MS,
     });
     const data = Array.isArray(response.data) ? response.data : [];


### PR DESCRIPTION
## Summary

Brings the mobile wallet fix (already on `master` via #2074) to `qa`, and removes the Arbitrum diagnostic that was added in #2069.

- **Root cause:** the global axios request interceptor in `lib/api.ts` injects the Solid backend `Bearer <JWT>` on iOS/Android. `lib/alchemy.ts` was using the same default `axios` import, so every Alchemy JSON-RPC call on mobile carried a Solid JWT and Alchemy answered 401. Web (`Platform.OS === 'web'`) skipped the branch, so the identical env key worked there — which is exactly the "same env, only mobile fails" pattern Sentry showed.
- **Fix:** route Alchemy through a dedicated `axios.create()` instance. Interceptors registered on the default `axios` don't apply to instance clients.
- **Cleanup:** remove the `balances.diagnostic.arbitrum` `Sentry.captureMessage` and its throttle state from `hooks/useBalances.ts` now that mobile is healthy.

## Test plan

- [ ] Native build (iOS + Android): wallet shows Base / Arbitrum / Ethereum balances on first load.
- [ ] Web build: regression check — balances still load.
- [ ] Sentry: confirm `balances.diagnostic.arbitrum` events stop after this ships.
- [ ] No remaining references to the removed throttle constants (`lastArbitrumDiagnosticAt`, `ARBITRUM_DIAGNOSTIC_THROTTLE_MS`) — grep is clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VC5iFVWihYjNd2LPVSGprz)_