### PR TITLE
fix(send): trigger validation on Max so Review enables immediately

### DIFF
--- a/components/Send/SendForm.tsx
+++ b/components/Send/SendForm.tsx
@@ -113,6 +113,7 @@ const SendForm: React.FC<SendFormProps> = ({ onNext }) => {
     handleSubmit,
     formState: { errors, isValid },
     setValue,
+    trigger,
   } = useForm({
     resolver: zodResolver(sendSchema),
     mode: Platform.OS === 'web' ? 'onChange' : undefined,
@@ -155,7 +156,12 @@ const SendForm: React.FC<SendFormProps> = ({ onNext }) => {
     const maxAmount = formatUnits(balanceWei, liveToken.contractDecimals);
     setAmount(maxAmount);
     setValue('amount', maxAmount);
-  }, [setAmount, setValue, liveToken, balanceWei]);
+    // RHF's onChange mode validates on the Controller's input change event,
+    // not on programmatic setValue. Without an explicit trigger, isValid
+    // stays at its prior value and Review stays disabled when the user
+    // hits Max without typing first.
+    trigger('amount');
+  }, [setAmount, setValue, trigger, liveToken, balanceWei]);
 
   const onSubmit = useCallback(
     (data: any) => {


### PR DESCRIPTION
## Summary
Cherry-pick of #2099 onto `qa`.

On the Send modal, clicking **Max** without typing first leaves the **Review** button disabled. `handleMaxPress` calls `setValue('amount', maxAmount)`, but RHF's `onChange` mode only re-runs the Zod schema when the `Controller`'s `TextInput` fires its own `onChange` — programmatic `setValue` doesn't re-validate, so `isValid` stays `false` and the Review button reads `disabled={!selectedToken || !isValid}`.

Call `trigger('amount')` after `setValue` — the same pattern `CardRepayForm` and `Unstake/RegularWithdrawForm` already use for the identical case.

## Test plan
- [ ] Open Send → pick a recipient → pick a token with non-zero balance
- [ ] Without typing in the amount field, click **Max** → Review becomes enabled
- [ ] Type a custom amount after Max → Review still tracks validity correctly

https://claude.ai/code/session_013ovmPbLFvPhUCQq9qggyes

---
_Generated by [Claude Code](https://claude.ai/code/session_013ovmPbLFvPhUCQq9qggyes)_