### PR TITLE
fix(ios): repin DiditSDK pod to 3.2.9 to match wrapper's switch statements

### DIFF
--- a/patches/@didit-protocol+sdk-react-native+3.2.8.patch
+++ b/patches/@didit-protocol+sdk-react-native+3.2.8.patch
@@ -1,5 +1,5 @@
 diff --git a/node_modules/@didit-protocol/sdk-react-native/app.plugin.js b/node_modules/@didit-protocol/sdk-react-native/app.plugin.js
-index 7943542..b2c9988 100644
+index 7943542..45ae038 100644
 --- a/node_modules/@didit-protocol/sdk-react-native/app.plugin.js
 +++ b/node_modules/@didit-protocol/sdk-react-native/app.plugin.js
 @@ -12,7 +12,7 @@ const MAVEN_REPO =
@@ -7,7 +7,7 @@ index 7943542..b2c9988 100644
  
  const PODSPEC_URL =
 -  'https://raw.githubusercontent.com/didit-protocol/sdk-ios/main/DiditSDK.podspec';
-+  'https://raw.githubusercontent.com/didit-protocol/sdk-ios/3.2.13/DiditSDK.podspec';
++  'https://raw.githubusercontent.com/didit-protocol/sdk-ios/3.2.9/DiditSDK.podspec';
  
  const POD_LINE = `  pod 'DiditSDK', :podspec => '${PODSPEC_URL}'`;
  


### PR DESCRIPTION
## Summary
PR #2093 pinned the DiditSDK pod to `3.2.13` to unblock `pod install`. That fixed the version-resolution error, but the next build surfaced a second issue:

```
Build failed: switch must be exhaustive
```

`DiditSDK 3.2.10` added a new `.retryBlocked` case to `VerificationError`. The wrapper `@didit-protocol/sdk-react-native@3.2.8`'s `ios/DiditSdkBridge.swift` has a `mapErrorType` switch over `VerificationError` that only handles the original 4 cases — `.sessionExpired`, `.networkError`, `.cameraAccessDenied`, `.unknown`. Xcode rejects it.

`3.2.9` is the latest DiditSDK iOS release **before** the enum was extended, so the wrapper's switch is still exhaustive against it.

## Verification
Downloaded `DiditSDK-CocoaPods.zip` from GitHub releases for several versions and inspected `arm64-apple-ios.swiftinterface`:

| Version | `VerificationError` cases |
|---|---|
| 3.2.8 | sessionExpired, networkError, cameraAccessDenied, unknown |
| 3.2.9 | sessionExpired, networkError, cameraAccessDenied, unknown |
| 3.2.10 | sessionExpired, **retryBlocked**, networkError, cameraAccessDenied, unknown |
| 3.2.11 – 3.2.13 | (same 5-case shape as 3.2.10) |

`VerificationStatus` (3 cases) and `VerificationResult` are unchanged across 3.2.x, so the other switches in the bridge are unaffected.

## Test plan
- [ ] Next EAS iOS build gets past the Fastlane / Xcode build step
- [ ] Resulting build runs on device — KYC flow still launches Didit verification

https://claude.ai/code/session_013ovmPbLFvPhUCQq9qggyes

---
_Generated by [Claude Code](https://claude.ai/code/session_013ovmPbLFvPhUCQq9qggyes)_