### PR TITLE
fix(activity): typed borrow/bridge card-deposit activities (master backport)

### DIFF
--- a/components/Card/CardDepositInternalForm.tsx
+++ b/components/Card/CardDepositInternalForm.tsx
@@ -926,9 +926,9 @@ export default function CardDepositInternalForm() {
 
         // Create activity event (stays PENDING until Bridge processes it)
         const clientTxId = await createActivity({
-          type: TransactionType.CARD_TRANSACTION,
-          title: `Card Deposit`,
-          shortTitle: `Card Deposit`,
+          type: TransactionType.BORROW_AND_DEPOSIT_TO_CARD,
+          title: `Borrow and deposit to Card`,
+          shortTitle: `Borrow and deposit to Card`,
           amount: data.amount,
           symbol: sourceSymbol,
           chainId: fuse.id,
@@ -936,7 +936,7 @@ export default function CardDepositInternalForm() {
           toAddress: borrowFundingAddress,
           status: TransactionStatus.PENDING,
           metadata: {
-            description: `Deposit ${data.amount} ${sourceSymbol} to card`,
+            description: `Borrow and deposit ${data.amount} ${sourceSymbol} to card`,
             processingStatus: 'bridging',
             tokenAddress: sourceTokenAddress,
           },
@@ -1053,9 +1053,9 @@ export default function CardDepositInternalForm() {
 
         // Create activity event (stays PENDING until Bridge processes it)
         const clientTxId = await createActivity({
-          type: TransactionType.CARD_TRANSACTION,
-          title: `Card Deposit`,
-          shortTitle: `Card Deposit`,
+          type: TransactionType.BRIDGE_DEPOSIT,
+          title: `Deposit ${sourceSymbol} to Card`,
+          shortTitle: `Deposit ${sourceSymbol}`,
           amount: data.amount,
           symbol: sourceSymbol,
           chainId: fuse.id,


### PR DESCRIPTION
## Summary

Cherry-picks `d2d2bb6b` from qa (originally merged via #2071) so master receives the same fix.

The borrow handler and the SAVINGS/bridge fallthrough in `CardDepositInternalForm.tsx` were both creating generic `CARD_TRANSACTION` "Card Deposit" rows. The backend's card-balance webhook (`findPendingCardDepositActivity`) only matches `BORROW_AND_DEPOSIT_TO_CARD` / `BRIDGE_DEPOSIT` to flip pending rows to SUCCESS, so these rows stayed pending forever and were hidden by the 24h stuck-tx filter in `ActivityTransactions.tsx`. Writing the correct type from the form lets the existing webhook lookup match, so the activity reaches SUCCESS and stays visible.

Pair: solid-backend backport adds `CARD_TRANSACTION` to the webhook lookup as a safety net for legacy stragglers.

## Test plan

- [ ] Trigger a "Borrow against Savings → Deposit to Card" flow and confirm the new activity row appears as `borrow_and_deposit_to_card` in Mongo
- [ ] Confirm the card-balance webhook flips it from `pending` → `success`
- [ ] Confirm the activity is visible in the Activity → Wallet tab after status flips

https://claude.ai/code/session_01DQgmuLpKSnWQTDRogWXHZM

---
_Generated by [Claude Code](https://claude.ai/code/session_01DQgmuLpKSnWQTDRogWXHZM)_