### PR TITLE
fix(savings): keep page mounted on vault switch, show inline skeletons

### DIFF
--- a/app/(protected)/(tabs)/savings.tsx
+++ b/app/(protected)/(tabs)/savings.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo } from 'react';
+import React, { useEffect, useMemo, useRef } from 'react';
 import { ImageBackground, Platform, ScrollView, View } from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
 import { useLocalSearchParams } from 'expo-router';
@@ -112,6 +112,17 @@ export default function Savings() {
   const isLoading = isBalanceLoading || isTransactionsLoading;
   const isEmptyStateLoading = isTotalBalanceLoading || isTransactionsLoading;
 
+  // Only show the full-page loader on the very first load. When the user
+  // switches vaults the per-vault queries refetch (isLoading flips true) — we
+  // must NOT unmount the page for that, or the vault tabs feel "stuck" on
+  // Android while reanimated components remount. Inline skeletons in the
+  // savings detail section cover the refetch instead.
+  const hasInitialDataLoadedRef = useRef(false);
+  if (!isLoading && !hasInitialDataLoadedRef.current) {
+    hasInitialDataLoadedRef.current = true;
+  }
+  const isInitialLoading = isLoading && !hasInitialDataLoadedRef.current;
+
   const displayPrefix = useMemo(() => {
     if (VAULTS[selectedVault].name === 'USDC') {
       return '$';
@@ -169,7 +180,7 @@ export default function Savings() {
   );
 
   return (
-    <PageLayout isLoading={isLoading} stickyHeader={stickyHeader}>
+    <PageLayout isLoading={isInitialLoading} stickyHeader={stickyHeader}>
       <View className="mx-auto w-full max-w-7xl gap-10 px-4 pb-8 md:gap-7 md:pb-12">
         {isScreenMedium ? (
           <View className="flex-row gap-4">
@@ -217,42 +228,46 @@ export default function Savings() {
                       <TooltipPopover text="Redeemable amount: balance x exchange rate" />
                     </View>
                     <View className="flex-row items-center">
-                      <SavingCountUp
-                        prefix={displayPrefix}
-                        suffix={displaySuffix ?? ''}
-                        balance={balance ?? 0}
-                        decimalPlaces={currentVault.name === 'ETH' ? 8 : 2}
-                        decimals={currentVault.decimals}
-                        apy={vaultAPY}
-                        lastTimestamp={firstDepositTimestamp ?? 0}
-                        userDepositTransactions={userDepositTransactions}
-                        exchangeRate={exchangeRate}
-                        tokenAddress={currentVault.vaults[0].address}
-                        vault={currentVault.name}
-                        summary={savingsSummary}
-                        classNames={{
-                          wrapper: 'text-foreground',
-                          decimalSeparator: 'text-2xl md:text-4.5xl font-medium',
-                        }}
-                        styles={{
-                          wholeText: {
-                            fontSize: isScreenMedium ? 70 : fontSize(3),
-                            fontWeight: 'medium',
-                            fontFamily: 'MonaSans_500Medium',
-                            color: '#ffffff',
-                            marginRight: -2,
-                          },
-                          decimalText: {
-                            fontSize: isScreenMedium ? fontSize(2.5) : fontSize(1.5),
-                            fontWeight: '300',
-                            fontFamily: 'MonaSans_500Medium',
-                            color: '#ffffff',
-                          },
-                          suffixText: {
-                            fontSize: isScreenMedium ? fontSize(2.5) : fontSize(1.5),
-                          },
-                        }}
-                      />
+                      {isLoading ? (
+                        <Skeleton className="h-11 w-44 rounded-md bg-purple/50 md:h-[70px] md:w-60" />
+                      ) : (
+                        <SavingCountUp
+                          prefix={displayPrefix}
+                          suffix={displaySuffix ?? ''}
+                          balance={balance ?? 0}
+                          decimalPlaces={currentVault.name === 'ETH' ? 8 : 2}
+                          decimals={currentVault.decimals}
+                          apy={vaultAPY}
+                          lastTimestamp={firstDepositTimestamp ?? 0}
+                          userDepositTransactions={userDepositTransactions}
+                          exchangeRate={exchangeRate}
+                          tokenAddress={currentVault.vaults[0].address}
+                          vault={currentVault.name}
+                          summary={savingsSummary}
+                          classNames={{
+                            wrapper: 'text-foreground',
+                            decimalSeparator: 'text-2xl md:text-4.5xl font-medium',
+                          }}
+                          styles={{
+                            wholeText: {
+                              fontSize: isScreenMedium ? 70 : fontSize(3),
+                              fontWeight: 'medium',
+                              fontFamily: 'MonaSans_500Medium',
+                              color: '#ffffff',
+                              marginRight: -2,
+                            },
+                            decimalText: {
+                              fontSize: isScreenMedium ? fontSize(2.5) : fontSize(1.5),
+                              fontWeight: '300',
+                              fontFamily: 'MonaSans_500Medium',
+                              color: '#ffffff',
+                            },
+                            suffixText: {
+                              fontSize: isScreenMedium ? fontSize(2.5) : fontSize(1.5),
+                            },
+                          }}
+                        />
+                      )}
                     </View>
                   </View>
                   <View className="gap-1">
@@ -263,45 +278,49 @@ export default function Savings() {
                       <TooltipPopover text="Profit to date: total value - total deposited" />
                     </View>
                     <View className="flex-row items-center">
-                      <SavingCountUp
-                        prefix={displayPrefix}
-                        suffix={displaySuffix ?? ''}
-                        balance={balance ?? 0}
-                        decimals={currentVault.decimals}
-                        apy={vaultAPY}
-                        lastTimestamp={firstDepositTimestamp ?? 0}
-                        mode={SavingMode.CURRENT}
-                        inputsReady={
-                          !isAPYsLoading && Boolean(balance && (firstDepositTimestamp ?? 0) > 0)
-                        }
-                        userDepositTransactions={userDepositTransactions}
-                        exchangeRate={exchangeRate}
-                        tokenAddress={currentVault.vaults[0].address}
-                        vault={currentVault.name}
-                        summary={savingsSummary}
-                        classNames={{
-                          wrapper: 'text-foreground',
-                          decimalSeparator: 'text-2xl md:text-4.5xl font-medium',
-                        }}
-                        styles={{
-                          wholeText: {
-                            fontSize: isScreenMedium ? 40 : fontSize(3),
-                            fontWeight: 'medium',
-                            fontFamily: 'MonaSans_500Medium',
-                            color: '#ffffff',
-                            marginRight: -2,
-                          },
-                          decimalText: {
-                            fontSize: isScreenMedium ? fontSize(2.5) : fontSize(1.5),
-                            fontWeight: '300',
-                            fontFamily: 'MonaSans_500Medium',
-                            color: '#ffffff',
-                          },
-                          suffixText: {
-                            fontSize: isScreenMedium ? fontSize(2.5) : fontSize(1.5),
-                          },
-                        }}
-                      />
+                      {isLoading ? (
+                        <Skeleton className="h-9 w-32 rounded-md bg-purple/50 md:h-10 md:w-40" />
+                      ) : (
+                        <SavingCountUp
+                          prefix={displayPrefix}
+                          suffix={displaySuffix ?? ''}
+                          balance={balance ?? 0}
+                          decimals={currentVault.decimals}
+                          apy={vaultAPY}
+                          lastTimestamp={firstDepositTimestamp ?? 0}
+                          mode={SavingMode.CURRENT}
+                          inputsReady={
+                            !isAPYsLoading && Boolean(balance && (firstDepositTimestamp ?? 0) > 0)
+                          }
+                          userDepositTransactions={userDepositTransactions}
+                          exchangeRate={exchangeRate}
+                          tokenAddress={currentVault.vaults[0].address}
+                          vault={currentVault.name}
+                          summary={savingsSummary}
+                          classNames={{
+                            wrapper: 'text-foreground',
+                            decimalSeparator: 'text-2xl md:text-4.5xl font-medium',
+                          }}
+                          styles={{
+                            wholeText: {
+                              fontSize: isScreenMedium ? 40 : fontSize(3),
+                              fontWeight: 'medium',
+                              fontFamily: 'MonaSans_500Medium',
+                              color: '#ffffff',
+                              marginRight: -2,
+                            },
+                            decimalText: {
+                              fontSize: isScreenMedium ? fontSize(2.5) : fontSize(1.5),
+                              fontWeight: '300',
+                              fontFamily: 'MonaSans_500Medium',
+                              color: '#ffffff',
+                            },
+                            suffixText: {
+                              fontSize: isScreenMedium ? fontSize(2.5) : fontSize(1.5),
+                            },
+                          }}
+                        />
+                      )}
                     </View>
                   </View>
                 </View>
@@ -412,42 +431,46 @@ export default function Savings() {
                       <TooltipPopover text="Redeemable amount: balance x exchange rate" />
                     </View>
                     <View className="flex-row items-center">
-                      <SavingCountUp
-                        prefix={displayPrefix}
-                        suffix={displaySuffix ?? ''}
-                        balance={balance ?? 0}
-                        decimalPlaces={currentVault.name === 'ETH' ? 8 : 2}
-                        decimals={currentVault.decimals}
-                        apy={vaultAPY}
-                        lastTimestamp={firstDepositTimestamp ?? 0}
-                        userDepositTransactions={userDepositTransactions}
-                        exchangeRate={exchangeRate}
-                        tokenAddress={currentVault.vaults[0].address}
-                        vault={currentVault.name}
-                        summary={savingsSummary}
-                        classNames={{
-                          wrapper: 'text-foreground',
-                          decimalSeparator: 'text-2xl md:text-4.5xl font-medium',
-                        }}
-                        styles={{
-                          wholeText: {
-                            fontSize: isScreenMedium ? 70 : fontSize(3),
-                            fontWeight: 'medium',
-                            fontFamily: 'MonaSans_500Medium',
-                            color: '#ffffff',
-                            marginRight: -2,
-                          },
-                          decimalText: {
-                            fontSize: isScreenMedium ? fontSize(2.5) : fontSize(1.5),
-                            fontWeight: '300',
-                            fontFamily: 'MonaSans_500Medium',
-                            color: '#ffffff',
-                          },
-                          suffixText: {
-                            fontSize: fontSize(2),
-                          },
-                        }}
-                      />
+                      {isLoading ? (
+                        <Skeleton className="h-11 w-44 rounded-md bg-purple/50" />
+                      ) : (
+                        <SavingCountUp
+                          prefix={displayPrefix}
+                          suffix={displaySuffix ?? ''}
+                          balance={balance ?? 0}
+                          decimalPlaces={currentVault.name === 'ETH' ? 8 : 2}
+                          decimals={currentVault.decimals}
+                          apy={vaultAPY}
+                          lastTimestamp={firstDepositTimestamp ?? 0}
+                          userDepositTransactions={userDepositTransactions}
+                          exchangeRate={exchangeRate}
+                          tokenAddress={currentVault.vaults[0].address}
+                          vault={currentVault.name}
+                          summary={savingsSummary}
+                          classNames={{
+                            wrapper: 'text-foreground',
+                            decimalSeparator: 'text-2xl md:text-4.5xl font-medium',
+                          }}
+                          styles={{
+                            wholeText: {
+                              fontSize: isScreenMedium ? 70 : fontSize(3),
+                              fontWeight: 'medium',
+                              fontFamily: 'MonaSans_500Medium',
+                              color: '#ffffff',
+                              marginRight: -2,
+                            },
+                            decimalText: {
+                              fontSize: isScreenMedium ? fontSize(2.5) : fontSize(1.5),
+                              fontWeight: '300',
+                              fontFamily: 'MonaSans_500Medium',
+                              color: '#ffffff',
+                            },
+                            suffixText: {
+                              fontSize: fontSize(2),
+                            },
+                          }}
+                        />
+                      )}
                     </View>
                   </View>
                   <View className="gap-1">
@@ -458,45 +481,49 @@ export default function Savings() {
                       <TooltipPopover text="Profit to date: total value - total deposited" />
                     </View>
                     <View className="flex-row items-center">
-                      <SavingCountUp
-                        prefix={displayPrefix}
-                        suffix={displaySuffix ?? ''}
-                        balance={balance ?? 0}
-                        decimals={currentVault.decimals}
-                        apy={vaultAPY}
-                        lastTimestamp={firstDepositTimestamp ?? 0}
-                        mode={SavingMode.CURRENT}
-                        inputsReady={
-                          !isAPYsLoading && Boolean(balance && (firstDepositTimestamp ?? 0) > 0)
-                        }
-                        userDepositTransactions={userDepositTransactions}
-                        exchangeRate={exchangeRate}
-                        tokenAddress={currentVault.vaults[0].address}
-                        vault={currentVault.name}
-                        summary={savingsSummary}
-                        classNames={{
-                          wrapper: 'text-foreground',
-                          decimalSeparator: 'text-2xl md:text-4.5xl font-medium',
-                        }}
-                        styles={{
-                          wholeText: {
-                            fontSize: isScreenMedium ? 40 : fontSize(3),
-                            fontWeight: 'medium',
-                            fontFamily: 'MonaSans_500Medium',
-                            color: '#ffffff',
-                            marginRight: -2,
-                          },
-                          decimalText: {
-                            fontSize: isScreenMedium ? fontSize(2.5) : fontSize(1.5),
-                            fontWeight: '300',
-                            fontFamily: 'MonaSans_500Medium',
-                            color: '#ffffff',
-                          },
-                          suffixText: {
-                            fontSize: fontSize(2),
-                          },
-                        }}
-                      />
+                      {isLoading ? (
+                        <Skeleton className="h-11 w-32 rounded-md bg-purple/50" />
+                      ) : (
+                        <SavingCountUp
+                          prefix={displayPrefix}
+                          suffix={displaySuffix ?? ''}
+                          balance={balance ?? 0}
+                          decimals={currentVault.decimals}
+                          apy={vaultAPY}
+                          lastTimestamp={firstDepositTimestamp ?? 0}
+                          mode={SavingMode.CURRENT}
+                          inputsReady={
+                            !isAPYsLoading && Boolean(balance && (firstDepositTimestamp ?? 0) > 0)
+                          }
+                          userDepositTransactions={userDepositTransactions}
+                          exchangeRate={exchangeRate}
+                          tokenAddress={currentVault.vaults[0].address}
+                          vault={currentVault.name}
+                          summary={savingsSummary}
+                          classNames={{
+                            wrapper: 'text-foreground',
+                            decimalSeparator: 'text-2xl md:text-4.5xl font-medium',
+                          }}
+                          styles={{
+                            wholeText: {
+                              fontSize: isScreenMedium ? 40 : fontSize(3),
+                              fontWeight: 'medium',
+                              fontFamily: 'MonaSans_500Medium',
+                              color: '#ffffff',
+                              marginRight: -2,
+                            },
+                            decimalText: {
+                              fontSize: isScreenMedium ? fontSize(2.5) : fontSize(1.5),
+                              fontWeight: '300',
+                              fontFamily: 'MonaSans_500Medium',
+                              color: '#ffffff',
+                            },
+                            suffixText: {
+                              fontSize: fontSize(2),
+                            },
+                          }}
+                        />
+                      )}
                     </View>
                   </View>
                 </View>

--- a/components/Savings/SavingsAnalytics.tsx
+++ b/components/Savings/SavingsAnalytics.tsx
@@ -40,7 +40,8 @@ const SavingsAnalytics = () => {
     historicalVault,
   );
   const currentVaultName = VAULTS[selectedVault]?.name?.toLowerCase();
-  const { data: vaultBreakdown } = useVaultBreakdown(currentVaultName);
+  const { data: vaultBreakdown, isLoading: isVaultBreakdownLoading } =
+    useVaultBreakdown(currentVaultName);
 
   useEffect(() => {
     isMountedRef.current = true;
@@ -136,7 +137,9 @@ const SavingsAnalytics = () => {
 
       {selectedTab === Tab.VAULT_BREAKDOWN && (
         <>
-          {vaultBreakdown && vaultBreakdown.length > 0 ? (
+          {isVaultBreakdownLoading ? (
+            <ChartFallback />
+          ) : vaultBreakdown && vaultBreakdown.length > 0 ? (
             <View className="flex-col gap-4 md:flex-row md:justify-between">
               <VaultBreakdownTable
                 data={vaultBreakdown}


### PR DESCRIPTION
## Summary
- Switching vault tabs on the savings page no longer unmounts the entire page — only the very first visit shows the full-page loader.
- Total Value and Interest Earned now render inline `<Skeleton>` placeholders while the new vault's balance/transactions refetch, instead of flashing through `<Loading />`.
- Vault Breakdown analytics tab now shows `<ChartFallback />` during refetch instead of flashing "No vault breakdown data available".

## Why
`isLoading = isBalanceLoading || isTransactionsLoading` was passed straight to `PageLayout`, which swaps the whole subtree for `<Loading />`. Both queries are keyed by the current vault, so every vault tab click flipped `isLoading` true and tore down the page — including the reanimated vault cards, count-up numbers, and analytics chart. On Android that remount cycle over the JS/native bridge felt stuck.

A `useRef` tracks whether the page has ever finished loading; only the initial render shows the page loader. Subsequent refetches keep the page mounted and render skeletons in the affected slots.

## Test plan
- [ ] Web: visit `/savings` → page loader shows once, then content
- [ ] Web: click between USDC / FUSE / ETH → vault cards stay in place, Total Value and Interest Earned show skeletons only, page does not blink
- [ ] Web: switch to Vault Breakdown tab, then change vaults → loading spinner shows instead of "No vault breakdown data available"
- [ ] Android native: switch vaults rapidly → no stuck/frozen state, animations remain smooth
- [ ] Empty-state user (no balance anywhere) still sees `<SavingsEmptyState />` after initial load completes

https://claude.ai/code/session_012rn1TuC6MDpYw9GPrGGFw7

---
_Generated by [Claude Code](https://claude.ai/code/session_012rn1TuC6MDpYw9GPrGGFw7)_