### PR TITLE
feat(balances): show native ETH on Arbitrum

### DIFF
--- a/constants/tokens.ts
+++ b/constants/tokens.ts
@@ -1,7 +1,7 @@
 import { Token } from '@cryptoalgebra/fuse-sdk';
 
 import { ImageSourcePropType } from 'react-native';
-import { base, fuse, mainnet } from 'viem/chains';
+import { arbitrum, base, fuse, mainnet } from 'viem/chains';
 import {
   BUSD,
   FUSD_V2,
@@ -42,6 +42,7 @@ export const NATIVE_TOKENS: Record<number, string> = {
   [mainnet.id]: 'ETH',
   [fuse.id]: 'fuse-network-token',
   [base.id]: 'ETH',
+  [arbitrum.id]: 'ETH',
 };
 
 /** CoinGecko API coin ids */
@@ -49,6 +50,7 @@ export const NATIVE_COINGECKO_TOKENS: Record<number, string> = {
   [mainnet.id]: 'ethereum',
   [fuse.id]: 'fuse-network-token',
   [base.id]: 'ethereum',
+  [arbitrum.id]: 'ethereum',
 };
 
 export const TOKEN_IMAGES: Record<string, ImageSourcePropType> = {

--- a/hooks/useBalances.ts
+++ b/hooks/useBalances.ts
@@ -1,7 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 import { formatUnits, parseUnits, zeroAddress } from 'viem';
 import { getBalance, readContract } from 'viem/actions';
-import { base, fuse, mainnet } from 'viem/chains';
+import { arbitrum, base, fuse, mainnet } from 'viem/chains';
 
 import { NATIVE_COINGECKO_TOKENS, NATIVE_TOKENS } from '@/constants/tokens';
 import { fetchCoinSimplePrice, fetchTokenList, fetchTokenPriceUsd } from '@/lib/api';
@@ -111,9 +111,11 @@ const fetchTokenBalances = async (safeAddress: string) => {
     ethBalance,
     fuseBalance,
     baseBalance,
+    arbitrumBalance,
     ethPrice,
     fusePrice,
     basePrice,
+    arbitrumPrice,
     tokenList,
   ] = await Promise.allSettled([
     // Token balances via the data-source dispatcher (Alchemy primary,
@@ -142,9 +144,13 @@ const fetchTokenBalances = async (safeAddress: string) => {
     getBalance(publicClient(base.id), {
       address: safeAddress as `0x${string}`,
     }),
+    getBalance(publicClient(arbitrum.id), {
+      address: safeAddress as `0x${string}`,
+    }),
     fetchTokenPriceUsd(NATIVE_TOKENS[mainnet.id]),
     fetchTokenPriceUsd(NATIVE_TOKENS[fuse.id]),
     fetchTokenPriceUsd(NATIVE_TOKENS[base.id]),
+    fetchTokenPriceUsd(NATIVE_TOKENS[arbitrum.id]),
     fetchTokenList({
       isActive: true,
     }),
@@ -353,6 +359,27 @@ const fetchTokenBalances = async (safeAddress: string) => {
       chainId: BASE_CHAIN_ID,
       commonId: baseEthTokenFromList?.commonId,
       tokenId: baseEthTokenFromList?.tokenId,
+    });
+  }
+
+  if (arbitrumBalance.status === PromiseStatus.FULFILLED && Number(arbitrumBalance.value)) {
+    const arbitrumPriceValue =
+      arbitrumPrice.status === PromiseStatus.FULFILLED ? Number(arbitrumPrice.value) : 0;
+    const arbitrumEthTokenFromList = tokenListData.find(
+      token => token.chainId === ARBITRUM_CHAIN_ID && token.symbol === 'ETH',
+    );
+    arbitrumTokens.push({
+      contractTickerSymbol: 'ETH',
+      contractName: 'Ether',
+      contractAddress: zeroAddress,
+      balance: arbitrumBalance.value.toString(),
+      quoteRate: arbitrumPriceValue,
+      contractDecimals: 18,
+      type: TokenType.NATIVE,
+      verified: true,
+      chainId: ARBITRUM_CHAIN_ID,
+      commonId: arbitrumEthTokenFromList?.commonId,
+      tokenId: arbitrumEthTokenFromList?.tokenId,
     });
   }
 


### PR DESCRIPTION
Cherry-pick of #2087 from `qa` to `master`.

## Summary
- Fetch the safe's native ETH balance on Arbitrum alongside Ethereum, Fuse, and Base.
- Add Arbitrum entries to `NATIVE_TOKENS` and `NATIVE_COINGECKO_TOKENS` so price lookup works.
- Unblocks users who accidentally sent ETH to their Arbitrum safe address — the balance now appears in the wallet and can be transferred out via the existing Send flow.

## Test plan
- [ ] Send ETH to a safe address on Arbitrum, confirm balance appears in wallet UI.
- [ ] Confirm USD value renders (price fetched via Alchemy/CoinGecko).
- [ ] Open Send flow, select Arbitrum ETH, transfer to an external address successfully.
- [ ] Verify existing Ethereum / Fuse / Base native balances still render correctly.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ThYo8D5jLeC2PfaiSGC7Ud)_