### PR TITLE
chore(ui): polish tab icons, page headers, and empty state copy

### DIFF
--- a/app/(protected)/(tabs)/_layout.tsx
+++ b/app/(protected)/(tabs)/_layout.tsx
@@ -57,7 +57,9 @@ export default function TabLayout() {
           title: 'Home',
           headerShown: false,
 
-          tabBarIcon: ({ focused }) => <LottieTabIcon source={homeAnimation} focused={focused} />,
+          tabBarIcon: ({ focused, size }) => (
+            <LottieTabIcon source={homeAnimation} focused={focused} size={size} />
+          ),
           href: path.HOME,
         }}
       />
@@ -69,8 +71,8 @@ export default function TabLayout() {
           title: 'Savings',
           headerShown: false,
 
-          tabBarIcon: ({ focused }) => (
-            <LottieTabIcon source={lightningAnimation} focused={focused} />
+          tabBarIcon: ({ focused, size }) => (
+            <LottieTabIcon source={lightningAnimation} focused={focused} size={size} />
           ),
           href: path.SAVINGS,
         }}
@@ -92,7 +94,9 @@ export default function TabLayout() {
           title: 'Card',
           headerShown: false,
 
-          tabBarIcon: ({ focused }) => <LottieTabIcon source={cardAnimation} focused={focused} />,
+          tabBarIcon: ({ focused, size }) => (
+            <LottieTabIcon source={cardAnimation} focused={focused} size={size} />
+          ),
           href: path.CARD,
         }}
       />
@@ -113,7 +117,9 @@ export default function TabLayout() {
           title: 'Activity',
           headerShown: false,
 
-          tabBarIcon: ({ focused }) => <LottieTabIcon source={bellAnimation} focused={focused} />,
+          tabBarIcon: ({ focused, size }) => (
+            <LottieTabIcon source={bellAnimation} focused={focused} size={size} />
+          ),
           href: path.ACTIVITY,
         }}
       />

