### PR TITLE
fix(activity): send hash and url to backend on update (master backport)

### DIFF
--- a/hooks/useActivityActions.ts
+++ b/hooks/useActivityActions.ts
@@ -155,7 +155,8 @@ export function useActivityActions() {
       withRefreshToken(() =>
         updateActivityEvent(clientTxId, {
           status: backendStatus,
-          txHash: updates.hash,
+          hash: updates.hash,
+          url: updates.url,
           userOpHash: updates.userOpHash,
           metadata: updates.metadata,
         }),

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1345,7 +1345,8 @@ export interface ActivityEvents {
 
 export interface UpdateActivityEvent {
   status?: TransactionStatus;
-  txHash?: string;
+  hash?: string;
+  url?: string;
   userOpHash?: string;
   metadata?: Record<string, any>;
 }


### PR DESCRIPTION
## Summary

Cherry-picks `838f1be5` from qa (originally merged via #2080) so master receives the same fix.

`updateActivityEvent` was sending `txHash` (not a backend DTO field — silently dropped by mongoose's strict schema) and omitting `url` entirely. The backend's `UpdateActivityDto` declares `hash` and `url`; the schema persists both. So neither field ever made it into the DB, even though local Zustand held the values.

**Symptom:** after a hard refresh / cache clear, the activity-detail page lost its LayerZero explorer-row link, because the backend's `GET /activity` returned an activity with no `hash` or `url` and the page no longer had the local fallback.

**Side effect:** `useCardDepositPoller`, which keys off `activity.hash`, can now actually pick up pending card-deposit rows as a fallback when the webhook is delayed.

## Test plan

- [ ] Trigger an activity update (borrow → deposit to card, or any flow calling `updateActivity` with a hash)
- [ ] Hard-refresh / clear cache → activity detail page still shows the explorer row
- [ ] Verify `db.activities.findOne({ clientTxId: ... })` has `hash` and `url` populated server-side

https://claude.ai/code/session_01DQgmuLpKSnWQTDRogWXHZM

---
_Generated by [Claude Code](https://claude.ai/code/session_01DQgmuLpKSnWQTDRogWXHZM)_