### PR TITLE
Fix vault switching UX and add inline loading states

### DIFF
--- a/app/(protected)/(tabs)/savings.tsx
+++ b/app/(protected)/(tabs)/savings.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo } from 'react';
+import React, { useEffect, useMemo, useRef } from 'react';
 import { ImageBackground, Platform, ScrollView, View } from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
 import { useLocalSearchParams } from 'expo-router';
@@ -112,6 +112,17 @@ export default function Savings() {
   const isLoading = isBalanceLoading || isTransactionsLoading;
   const isEmptyStateLoading = isTotalBalanceLoading || isTransactionsLoading;
 
+  // Only show the full-page loader on the very first load. When the user
+  // switches vaults the per-vault queries refetch (isLoading flips true) — we
+  // must NOT unmount the page for that, or the vault tabs feel "stuck" on
+  // Android while reanimated components remount. Inline skeletons in the
+  // savings detail section cover the refetch instead.
+  const hasInitialDataLoadedRef = useRef(false);
+  if (!isLoading && !hasInitialDataLoadedRef.current) {
+    hasInitialDataLoadedRef.current = true;
+  }
+  const isInitialLoading = isLoading && !hasInitialDataLoadedRef.current;
+
   const displayPrefix = useMemo(() => {
     if (VAULTS[selectedVault].name === 'USDC') {
       return '$';
@@ -169,7 +180,7 @@ export default function Savings() {
   );
 
   return (
-    <PageLayout isLoading={isLoading} stickyHeader={stickyHeader}>
+    <PageLayout isLoading={isInitialLoading} stickyHeader={stickyHeader}>
       <View className="mx-auto w-full max-w-7xl gap-10 px-4 pb-8 md:gap-7 md:pb-12">
         {isScreenMedium ? (
           <View className="flex-row gap-4">
@@ -217,42 +228,46 @@ export default function Savings() {
                       <TooltipPopover text="Redeemable amount: balance x exchange rate" />
                     </View>
                     <View className="flex-row items-center">
-                      <SavingCountUp
-                        prefix={displayPrefix}
-                        suffix={displaySuffix ?? ''}
-                        balance={balance ?? 0}
-                        decimalPlaces={currentVault.name === 'ETH' ? 8 : 2}
-                        decimals={currentVault.decimals}
-                        apy={vaultAPY}
-                        lastTimestamp={firstDepositTimestamp ?? 0}
-                        userDepositTransactions={userDepositTransactions}
-                        exchangeRate={exchangeRate}
-                        tokenAddress={currentVault.vaults[0].address}
-                        vault={currentVault.name}
-                        summary={savingsSummary}
-                        classNames={{
-                          wrapper: 'text-foreground',
-                          decimalSeparator: 'text-2xl md:text-4.5xl font-medium',
-                        }}
-                        styles={{
-                          wholeText: {
-                            fontSize: isScreenMedium ? 70 : fontSize(3),
-                            fontWeight: 'medium',
-                            fontFamily: 'MonaSans_500Medium',
-                            color: '#ffffff',
-                            marginRight: -2,
-                          },
-                          decimalText: {
-                            fontSize: isScreenMedium ? fontSize(2.5) : fontSize(1.5),
-                            fontWeight: '300',
-                            fontFamily: 'MonaSans_500Medium',
-                            color: '#ffffff',
-                          },
-                          suffixText: {
-                            fontSize: isScreenMedium ? fontSize(2.5) : fontSize(1.5),
-                          },
-                        }}
-                      />
+                      {isLoading ? (
+                        <Skeleton className="h-11 w-44 rounded-md bg-purple/50 md:h-[70px] md:w-60" />
+                      ) : (
+                        <SavingCountUp
+                          prefix={displayPrefix}
+                          suffix={displaySuffix ?? ''}
+                          balance={balance ?? 0}
+                          decimalPlaces={currentVault.name === 'ETH' ? 8 : 2}
+                          decimals={currentVault.decimals}
+                          apy={vaultAPY}
+                          lastTimestamp={firstDepositTimestamp ?? 0}
+                          userDepositTransactions={userDepositTransactions}
+                          exchangeRate={exchangeRate}
+                          tokenAddress={currentVault.vaults[0].address}
+                          vault={currentVault.name}
+                          summary={savingsSummary}
+                          classNames={{
+                            wrapper: 'text-foreground',
+                            decimalSeparator: 'text-2xl md:text-4.5xl font-medium',
+                          }}
+                          styles={{
+                            wholeText: {
+                              fontSize: isScreenMedium ? 70 : fontSize(3),
+                              fontWeight: 'medium',
+                              fontFamily: 'MonaSans_500Medium',
+                              color: '#ffffff',
+                              marginRight: -2,
+                            },
+                            decimalText: {
+                              fontSize: isScreenMedium ? fontSize(2.5) : fontSize(1.5),
+                              fontWeight: '300',
+                              fontFamily: 'MonaSans_500Medium',
+                              color: '#ffffff',
+                            },
+                            suffixText: {
+                              fontSize: isScreenMedium ? fontSize(2.5) : fontSize(1.5),
+                            },
+                          }}
+                        />
+                      )}
                     </View>
                   </View>
                   <View className="gap-1">
@@ -263,45 +278,49 @@ export default function Savings() {
                       <TooltipPopover text="Profit to date: total value - total deposited" />
                     </View>
                     <View className="flex-row items-center">
-                      <SavingCountUp
-                        prefix={displayPrefix}
-                        suffix={displaySuffix ?? ''}
-                        balance={balance ?? 0}
-                        decimals={currentVault.decimals}
-                        apy={vaultAPY}
-                        lastTimestamp={firstDepositTimestamp ?? 0}
-                        mode={SavingMode.CURRENT}
-                        inputsReady={
-                          !isAPYsLoading && Boolean(balance && (firstDepositTimestamp ?? 0) > 0)
-                        }
-                        userDepositTransactions={userDepositTransactions}
-                        exchangeRate={exchangeRate}
-                        tokenAddress={currentVault.vaults[0].address}
-                        vault={currentVault.name}
-                        summary={savingsSummary}
-                        classNames={{
-                          wrapper: 'text-foreground',
-                          decimalSeparator: 'text-2xl md:text-4.5xl font-medium',
-                        }}
-                        styles={{
-                          wholeText: {
-                            fontSize: isScreenMedium ? 40 : fontSize(3),
-                            fontWeight: 'medium',
-                            fontFamily: 'MonaSans_500Medium',
-                            color: '#ffffff',
-                            marginRight: -2,
-                          },
-                          decimalText: {
-                            fontSize: isScreenMedium ? fontSize(2.5) : fontSize(1.5),
-                            fontWeight: '300',
-                            fontFamily: 'MonaSans_500Medium',
-                            color: '#ffffff',
-                          },
-                          suffixText: {
-                            fontSize: isScreenMedium ? fontSize(2.5) : fontSize(1.5),
-                          },
-                        }}
-                      />
+                      {isLoading ? (
+                        <Skeleton className="h-9 w-32 rounded-md bg-purple/50 md:h-10 md:w-40" />
+                      ) : (
+                        <SavingCountUp
+                          prefix={displayPrefix}
+                          suffix={displaySuffix ?? ''}
+                          balance={balance ?? 0}
+                          decimals={currentVault.decimals}
+                          apy={vaultAPY}
+                          lastTimestamp={firstDepositTimestamp ?? 0}
+                          mode={SavingMode.CURRENT}
+                          inputsReady={
+                            !isAPYsLoading && Boolean(balance && (firstDepositTimestamp ?? 0) > 0)
+                          }
+                          userDepositTransactions={userDepositTransactions}
+                          exchangeRate={exchangeRate}
+                          tokenAddress={currentVault.vaults[0].address}
+                          vault={currentVault.name}
+                          summary={savingsSummary}
+                          classNames={{
+                            wrapper: 'text-foreground',
+                            decimalSeparator: 'text-2xl md:text-4.5xl font-medium',
+                          }}
+                          styles={{
+                            wholeText: {
+                              fontSize: isScreenMedium ? 40 : fontSize(3),
+                              fontWeight: 'medium',
+                              fontFamily: 'MonaSans_500Medium',
+                              color: '#ffffff',
+                              marginRight: -2,
+                            },
+                            decimalText: {
+                              fontSize: isScreenMedium ? fontSize(2.5) : fontSize(1.5),
+                              fontWeight: '300',
+                              fontFamily: 'MonaSans_500Medium',
+                              color: '#ffffff',
+                            },
+                            suffixText: {
+                              fontSize: isScreenMedium ? fontSize(2.5) : fontSize(1.5),
+                            },
+                          }}
+                        />
+                      )}
                     </View>
                   </View>
                 </View>
@@ -412,42 +431,46 @@ export default function Savings() {
                       <TooltipPopover text="Redeemable amount: balance x exchange rate" />
                     </View>
                     <View className="flex-row items-center">
-                      <SavingCountUp
-                        prefix={displayPrefix}
-                        suffix={displaySuffix ?? ''}
-                        balance={balance ?? 0}
-                        decimalPlaces={currentVault.name === 'ETH' ? 8 : 2}
-                        decimals={currentVault.decimals}
-                        apy={vaultAPY}
-                        lastTimestamp={firstDepositTimestamp ?? 0}
-                        userDepositTransactions={userDepositTransactions}
-                        exchangeRate={exchangeRate}
-                        tokenAddress={currentVault.vaults[0].address}
-                        vault={currentVault.name}
-                        summary={savingsSummary}
-                        classNames={{
-                          wrapper: 'text-foreground',
-                          decimalSeparator: 'text-2xl md:text-4.5xl font-medium',
-                        }}
-                        styles={{
-                          wholeText: {
-                            fontSize: isScreenMedium ? 70 : fontSize(3),
-                            fontWeight: 'medium',
-                            fontFamily: 'MonaSans_500Medium',
-                            color: '#ffffff',
-                            marginRight: -2,
-                          },
-                          decimalText: {
-                            fontSize: isScreenMedium ? fontSize(2.5) : fontSize(1.5),
-                            fontWeight: '300',
-                            fontFamily: 'MonaSans_500Medium',
-                            color: '#ffffff',
-                          },
-                          suffixText: {
-                            fontSize: fontSize(2),
-                          },
-                        }}
-                      />
+                      {isLoading ? (
+                        <Skeleton className="h-11 w-44 rounded-md bg-purple/50" />
+                      ) : (
+                        <SavingCountUp
+                          prefix={displayPrefix}
+                          suffix={displaySuffix ?? ''}
+                          balance={balance ?? 0}
+                          decimalPlaces={currentVault.name === 'ETH' ? 8 : 2}
+                          decimals={currentVault.decimals}
+                          apy={vaultAPY}
+                          lastTimestamp={firstDepositTimestamp ?? 0}
+                          userDepositTransactions={userDepositTransactions}
+                          exchangeRate={exchangeRate}
+                          tokenAddress={currentVault.vaults[0].address}
+                          vault={currentVault.name}
+                          summary={savingsSummary}
+                          classNames={{
+                            wrapper: 'text-foreground',
+                            decimalSeparator: 'text-2xl md:text-4.5xl font-medium',
+                          }}
+                          styles={{
+                            wholeText: {
+                              fontSize: isScreenMedium ? 70 : fontSize(3),
+                              fontWeight: 'medium',
+                              fontFamily: 'MonaSans_500Medium',
+                              color: '#ffffff',
+                              marginRight: -2,
+                            },
+                            decimalText: {
+                              fontSize: isScreenMedium ? fontSize(2.5) : fontSize(1.5),
+                              fontWeight: '300',
+                              fontFamily: 'MonaSans_500Medium',
+                              color: '#ffffff',
+                            },
+                            suffixText: {
+                              fontSize: fontSize(2),
+                            },
+                          }}
+                        />
+                      )}
                     </View>
                   </View>
                   <View className="gap-1">
@@ -458,45 +481,49 @@ export default function Savings() {
                       <TooltipPopover text="Profit to date: total value - total deposited" />
                     </View>
                     <View className="flex-row items-center">
-                      <SavingCountUp
-                        prefix={displayPrefix}
-                        suffix={displaySuffix ?? ''}
-                        balance={balance ?? 0}
-                        decimals={currentVault.decimals}
-                        apy={vaultAPY}
-                        lastTimestamp={firstDepositTimestamp ?? 0}
-                        mode={SavingMode.CURRENT}
-                        inputsReady={
-                          !isAPYsLoading && Boolean(balance && (firstDepositTimestamp ?? 0) > 0)
-                        }
-                        userDepositTransactions={userDepositTransactions}
-                        exchangeRate={exchangeRate}
-                        tokenAddress={currentVault.vaults[0].address}
-                        vault={currentVault.name}
-                        summary={savingsSummary}
-                        classNames={{
-                          wrapper: 'text-foreground',
-                          decimalSeparator: 'text-2xl md:text-4.5xl font-medium',
-                        }}
-                        styles={{
-                          wholeText: {
-                            fontSize: isScreenMedium ? 40 : fontSize(3),
-                            fontWeight: 'medium',
-                            fontFamily: 'MonaSans_500Medium',
-                            color: '#ffffff',
-                            marginRight: -2,
-                          },
-                          decimalText: {
-                            fontSize: isScreenMedium ? fontSize(2.5) : fontSize(1.5),
-                            fontWeight: '300',
-                            fontFamily: 'MonaSans_500Medium',
-                            color: '#ffffff',
-                          },
-                          suffixText: {
-                            fontSize: fontSize(2),
-                          },
-                        }}
-                      />
+                      {isLoading ? (
+                        <Skeleton className="h-11 w-32 rounded-md bg-purple/50" />
+                      ) : (
+                        <SavingCountUp
+                          prefix={displayPrefix}
+                          suffix={displaySuffix ?? ''}
+                          balance={balance ?? 0}
+                          decimals={currentVault.decimals}
+                          apy={vaultAPY}
+                          lastTimestamp={firstDepositTimestamp ?? 0}
+                          mode={SavingMode.CURRENT}
+                          inputsReady={
+                            !isAPYsLoading && Boolean(balance && (firstDepositTimestamp ?? 0) > 0)
+                          }
+                          userDepositTransactions={userDepositTransactions}
+                          exchangeRate={exchangeRate}
+                          tokenAddress={currentVault.vaults[0].address}
+                          vault={currentVault.name}
+                          summary={savingsSummary}
+                          classNames={{
+                            wrapper: 'text-foreground',
+                            decimalSeparator: 'text-2xl md:text-4.5xl font-medium',
+                          }}
+                          styles={{
+                            wholeText: {
+                              fontSize: isScreenMedium ? 40 : fontSize(3),
+                              fontWeight: 'medium',
+                              fontFamily: 'MonaSans_500Medium',
+                              color: '#ffffff',
+                              marginRight: -2,
+                            },
+                            decimalText: {
+                              fontSize: isScreenMedium ? fontSize(2.5) : fontSize(1.5),
+                              fontWeight: '300',
+                              fontFamily: 'MonaSans_500Medium',
+                              color: '#ffffff',
+                            },
+                            suffixText: {
+                              fontSize: fontSize(2),
+                            },
+                          }}
+                        />
+                      )}
                     </View>
                   </View>
                 </View>

--- a/components/Savings/SavingsAnalytics.tsx
+++ b/components/Savings/SavingsAnalytics.tsx
@@ -40,7 +40,8 @@ const SavingsAnalytics = () => {
     historicalVault,
   );
   const currentVaultName = VAULTS[selectedVault]?.name?.toLowerCase();
-  const { data: vaultBreakdown } = useVaultBreakdown(currentVaultName);
+  const { data: vaultBreakdown, isLoading: isVaultBreakdownLoading } =
+    useVaultBreakdown(currentVaultName);
 
   useEffect(() => {
     isMountedRef.current = true;
@@ -136,7 +137,9 @@ const SavingsAnalytics = () => {
 
       {selectedTab === Tab.VAULT_BREAKDOWN && (
         <>
-          {vaultBreakdown && vaultBreakdown.length > 0 ? (
+          {isVaultBreakdownLoading ? (
+            <ChartFallback />
+          ) : vaultBreakdown && vaultBreakdown.length > 0 ? (
             <View className="flex-col gap-4 md:flex-row md:justify-between">
               <VaultBreakdownTable
                 data={vaultBreakdown}


### PR DESCRIPTION
## Summary
Improved the savings page loading experience by distinguishing between initial page load and subsequent vault switches, and added inline skeleton loaders for better UX during data refetches.

## Key Changes
- **Separate initial vs. refetch loading states**: Introduced `isInitialLoading` using a `useRef` to track whether the page has loaded data at least once. The full-page loader now only shows on initial load, preventing the page from unmounting when users switch vaults (which was causing "stuck" vault tabs on Android with reanimated components).
- **Inline skeleton loaders**: Added `Skeleton` components that display during refetches for:
  - Balance display (redeemable amount)
  - Profit display (current earnings)
  - Both desktop and mobile layouts
- **Loading state in SavingsAnalytics**: Added `isVaultBreakdownLoading` state to show a `ChartFallback` component while vault breakdown data is being fetched, improving perceived performance during vault switches.

## Implementation Details
- The `hasInitialDataLoadedRef` ref persists across renders and prevents the full-page loader from showing again after the first successful data load
- Inline skeletons use `isLoading` (the per-vault refetch state) rather than `isInitialLoading`, so they appear during vault switches while the page remains mounted
- This approach maintains smooth tab navigation on Android while providing visual feedback during data updates

https://claude.ai/code/session_012rn1TuC6MDpYw9GPrGGFw7