### PR TITLE
fix(card): drop Latin-only name validation from Rain KYC and align physical card shipping rule

### DIFF
--- a/components/Card/OrderPhysicalCardModal.tsx
+++ b/components/Card/OrderPhysicalCardModal.tsx
@@ -25,17 +25,23 @@ interface OrderPhysicalCardModalProps {
 const MODAL_STATE: ModalState = { name: 'order-physical-card', number: 1 };
 const CLOSE_STATE: ModalState = { name: 'close', number: 0 };
 
+// Rain embosses firstName + lastName as the displayName on physical cards
+// and only allows alphanumeric characters, spaces, periods, and hyphens.
+const PHYSICAL_CARD_NAME_REGEX = /^[a-zA-Z0-9 .\-]+$/;
+const PHYSICAL_CARD_NAME_MESSAGE =
+  'Only letters, numbers, spaces, periods, and hyphens are allowed';
+
 const shippingSchema = z.object({
   firstName: z
     .string()
     .min(1, { message: 'First name is required' })
     .max(50)
-    .regex(/^[a-zA-Z -]+$/, { message: 'Only Latin characters, spaces, and hyphens' }),
+    .regex(PHYSICAL_CARD_NAME_REGEX, { message: PHYSICAL_CARD_NAME_MESSAGE }),
   lastName: z
     .string()
     .min(1, { message: 'Last name is required' })
     .max(50)
-    .regex(/^[a-zA-Z -]+$/, { message: 'Only Latin characters, spaces, and hyphens' }),
+    .regex(PHYSICAL_CARD_NAME_REGEX, { message: PHYSICAL_CARD_NAME_MESSAGE }),
   line1: z.string().min(1, { message: 'Address is required' }).max(100),
   line2: z.string().max(100).optional().or(z.literal('')),
   city: z.string().min(1, { message: 'City is required' }).max(50),

--- a/components/RainKyc/rainKycSchema.ts
+++ b/components/RainKyc/rainKycSchema.ts
@@ -2,25 +2,10 @@ import { z } from 'zod';
 
 import type { RainDocumentType } from '@/lib/types';
 
-/**
- * Rain requires the card display name to contain only Latin characters.
- * Allows Basic Latin + Latin Extended (accented) letters, spaces, hyphens, apostrophes, and periods.
- */
-const LATIN_NAME_REGEX = /^[a-zA-ZÀ-ÖØ-öø-ÿĀ-ſ\s\-'.]+$/;
-const LATIN_NAME_MESSAGE = 'Only Latin characters are allowed (no Cyrillic, Arabic, CJK, etc.)';
-
 export const rainKycFormSchema = z
   .object({
-    firstName: z
-      .string()
-      .min(1, 'First name is required')
-      .max(50)
-      .regex(LATIN_NAME_REGEX, LATIN_NAME_MESSAGE),
-    lastName: z
-      .string()
-      .min(1, 'Last name is required')
-      .max(50)
-      .regex(LATIN_NAME_REGEX, LATIN_NAME_MESSAGE),
+    firstName: z.string().min(1, 'First name is required').max(50),
+    lastName: z.string().min(1, 'Last name is required').max(50),
     birthDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'Use YYYY-MM-DD'),
     nationalId: z.string().min(1, 'National ID / SSN is required'),
     countryOfIssue: z.string().length(2, 'Use 2-letter country code'),


### PR DESCRIPTION
Cherry-pick of `7fac8202` from qa (originally merged via #2086) onto master. Paired with backend PR Solid-Money/solid-backend#1465.

## Summary
Rain's only character restriction is on `configuration.displayName` for physical cards (alphanumeric, spaces, periods, hyphens) and is ignored for virtual cards entirely. The Rain KYC form was rejecting valid applicants with non-Latin names (Cyrillic, Arabic, CJK) for both virtual and physical cards.

- `RainKyc/rainKycSchema.ts`: removed Latin-only regex on `firstName` / `lastName`.
- `Card/OrderPhysicalCardModal.tsx`: relaxed the shipping-name regex to match Rain's documented rule (also allow digits and periods) since these names are embossed as the physical card's `displayName`.

## Test plan
- [ ] Submit Rain KYC with a non-Latin name (e.g. Japanese, Cyrillic) — form accepts it and submits
- [ ] Existing Latin-name submissions continue to work
- [ ] Order physical card with the allowed character set (letters, digits, spaces, periods, hyphens) — passes shipping-name validation
- [ ] Disallowed characters (e.g. `@`, `#`) still rejected by the shipping-name field

---
_Generated by [Claude Code](https://claude.ai/code/session_01E261D3wSX3XpTuNzjP9Nfm)_