### PR TITLE
Add Arbitrum network support to balance fetching

### DIFF
--- a/constants/tokens.ts
+++ b/constants/tokens.ts
@@ -1,7 +1,7 @@
 import { Token } from '@cryptoalgebra/fuse-sdk';
 
 import { ImageSourcePropType } from 'react-native';
-import { base, fuse, mainnet } from 'viem/chains';
+import { arbitrum, base, fuse, mainnet } from 'viem/chains';
 import {
   BUSD,
   FUSD_V2,
@@ -42,6 +42,7 @@ export const NATIVE_TOKENS: Record<number, string> = {
   [mainnet.id]: 'ETH',
   [fuse.id]: 'fuse-network-token',
   [base.id]: 'ETH',
+  [arbitrum.id]: 'ETH',
 };
 
 /** CoinGecko API coin ids */
@@ -49,6 +50,7 @@ export const NATIVE_COINGECKO_TOKENS: Record<number, string> = {
   [mainnet.id]: 'ethereum',
   [fuse.id]: 'fuse-network-token',
   [base.id]: 'ethereum',
+  [arbitrum.id]: 'ethereum',
 };
 
 export const TOKEN_IMAGES: Record<string, ImageSourcePropType> = {

--- a/hooks/useBalances.ts
+++ b/hooks/useBalances.ts
@@ -1,7 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 import { formatUnits, parseUnits, zeroAddress } from 'viem';
 import { getBalance, readContract } from 'viem/actions';
-import { base, fuse, mainnet } from 'viem/chains';
+import { arbitrum, base, fuse, mainnet } from 'viem/chains';
 
 import { NATIVE_COINGECKO_TOKENS, NATIVE_TOKENS } from '@/constants/tokens';
 import { fetchCoinSimplePrice, fetchTokenList, fetchTokenPriceUsd } from '@/lib/api';
@@ -111,9 +111,11 @@ const fetchTokenBalances = async (safeAddress: string) => {
     ethBalance,
     fuseBalance,
     baseBalance,
+    arbitrumBalance,
     ethPrice,
     fusePrice,
     basePrice,
+    arbitrumPrice,
     tokenList,
   ] = await Promise.allSettled([
     // Token balances via the data-source dispatcher (Alchemy primary,
@@ -142,9 +144,13 @@ const fetchTokenBalances = async (safeAddress: string) => {
     getBalance(publicClient(base.id), {
       address: safeAddress as `0x${string}`,
     }),
+    getBalance(publicClient(arbitrum.id), {
+      address: safeAddress as `0x${string}`,
+    }),
     fetchTokenPriceUsd(NATIVE_TOKENS[mainnet.id]),
     fetchTokenPriceUsd(NATIVE_TOKENS[fuse.id]),
     fetchTokenPriceUsd(NATIVE_TOKENS[base.id]),
+    fetchTokenPriceUsd(NATIVE_TOKENS[arbitrum.id]),
     fetchTokenList({
       isActive: true,
     }),
@@ -353,6 +359,27 @@ const fetchTokenBalances = async (safeAddress: string) => {
       chainId: BASE_CHAIN_ID,
       commonId: baseEthTokenFromList?.commonId,
       tokenId: baseEthTokenFromList?.tokenId,
+    });
+  }
+
+  if (arbitrumBalance.status === PromiseStatus.FULFILLED && Number(arbitrumBalance.value)) {
+    const arbitrumPriceValue =
+      arbitrumPrice.status === PromiseStatus.FULFILLED ? Number(arbitrumPrice.value) : 0;
+    const arbitrumEthTokenFromList = tokenListData.find(
+      token => token.chainId === ARBITRUM_CHAIN_ID && token.symbol === 'ETH',
+    );
+    arbitrumTokens.push({
+      contractTickerSymbol: 'ETH',
+      contractName: 'Ether',
+      contractAddress: zeroAddress,
+      balance: arbitrumBalance.value.toString(),
+      quoteRate: arbitrumPriceValue,
+      contractDecimals: 18,
+      type: TokenType.NATIVE,
+      verified: true,
+      chainId: ARBITRUM_CHAIN_ID,
+      commonId: arbitrumEthTokenFromList?.commonId,
+      tokenId: arbitrumEthTokenFromList?.tokenId,
     });
   }
 


### PR DESCRIPTION
## Summary
This PR adds support for the Arbitrum network to the balance fetching functionality, enabling users to view their native ETH balances and prices on Arbitrum alongside existing supported networks (Ethereum mainnet, Fuse, and Base).

## Key Changes
- **Import Arbitrum chain**: Added `arbitrum` to the viem chains imports in both `hooks/useBalances.ts` and `constants/tokens.ts`
- **Balance fetching**: Extended `fetchTokenBalances` to fetch native ETH balance on Arbitrum using the public client
- **Price fetching**: Added price fetching for Arbitrum's native ETH token via the CoinGecko API
- **Token processing**: Implemented logic to process and format Arbitrum ETH balances, including:
  - Validation of fulfilled balance promises
  - Price value extraction with fallback to 0
  - Token metadata lookup from the token list
  - Creation of native token objects with proper chain ID and token information
- **Token constants**: Updated `NATIVE_TOKENS` and `NATIVE_COINGECKO_TOKENS` mappings to include Arbitrum's ETH token configuration

## Implementation Details
The Arbitrum implementation follows the existing pattern used for Base and Fuse networks:
- Uses the same native token symbol ('ETH') and CoinGecko ID ('ethereum')
- Maintains consistent token object structure with `TokenType.NATIVE` designation
- Properly handles promise settlement status checks before processing balance data
- Integrates seamlessly with the existing token list lookup mechanism

https://claude.ai/code/session_01ThYo8D5jLeC2PfaiSGC7Ud