### PR TITLE
fix(ios): pin DiditSDK pod to 3.2.13 instead of tracking main

### DIFF
--- a/patches/@didit-protocol+sdk-react-native+3.2.8.patch
+++ b/patches/@didit-protocol+sdk-react-native+3.2.8.patch
@@ -1,5 +1,5 @@
 diff --git a/node_modules/@didit-protocol/sdk-react-native/app.plugin.js b/node_modules/@didit-protocol/sdk-react-native/app.plugin.js
-index 7943542..b2c9988 100644
+index 7943542..45ae038 100644
 --- a/node_modules/@didit-protocol/sdk-react-native/app.plugin.js
 +++ b/node_modules/@didit-protocol/sdk-react-native/app.plugin.js
 @@ -12,7 +12,7 @@ const MAVEN_REPO =
@@ -7,7 +7,7 @@ index 7943542..b2c9988 100644
  
  const PODSPEC_URL =
 -  'https://raw.githubusercontent.com/didit-protocol/sdk-ios/main/DiditSDK.podspec';
-+  'https://raw.githubusercontent.com/didit-protocol/sdk-ios/3.2.13/DiditSDK.podspec';
++  'https://raw.githubusercontent.com/didit-protocol/sdk-ios/3.2.9/DiditSDK.podspec';
  
  const POD_LINE = `  pod 'DiditSDK', :podspec => '${PODSPEC_URL}'`;
  

--- a/patches/@didit-protocol+sdk-react-native+3.2.8.patch
+++ b/patches/@didit-protocol+sdk-react-native+3.2.8.patch
@@ -1,0 +1,13 @@
+diff --git a/node_modules/@didit-protocol/sdk-react-native/app.plugin.js b/node_modules/@didit-protocol/sdk-react-native/app.plugin.js
+index 7943542..b2c9988 100644
+--- a/node_modules/@didit-protocol/sdk-react-native/app.plugin.js
++++ b/node_modules/@didit-protocol/sdk-react-native/app.plugin.js
+@@ -12,7 +12,7 @@ const MAVEN_REPO =
+ const MAVEN_LINE = `        maven { url "${MAVEN_REPO}" }`;
+ 
+ const PODSPEC_URL =
+-  'https://raw.githubusercontent.com/didit-protocol/sdk-ios/main/DiditSDK.podspec';
++  'https://raw.githubusercontent.com/didit-protocol/sdk-ios/3.2.13/DiditSDK.podspec';
+ 
+ const POD_LINE = `  pod 'DiditSDK', :podspec => '${PODSPEC_URL}'`;
+ 


### PR DESCRIPTION
## Summary
Cherry-pick of #2093 onto `qa`.

`@didit-protocol/sdk-react-native`'s Expo plugin injects the iOS Podfile entry pointing at `https://raw.githubusercontent.com/didit-protocol/sdk-ios/main/DiditSDK.podspec`. On 2026-05-25 that `main` branch was bumped to **4.0.0**, which no longer satisfies the `SdkReactNative.podspec` constraint `DiditSDK ~> 3.2`. Every iOS EAS build now fails at `pod install` with a CocoaPods version conflict.

This patches the plugin to use the `3.2.13` tagged podspec — the latest 3.2.x release that still ships the flat `DiditSDK.xcframework` + `OpenSSL.xcframework` that `patches/react-native-quick-crypto+0.7.17.patch` reuses for OpenSSL.

## Test plan
- [ ] Next iOS EAS build (fingerprint changes because `patches/` is in the fingerprint inputs) completes `pod install` without a DiditSDK version conflict
- [ ] Resulting build runs on device — KYC flow still launches Didit verification

https://claude.ai/code/session_013ovmPbLFvPhUCQq9qggyes

---
_Generated by [Claude Code](https://claude.ai/code/session_013ovmPbLFvPhUCQq9qggyes)_