### PR TITLE
fix(activity): send hash and url to backend on update so they actuall…

### DIFF
--- a/hooks/useActivityActions.ts
+++ b/hooks/useActivityActions.ts
@@ -155,7 +155,8 @@ export function useActivityActions() {
       withRefreshToken(() =>
         updateActivityEvent(clientTxId, {
           status: backendStatus,
-          txHash: updates.hash,
+          hash: updates.hash,
+          url: updates.url,
           userOpHash: updates.userOpHash,
           metadata: updates.metadata,
         }),

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1347,7 +1347,8 @@ export interface ActivityEvents {
 
 export interface UpdateActivityEvent {
   status?: TransactionStatus;
-  txHash?: string;
+  hash?: string;
+  url?: string;
   userOpHash?: string;
   metadata?: Record<string, any>;
 }


### PR DESCRIPTION
…y persist

updateActivityEvent was sending `txHash` (not a backend DTO field — silently dropped by mongoose's strict schema) and omitting `url` entirely. The backend's UpdateActivityDto declares `hash` and `url`; the schema persists both. So neither field ever made it into the DB, even though local Zustand held the values.

Symptom: after a hard refresh / cache clear, the activity-detail page lost its LayerZero explorer-row link, because the backend's GET /activity returned an activity with no `hash` or `url` and the page no longer had the local fallback.

Side effect: useCardDepositPoller, which keys off activity.hash, can now actually pick up pending card-deposit rows as a fallback when the webhook is delayed (separate but related fix to broaden its activity types).

https://claude.ai/code/session_01DQgmuLpKSnWQTDRogWXHZM