### PR TITLE
Update DiditSDK podspec URL to use stable version 3.2.13

### DIFF
--- a/patches/@didit-protocol+sdk-react-native+3.2.8.patch
+++ b/patches/@didit-protocol+sdk-react-native+3.2.8.patch
@@ -1,0 +1,13 @@
+diff --git a/node_modules/@didit-protocol/sdk-react-native/app.plugin.js b/node_modules/@didit-protocol/sdk-react-native/app.plugin.js
+index 7943542..b2c9988 100644
+--- a/node_modules/@didit-protocol/sdk-react-native/app.plugin.js
++++ b/node_modules/@didit-protocol/sdk-react-native/app.plugin.js
+@@ -12,7 +12,7 @@ const MAVEN_REPO =
+ const MAVEN_LINE = `        maven { url "${MAVEN_REPO}" }`;
+ 
+ const PODSPEC_URL =
+-  'https://raw.githubusercontent.com/didit-protocol/sdk-ios/main/DiditSDK.podspec';
++  'https://raw.githubusercontent.com/didit-protocol/sdk-ios/3.2.13/DiditSDK.podspec';
+ 
+ const POD_LINE = `  pod 'DiditSDK', :podspec => '${PODSPEC_URL}'`;
+ 


### PR DESCRIPTION
## Summary
Updated the DiditSDK podspec URL reference to point to a specific stable version instead of the main branch.

## Changes
- Updated the `PODSPEC_URL` in the `@didit-protocol/sdk-react-native` app plugin to reference the `3.2.13` release tag instead of the `main` branch
  - Changed from: `https://raw.githubusercontent.com/didit-protocol/sdk-ios/main/DiditSDK.podspec`
  - Changed to: `https://raw.githubusercontent.com/didit-protocol/sdk-ios/3.2.13/DiditSDK.podspec`

## Details
This change ensures that the iOS SDK dependency uses a pinned, stable version (3.2.13) rather than tracking the main branch, which can introduce unexpected changes and breaking updates. This improves build reproducibility and stability for React Native projects using this SDK.

https://claude.ai/code/session_013ovmPbLFvPhUCQq9qggyes