--- a/app/(protected)/(tabs)/activity/index.tsx
+++ b/app/(protected)/(tabs)/activity/index.tsx
@@ -20,7 +20,7 @@ export default function Activity() {
   const isWeb = Platform.OS === 'web';
   const userHasCard = hasCard(cardStatus);
 
-  const stickyHeader = (
+  const pageHeader = (
     <View className="mx-auto w-full max-w-7xl px-4 pb-[10px] pt-6 md:pt-12">
       <View className="flex-row items-center justify-between">
         <Text className="text-3xl font-semibold">Activity</Text>
@@ -38,7 +38,8 @@ export default function Activity() {
   );
 
   return (
-    <PageLayout isLoading={isCardStatusLoading} stickyHeader={stickyHeader}>
+    <PageLayout isLoading={isCardStatusLoading}>
+      {pageHeader}
       <View
         className={cn('mx-auto w-full max-w-7xl px-4 pb-8 md:pb-12', {
           'flex-1': !isWeb,

--- a/app/(protected)/(tabs)/card/details.tsx
+++ b/app/(protected)/(tabs)/card/details.tsx
@@ -140,7 +140,7 @@ export default function CardDetails() {
     }).start();
   }, [flipAnimation]);
 
-  const stickyHeader = isScreenMedium ? (
+  const pageHeader = isScreenMedium ? (
     <View className="mx-auto w-full max-w-7xl px-4 pt-12">
       <DesktopHeader
         isCardFrozen={isCardFrozen}
@@ -163,7 +163,8 @@ export default function CardDetails() {
   // Desktop layout
   if (isScreenMedium) {
     return (
-      <PageLayout desktopOnly isLoading={isLoading} stickyHeader={stickyHeader}>
+      <PageLayout desktopOnly isLoading={isLoading}>
+        {pageHeader}
         <View className="mx-auto w-full max-w-7xl px-4 pb-12">
           {/* Row 1: Spending Balance Card + Card Image */}
           <View className="mt-12 flex-row gap-6">
@@ -218,7 +219,8 @@ export default function CardDetails() {
 
   // Mobile layout
   return (
-    <PageLayout isLoading={isLoading} stickyHeader={stickyHeader}>
+    <PageLayout isLoading={isLoading}>
+      {pageHeader}
       <View className="mx-auto w-full max-w-lg px-4">
         <View className="flex-1">
           <BalanceDisplay amount={availableAmount} />
@@ -313,7 +315,7 @@ function DesktopHeader({
 
   return (
     <View className="flex-row justify-between">
-      <Text className="text-5xl font-semibold">Card</Text>
+      <Text className="text-3xl font-semibold">Card</Text>
       <View className="flex-row items-center gap-2">
         <Button
           variant="secondary"

--- a/app/(protected)/(tabs)/points/index.tsx
+++ b/app/(protected)/(tabs)/points/index.tsx
@@ -31,7 +31,7 @@ export default function Points() {
 
   const depositPoints = depositRewards?.totalPoints || 0;
 
-  const stickyHeader = (
+  const pageHeader = (
     <View className="mx-auto w-full max-w-7xl px-4 pb-[10px] pt-4 md:pb-9 md:pt-12">
       {isScreenMedium ? (
         <View className="flex-row items-center justify-between ">
@@ -44,7 +44,8 @@ export default function Points() {
   );
 
   return (
-    <PageLayout isLoading={isPointsLoading} stickyHeader={stickyHeader}>
+    <PageLayout isLoading={isPointsLoading}>
+      {pageHeader}
       <View className="mx-auto w-full max-w-7xl gap-6 px-4 pb-8 md:gap-9 md:pb-12">
         <LinearGradient
           colors={['rgba(255, 209, 81, 0.25)', 'rgba(255, 209, 81, 0.17)']}

--- a/app/(protected)/(tabs)/rewards/index.tsx
+++ b/app/(protected)/(tabs)/rewards/index.tsx
@@ -49,7 +49,7 @@ export default function Rewards() {
       <View className="mx-auto w-full max-w-7xl gap-6 px-4 pb-24 pt-6 md:gap-10 md:py-12">
         {isScreenMedium ? (
           <View className="flex-row items-center justify-between">
-            <Text className="text-5xl font-semibold">Rewards</Text>
+            <Text className="text-3xl font-semibold">Rewards</Text>
           </View>
         ) : (
           <Text className="text-3xl font-semibold">Rewards</Text>

--- a/app/(protected)/(tabs)/savings-old.tsx
+++ b/app/(protected)/(tabs)/savings-old.tsx
@@ -123,7 +123,7 @@ export default function SavingsOld() {
   const projectedEarnings =
     balance && vaultAPY ? balance * (exchangeRate ?? 1) * (vaultAPY / 100) : 0;
 
-  const stickyHeader = (
+  const pageHeader = (
     <View className="mx-auto w-full max-w-7xl px-4 pb-[40px] pt-6 md:pb-7 md:pt-12">
       {isScreenMedium ? (
         <View className="flex-row items-center justify-between">
@@ -145,7 +145,8 @@ export default function SavingsOld() {
   );
 
   return (
-    <PageLayout isLoading={isLoading} stickyHeader={stickyHeader}>
+    <PageLayout isLoading={isLoading}>
+      {pageHeader}
       <View className="mx-auto w-full max-w-7xl gap-10 px-4 pb-8 md:gap-7 md:pb-12">
         {isScreenMedium ? (
           <View className="flex-row gap-4">

--- a/components/CustomTabBar.tsx
+++ b/components/CustomTabBar.tsx
@@ -121,7 +121,7 @@ export function CustomTabBar({ state, descriptors, navigation }: BottomTabBarPro
         const icon = options.tabBarIcon?.({
           focused: isFocused,
           color: isFocused ? 'white' : 'rgba(255, 255, 255, 1)',
-          size: 24,
+          size: Platform.OS === 'web' ? 36 : 40,
         });
 
         return (

--- a/components/Home/DepositButton.tsx
+++ b/components/Home/DepositButton.tsx
@@ -11,7 +11,7 @@ const DepositButton = () => {
       <Button variant="brand" className="h-[3.375rem] rounded-xl pr-6 md:w-72">
         <View className="flex-row items-center gap-2">
           <Plus color="black" />
-          <Text className="text-base font-bold">Fund your Solid wallet</Text>
+          <Text className="text-base font-bold">Make your first deposit</Text>
         </View>
       </Button>
     );

--- a/components/Home/DepositImage.tsx
+++ b/components/Home/DepositImage.tsx
@@ -20,6 +20,7 @@ const DepositImage = () => {
         ...(!isScreenMedium && { marginLeft: 'auto', marginRight: 'auto' }),
         width: isScreenMedium ? 300 : 186,
         height: isScreenMedium ? 300 : 202,
+        marginTop: isScreenMedium ? -10 : 0,
       }}
       alt="Deposit illustration"
     />

--- a/components/Home/EmptyState.tsx
+++ b/components/Home/EmptyState.tsx
@@ -51,7 +51,7 @@ export default function HomeEmptyState() {
               <>
                 <View className="max-w-2xl flex-1 justify-between gap-6">
                   <View className="gap-3">
-                    <Text className="text-4.5xl font-semibold text-foreground">
+                    <Text className="text-4.5xl font-medium text-foreground">
                       Welcome to Solid
                     </Text>
                     <DepositDescription />
@@ -64,7 +64,7 @@ export default function HomeEmptyState() {
               <>
                 <DepositImage />
                 <View className="items-center gap-3">
-                  <Text className="text-2xl font-bold text-foreground">Welcome to Solid</Text>
+                  <Text className="text-2xl font-medium text-foreground">Welcome to Solid</Text>
                   <DepositDescription />
                 </View>
                 <DepositButton />
@@ -141,7 +141,7 @@ function SolidBenefitCard({
       <Image source={icon} style={{ width: 40, height: 40 }} contentFit="contain" />
       <Text
         className={cn(
-          'max-w-52 text-2xl font-semibold leading-[1.1] text-foreground md:max-w-64 md:text-3xl',
+          'max-w-52 text-2xl font-medium leading-[1.1] text-foreground md:max-w-64 md:text-3xl',
           classNames?.headline,
         )}
       >

--- a/components/LottieTabIcon.tsx
+++ b/components/LottieTabIcon.tsx
@@ -1,15 +1,71 @@
-import { useEffect, useRef } from 'react';
-import { Platform } from 'react-native';
+import { useEffect, useMemo, useRef } from 'react';
+import { View } from 'react-native';
 import LottieView, { type LottieViewProps } from 'lottie-react-native';
 
 interface LottieTabIconProps {
   source: LottieViewProps['source'];
   focused: boolean;
+  size?: number;
 }
 
-export function LottieTabIcon({ source, focused }: LottieTabIconProps) {
+const WHITE = [1, 1, 1, 1];
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function normalizeColorValue(value: unknown): unknown {
+  if (Array.isArray(value) && value.length >= 3 && value.every(item => typeof item === 'number')) {
+    return [WHITE[0], WHITE[1], WHITE[2], typeof value[3] === 'number' ? value[3] : WHITE[3]];
+  }
+
+  if (Array.isArray(value)) {
+    return value.map(item => {
+      if (!isObject(item)) return item;
+
+      return {
+        ...item,
+        s: normalizeColorValue(item.s),
+        e: normalizeColorValue(item.e),
+      };
+    });
+  }
+
+  return value;
+}
+
+function normalizeLottieColors(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(normalizeLottieColors);
+  }
+
+  if (!isObject(value)) {
+    return value;
+  }
+
+  const next: Record<string, unknown> = {};
+
+  for (const [key, child] of Object.entries(value)) {
+    next[key] = normalizeLottieColors(child);
+  }
+
+  if ((value.ty === 'st' || value.ty === 'fl') && isObject(next.c)) {
+    next.c = {
+      ...next.c,
+      k: normalizeColorValue(next.c.k),
+    };
+  }
+
+  return next;
+}
+
+export function LottieTabIcon({ source, focused, size = 24 }: LottieTabIconProps) {
   const lottieRef = useRef<LottieView>(null);
   const hasPlayedInitial = useRef(false);
+  const normalizedSource = useMemo(
+    () => normalizeLottieColors(source) as LottieTabIconProps['source'],
+    [source],
+  );
 
   useEffect(() => {
     if (focused) {
@@ -20,16 +76,16 @@ export function LottieTabIcon({ source, focused }: LottieTabIconProps) {
     }
   }, [focused]);
 
-  const size = Platform.OS === 'web' ? 36 : 40;
-
   return (
-    <LottieView
-      ref={lottieRef}
-      source={source}
-      autoPlay={focused}
-      loop={false}
-      style={{ width: size, height: size }}
-      resizeMode="contain"
-    />
+    <View style={{ width: size, height: size }}>
+      <LottieView
+        ref={lottieRef}
+        source={normalizedSource}
+        autoPlay={focused}
+        loop={false}
+        style={{ width: '100%', height: '100%' }}
+        resizeMode="contain"
+      />
+    </View>
   );
 }

--- a/components/Savings/EmptyState.tsx
+++ b/components/Savings/EmptyState.tsx
@@ -30,7 +30,7 @@ export default function SavingsEmptyState() {
         <View>
           {isScreenMedium ? (
             <View className="flex-row items-center justify-between">
-              <Text className="text-5xl font-semibold">Savings</Text>
+              <Text className="text-3xl font-semibold">Savings</Text>
               <View className="flex-row gap-2">
                 <DashboardHeaderButtons hideSend hideDeposit />
                 <DepositTrigger

--- a/package-lock.json
+++ b/package-lock.json
@@ -11181,17 +11181,6 @@
         }
       }
     },
-    "node_modules/@reown/appkit-controllers/node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
     "node_modules/@reown/appkit-pay": {
       "version": "1.7.8",
       "resolved": "https://registry.npmjs.org/@reown/appkit-pay/-/appkit-pay-1.7.8.tgz",
@@ -11815,17 +11804,6 @@
         }
       }
     },
-    "node_modules/@reown/appkit-utils/node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
     "node_modules/@reown/appkit-wallet": {
       "version": "1.7.8",
       "resolved": "https://registry.npmjs.org/@reown/appkit-wallet/-/appkit-wallet-1.7.8.tgz",
@@ -12332,17 +12310,6 @@
         "utf-8-validate": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@reown/appkit/node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@repeaterjs/repeater": {
@@ -16938,17 +16905,6 @@
         }
       }
     },
-    "node_modules/@walletconnect/ethereum-provider/node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
     "node_modules/@walletconnect/events": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@walletconnect/events/-/events-1.0.1.tgz",
@@ -17585,17 +17541,6 @@
         "utf-8-validate": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@walletconnect/universal-provider/node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@walletconnect/utils": {
@@ -36035,7 +35980,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -36052,7 +35996,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -36069,7 +36012,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -36086,7 +36028,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -36103,7 +36044,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -36120,7 +36060,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -36137,7 +36076,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -36154,7 +36092,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -36171,7 +36108,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -36188,7 +36124,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -36205,7 +36140,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -36222,7 +36156,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -36239,7 +36172,6 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -36256,7 +36188,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -36273,7 +36204,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -36290,7 +36220,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -36307,7 +36236,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -36324,7 +36252,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -36341,7 +36268,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -36358,7 +36284,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -36375,7 +36300,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -36392,7 +36316,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -36409,7 +36332,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -36426,7 +36348,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -36443,7 +36364,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -36460,7 +36380,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [


### PR DESCRIPTION
- Normalize Lottie tab icon colors to white and drive size from the tab bar so the icons render consistently across platforms
- Render page headers inline instead of via PageLayout's stickyHeader on Activity, Card, Points, and Savings (old)
- Shrink desktop section titles from text-5xl to text-3xl on Card, Rewards, and Savings empty state
- Reword home empty state CTA to "Make your first deposit" and lighten welcome headings to medium
- Nudge the home deposit illustration up slightly on desktop
- Drop unused nested zod entries from package-lock.json