### PR TITLE
Add token rescue feature for recovering stuck USDC

### DIFF
--- a/app/(protected)/_layout.tsx
+++ b/app/(protected)/_layout.tsx
@@ -215,6 +215,13 @@ export default function ProtectedLayout() {
           presentation: 'fullScreenModal',
         }}
       />
+      <Stack.Screen
+        name="rescue-token"
+        options={{
+          headerShown: false,
+          animation: 'slide_from_right',
+        }}
+      />
     </Stack>
   );
 }

--- a/app/(protected)/rescue-token.tsx
+++ b/app/(protected)/rescue-token.tsx
@@ -1,0 +1,289 @@
+import { useMemo } from 'react';
+import { ActivityIndicator, View } from 'react-native';
+import Toast from 'react-native-toast-message';
+import { useRouter } from 'expo-router';
+import { useQuery } from '@tanstack/react-query';
+import { Image } from 'expo-image';
+import { Address, encodeFunctionData, erc20Abi, formatEther, formatUnits } from 'viem';
+import { mainnet } from 'viem/chains';
+import { useBalance, useReadContract } from 'wagmi';
+
+import Wallet from '@/assets/images/wallet';
+import PageLayout from '@/components/PageLayout';
+import TooltipPopover from '@/components/Tooltip';
+import { BackButton } from '@/components/ui/back-button';
+import { Button } from '@/components/ui/button';
+import Skeleton from '@/components/ui/skeleton';
+import { Text } from '@/components/ui/text';
+import { path } from '@/constants/path';
+import useRescueToken from '@/hooks/useRescueToken';
+import useUser from '@/hooks/useUser';
+import { getAsset } from '@/lib/assets';
+import { ADDRESSES } from '@/lib/config';
+import { Status } from '@/lib/types';
+import { cn, eclipseAddress, formatNumber } from '@/lib/utils';
+import { publicClient } from '@/lib/wagmi';
+
+const USDC_DECIMALS = 6;
+// Fallback gas units for a standard USDC transfer when on-chain estimation is unavailable
+// (e.g. user has 0 USDC and estimateContractGas reverts).
+const FALLBACK_USDC_TRANSFER_GAS = 65_000n;
+
+const GAS_INFO_TEXT =
+  'ETH is required to pay network fees to transfer your stuck tokens out. ' +
+  "If you don't have enough ETH, reach out to the Solid team and we can top up " +
+  'your wallet with the gas needed to recover your tokens.';
+
+export default function RescueToken() {
+  const router = useRouter();
+  const { user } = useUser();
+  const { rescue, status } = useRescueToken();
+
+  const eoaAddress = user?.walletAddress as Address | undefined;
+  const safeAddress = user?.safeAddress as Address | undefined;
+
+  const { data: usdcBalance, isLoading: isUsdcLoading } = useReadContract({
+    abi: erc20Abi,
+    address: ADDRESSES.ethereum.usdc,
+    functionName: 'balanceOf',
+    args: eoaAddress ? [eoaAddress] : undefined,
+    chainId: mainnet.id,
+    query: { enabled: !!eoaAddress },
+  });
+
+  const { data: ethBalance, isLoading: isEthLoading } = useBalance({
+    address: eoaAddress,
+    chainId: mainnet.id,
+    query: { enabled: !!eoaAddress },
+  });
+
+  const { data: gasCostWei, isLoading: isGasLoading } = useQuery({
+    queryKey: [
+      'rescue-token-gas',
+      mainnet.id,
+      eoaAddress,
+      safeAddress,
+      usdcBalance?.toString(),
+    ],
+    queryFn: async () => {
+      if (!eoaAddress || !safeAddress) return 0n;
+      const client = publicClient(mainnet.id);
+      const fees = await client.estimateFeesPerGas();
+      const gasPrice = fees.maxFeePerGas || fees.gasPrice || (await client.getGasPrice());
+
+      let gasUnits = FALLBACK_USDC_TRANSFER_GAS;
+      if (usdcBalance && usdcBalance > 0n) {
+        try {
+          gasUnits = await client.estimateGas({
+            account: eoaAddress,
+            to: ADDRESSES.ethereum.usdc,
+            data: encodeFunctionData({
+              abi: erc20Abi,
+              functionName: 'transfer',
+              args: [safeAddress, usdcBalance],
+            }),
+          });
+        } catch {
+          gasUnits = FALLBACK_USDC_TRANSFER_GAS;
+        }
+      }
+
+      return gasUnits * gasPrice;
+    },
+    enabled: !!eoaAddress && !!safeAddress,
+    staleTime: 30 * 1000,
+    gcTime: 60 * 1000,
+  });
+
+  const usdcAmount = useMemo(
+    () => (usdcBalance ? Number(formatUnits(usdcBalance, USDC_DECIMALS)) : 0),
+    [usdcBalance],
+  );
+  const ethAmount = useMemo(
+    () => (ethBalance ? Number(formatEther(ethBalance.value)) : 0),
+    [ethBalance],
+  );
+  const gasEthAmount = useMemo(
+    () => (gasCostWei ? Number(formatEther(gasCostWei)) : 0),
+    [gasCostWei],
+  );
+
+  const hasUsdc = (usdcBalance ?? 0n) > 0n;
+  const hasEnoughEth =
+    !!gasCostWei && !!ethBalance && ethBalance.value >= gasCostWei;
+  const isRescuing = status === Status.PENDING;
+  const isDisabled =
+    isRescuing ||
+    isUsdcLoading ||
+    isEthLoading ||
+    isGasLoading ||
+    !hasUsdc ||
+    !hasEnoughEth;
+
+  const getButtonText = () => {
+    if (isRescuing) return 'Rescuing...';
+    if (!hasUsdc) return 'No USDC to rescue';
+    if (!hasEnoughEth) return 'Insufficient ETH for gas';
+    return 'Rescue tokens';
+  };
+
+  const handleRescue = async () => {
+    if (!usdcBalance || usdcBalance <= 0n) return;
+    try {
+      const txHash = await rescue(usdcBalance);
+      Toast.show({
+        type: 'success',
+        text1: 'Tokens rescued',
+        text2: `${formatNumber(usdcAmount)} USDC sent to your Solid wallet`,
+        props: {
+          link: `https://etherscan.io/tx/${txHash}`,
+          linkText: eclipseAddress(txHash),
+          image: { type: 'image', source: getAsset('images/usdc-4x.png') },
+        },
+      });
+      router.replace(path.HOME);
+    } catch (err) {
+      Toast.show({
+        type: 'error',
+        text1: 'Rescue failed',
+        text2: err instanceof Error ? err.message : 'Please try again',
+        props: { badgeText: '' },
+      });
+    }
+  };
+
+  return (
+    <PageLayout desktopOnly contentClassName="pb-10">
+      <View className="mx-auto w-full max-w-lg px-4 pt-8">
+        <View className="flex-row items-center justify-between">
+          <BackButton onPress={() => router.replace(path.HOME)} />
+          <Text className="text-center text-xl font-semibold text-white md:text-2xl">
+            Rescue tokens
+          </Text>
+          <View style={{ width: 40 }} />
+        </View>
+
+        <View className="mb-10 mt-8">
+          <View className="rounded-2xl border border-white/5 bg-[#1C1C1C] px-6 pb-8 pt-10">
+            <Text className="text-center text-2xl font-bold text-white">
+              Recover stuck USDC
+            </Text>
+            <Text className="mb-6 mt-3 text-center text-base leading-tight text-[#ACACAC]">
+              USDC was sent to your signer wallet on Ethereum by mistake. Sign with your
+              passkey to move it into your Solid wallet.
+            </Text>
+
+            <View className="gap-4">
+              <BalanceRow
+                label="Stuck balance"
+                isLoading={isUsdcLoading}
+                value={
+                  <View className="flex-row items-center gap-2">
+                    <Image
+                      source={getAsset('images/usdc-4x.png')}
+                      alt="USDC"
+                      style={{ width: 28, height: 28 }}
+                    />
+                    <Text className="text-lg font-semibold text-white">
+                      {formatNumber(usdcAmount)} USDC
+                    </Text>
+                  </View>
+                }
+              />
+
+              <DestinationRow safeAddress={safeAddress} />
+
+              <BalanceRow
+                label={
+                  <View className="flex-row items-center gap-1.5">
+                    <Text className="text-base font-medium text-white opacity-70">
+                      Required ETH gas
+                    </Text>
+                    <TooltipPopover
+                      text={GAS_INFO_TEXT}
+                      side="top"
+                      analyticsContext="rescue_token_gas_tooltip"
+                    />
+                  </View>
+                }
+                isLoading={isGasLoading}
+                value={
+                  <View className="items-end">
+                    <View className="flex-row items-center gap-2">
+                      <Image
+                        source={getAsset('images/eth.png')}
+                        alt="ETH"
+                        style={{ width: 20, height: 20 }}
+                      />
+                      <Text className="text-base font-semibold text-white">
+                        {formatNumber(gasEthAmount, 6, 6)} ETH
+                      </Text>
+                    </View>
+                    <Text
+                      className={cn(
+                        'text-sm',
+                        hasEnoughEth ? 'opacity-50' : 'text-red-400',
+                      )}
+                    >
+                      {isEthLoading ? '—' : `Balance: ${formatNumber(ethAmount, 6, 6)} ETH`}
+                    </Text>
+                  </View>
+                }
+              />
+            </View>
+
+            <Button
+              variant="brand"
+              onPress={handleRescue}
+              disabled={isDisabled}
+              className="mt-8 h-14 w-full rounded-2xl"
+            >
+              {isRescuing && <ActivityIndicator color="black" />}
+              <Text className="text-base font-bold text-primary-foreground">
+                {getButtonText()}
+              </Text>
+            </Button>
+          </View>
+        </View>
+      </View>
+    </PageLayout>
+  );
+}
+
+function BalanceRow({
+  label,
+  value,
+  isLoading,
+}: {
+  label: React.ReactNode;
+  value: React.ReactNode;
+  isLoading?: boolean;
+}) {
+  return (
+    <View className="flex-row items-center justify-between rounded-2xl bg-accent p-4">
+      {typeof label === 'string' ? (
+        <Text className="text-base font-medium text-white opacity-70">{label}</Text>
+      ) : (
+        label
+      )}
+      {isLoading ? <Skeleton className="h-6 w-24 rounded-md" /> : value}
+    </View>
+  );
+}
+
+function DestinationRow({ safeAddress }: { safeAddress?: Address }) {
+  return (
+    <View className="flex-row items-center justify-between rounded-2xl bg-accent p-4">
+      <Text className="text-base font-medium text-white opacity-70">To</Text>
+      <View className="flex-row items-center gap-2">
+        <Wallet />
+        <View className="items-end">
+          <Text className="text-base font-semibold text-white">Solid wallet</Text>
+          <Text className="text-xs text-white opacity-50">
+            {safeAddress ? eclipseAddress(safeAddress, 6, 6) : ''}
+          </Text>
+        </View>
+      </View>
+    </View>
+  );
+}

--- a/app/(protected)/rescue-token.tsx
+++ b/app/(protected)/rescue-token.tsx
@@ -130,14 +130,14 @@ export default function RescueToken() {
   const handleRescue = async () => {
     if (!usdcBalance || usdcBalance <= 0n) return;
     try {
-      const txHash = await rescue(usdcBalance);
+      const { transactionHash } = await rescue(usdcBalance);
       Toast.show({
         type: 'success',
         text1: 'Tokens rescued',
         text2: `${formatNumber(usdcAmount)} USDC sent to your Solid wallet`,
         props: {
-          link: `https://etherscan.io/tx/${txHash}`,
-          linkText: eclipseAddress(txHash),
+          link: `https://etherscan.io/tx/${transactionHash}`,
+          linkText: eclipseAddress(transactionHash),
           image: { type: 'image', source: getAsset('images/usdc-4x.png') },
         },
       });

--- a/constants/path.ts
+++ b/constants/path.ts
@@ -45,6 +45,7 @@ type Path = {
   ADD_REFERRER: Href;
   QUEST_WALLET: Route;
   QR_SCANNER: Route;
+  RESCUE_TOKEN: Href;
 };
 
 export const path: Path = {
@@ -94,4 +95,5 @@ export const path: Path = {
   QUEST_WALLET: '/quest-wallet',
   // Note: Type assertion needed because Expo Router types are regenerated at dev server start
   QR_SCANNER: '/qr-scanner' as Route,
+  RESCUE_TOKEN: '/rescue-token' as Href,
 };

--- a/constants/transaction.ts
+++ b/constants/transaction.ts
@@ -106,4 +106,8 @@ export const TRANSACTION_DETAILS: Record<TransactionType, TransactionDetails> = 
     sign: TransactionDirection.OUT,
     category: TransactionCategory.SAVINGS_ACCOUNT,
   },
+  [TransactionType.RESCUE_TOKEN]: {
+    sign: TransactionDirection.IN,
+    category: TransactionCategory.WALLET_TRANSFER,
+  },
 };

--- a/hooks/useRescueToken.ts
+++ b/hooks/useRescueToken.ts
@@ -6,19 +6,30 @@ import {
   Address,
   createWalletClient,
   erc20Abi,
+  formatUnits,
   hashTypedData,
   http,
 } from 'viem';
 import { mainnet } from 'viem/chains';
 
 import { ADDRESSES } from '@/lib/config';
-import { Status } from '@/lib/types';
+import { Status, TransactionStatus, TransactionType } from '@/lib/types';
 import { publicClient, rpcUrls } from '@/lib/wagmi';
 
+import { useActivityActions } from './useActivityActions';
 import useUser from './useUser';
 
+const USDC_DECIMALS = 6;
+const RESCUE_CHAIN_ID = mainnet.id;
+const RESCUE_EXPLORER = 'https://etherscan.io';
+
+type RescueResult = {
+  transactionHash: `0x${string}`;
+  clientTxId: string;
+};
+
 type UseRescueTokenReturn = {
-  rescue: (amountWei: bigint) => Promise<`0x${string}`>;
+  rescue: (amountWei: bigint) => Promise<RescueResult>;
   status: Status;
   error: string | null;
   reset: () => void;
@@ -27,6 +38,7 @@ type UseRescueTokenReturn = {
 const useRescueToken = (): UseRescueTokenReturn => {
   const { user } = useUser();
   const { createHttpClient } = useTurnkey();
+  const { createActivity, updateActivity } = useActivityActions();
   const [status, setStatus] = useState<Status>(Status.IDLE);
   const [error, setError] = useState<string | null>(null);
 
@@ -36,11 +48,30 @@ const useRescueToken = (): UseRescueTokenReturn => {
   }, []);
 
   const rescue = useCallback(
-    async (amountWei: bigint): Promise<`0x${string}`> => {
+    async (amountWei: bigint): Promise<RescueResult> => {
       if (!user?.walletAddress) throw new Error('Wallet address not found');
       if (!user?.safeAddress) throw new Error('Safe address not found');
       if (!user?.suborgId) throw new Error('Sub-organization not found');
       if (amountWei <= 0n) throw new Error('Amount must be greater than 0');
+
+      const amount = formatUnits(amountWei, USDC_DECIMALS);
+
+      const clientTxId = await createActivity({
+        type: TransactionType.RESCUE_TOKEN,
+        title: `Rescue ${amount} USDC`,
+        shortTitle: 'Rescue',
+        amount,
+        symbol: 'USDC',
+        chainId: RESCUE_CHAIN_ID,
+        fromAddress: user.walletAddress,
+        toAddress: user.safeAddress,
+        status: TransactionStatus.PENDING,
+        metadata: {
+          description: `Rescue ${amount} USDC from signer wallet to Solid wallet`,
+          tokenAddress: ADDRESSES.ethereum.usdc,
+          tokenDecimals: USDC_DECIMALS.toString(),
+        },
+      });
 
       try {
         setStatus(Status.PENDING);
@@ -68,7 +99,7 @@ const useRescueToken = (): UseRescueTokenReturn => {
         const walletClient = createWalletClient({
           account: turnkeyAccount,
           chain: mainnet,
-          transport: http(rpcUrls[mainnet.id]),
+          transport: http(rpcUrls[RESCUE_CHAIN_ID]),
         });
 
         const txHash = await walletClient.writeContract({
@@ -78,24 +109,57 @@ const useRescueToken = (): UseRescueTokenReturn => {
           args: [user.safeAddress as Address, amountWei],
         });
 
-        const receipt = await publicClient(mainnet.id).waitForTransactionReceipt({
+        await updateActivity(clientTxId, {
+          status: TransactionStatus.PROCESSING,
+          hash: txHash,
+          url: `${RESCUE_EXPLORER}/tx/${txHash}`,
+          metadata: { submittedAt: new Date().toISOString() },
+        });
+
+        const receipt = await publicClient(RESCUE_CHAIN_ID).waitForTransactionReceipt({
           hash: txHash,
         });
 
         if (receipt.status !== 'success') {
+          await updateActivity(clientTxId, {
+            status: TransactionStatus.FAILED,
+            hash: txHash,
+            url: `${RESCUE_EXPLORER}/tx/${txHash}`,
+            metadata: {
+              error: 'Transaction reverted on-chain',
+              failedAt: new Date().toISOString(),
+            },
+          });
           throw new Error('Rescue transaction reverted on-chain');
         }
 
+        await updateActivity(clientTxId, {
+          status: TransactionStatus.SUCCESS,
+          hash: txHash,
+          url: `${RESCUE_EXPLORER}/tx/${txHash}`,
+          metadata: { confirmedAt: new Date().toISOString() },
+        });
+
         setStatus(Status.SUCCESS);
-        return txHash;
+        return { transactionHash: txHash, clientTxId };
       } catch (err) {
         const message = err instanceof Error ? err.message : 'Failed to rescue tokens';
+
+        await updateActivity(clientTxId, {
+          status: TransactionStatus.FAILED,
+          metadata: {
+            error: message,
+            failedAt: new Date().toISOString(),
+          },
+        });
+
         Sentry.captureException(err, {
           tags: { type: 'rescue_token_error' },
           extra: {
             amountWei: amountWei.toString(),
             walletAddress: user.walletAddress,
             safeAddress: user.safeAddress,
+            clientTxId,
           },
           user: { id: user.userId, address: user.safeAddress },
         });
@@ -104,7 +168,7 @@ const useRescueToken = (): UseRescueTokenReturn => {
         throw err;
       }
     },
-    [createHttpClient, user],
+    [createActivity, updateActivity, createHttpClient, user],
   );
 
   return { rescue, status, error, reset };

--- a/hooks/useRescueToken.ts
+++ b/hooks/useRescueToken.ts
@@ -1,0 +1,113 @@
+import { useCallback, useState } from 'react';
+import * as Sentry from '@sentry/react-native';
+import { StamperType, useTurnkey } from '@turnkey/react-native-wallet-kit';
+import { createAccount } from '@turnkey/viem';
+import {
+  Address,
+  createWalletClient,
+  erc20Abi,
+  hashTypedData,
+  http,
+} from 'viem';
+import { mainnet } from 'viem/chains';
+
+import { ADDRESSES } from '@/lib/config';
+import { Status } from '@/lib/types';
+import { publicClient, rpcUrls } from '@/lib/wagmi';
+
+import useUser from './useUser';
+
+type UseRescueTokenReturn = {
+  rescue: (amountWei: bigint) => Promise<`0x${string}`>;
+  status: Status;
+  error: string | null;
+  reset: () => void;
+};
+
+const useRescueToken = (): UseRescueTokenReturn => {
+  const { user } = useUser();
+  const { createHttpClient } = useTurnkey();
+  const [status, setStatus] = useState<Status>(Status.IDLE);
+  const [error, setError] = useState<string | null>(null);
+
+  const reset = useCallback(() => {
+    setStatus(Status.IDLE);
+    setError(null);
+  }, []);
+
+  const rescue = useCallback(
+    async (amountWei: bigint): Promise<`0x${string}`> => {
+      if (!user?.walletAddress) throw new Error('Wallet address not found');
+      if (!user?.safeAddress) throw new Error('Safe address not found');
+      if (!user?.suborgId) throw new Error('Sub-organization not found');
+      if (amountWei <= 0n) throw new Error('Amount must be greater than 0');
+
+      try {
+        setStatus(Status.PENDING);
+        setError(null);
+
+        const passkeyClient = createHttpClient({
+          defaultStamperType: StamperType.Passkey,
+        });
+
+        const turnkeyAccount = await createAccount({
+          client: passkeyClient,
+          organizationId: user.suborgId,
+          signWith: user.walletAddress,
+        });
+
+        // Same workaround as useUser.safeAA: route signTypedData through raw sign
+        if (turnkeyAccount.sign) {
+          const originalSign = turnkeyAccount.sign.bind(turnkeyAccount);
+          turnkeyAccount.signTypedData = async (typedData: any) => {
+            const hash = hashTypedData(typedData);
+            return originalSign({ hash });
+          };
+        }
+
+        const walletClient = createWalletClient({
+          account: turnkeyAccount,
+          chain: mainnet,
+          transport: http(rpcUrls[mainnet.id]),
+        });
+
+        const txHash = await walletClient.writeContract({
+          address: ADDRESSES.ethereum.usdc,
+          abi: erc20Abi,
+          functionName: 'transfer',
+          args: [user.safeAddress as Address, amountWei],
+        });
+
+        const receipt = await publicClient(mainnet.id).waitForTransactionReceipt({
+          hash: txHash,
+        });
+
+        if (receipt.status !== 'success') {
+          throw new Error('Rescue transaction reverted on-chain');
+        }
+
+        setStatus(Status.SUCCESS);
+        return txHash;
+      } catch (err) {
+        const message = err instanceof Error ? err.message : 'Failed to rescue tokens';
+        Sentry.captureException(err, {
+          tags: { type: 'rescue_token_error' },
+          extra: {
+            amountWei: amountWei.toString(),
+            walletAddress: user.walletAddress,
+            safeAddress: user.safeAddress,
+          },
+          user: { id: user.userId, address: user.safeAddress },
+        });
+        setStatus(Status.ERROR);
+        setError(message);
+        throw err;
+      }
+    },
+    [createHttpClient, user],
+  );
+
+  return { rescue, status, error, reset };
+};
+
+export default useRescueToken;

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -689,6 +689,7 @@ export enum TransactionType {
   FAST_WITHDRAW = 'fast_withdraw',
   REPAY_AND_WITHDRAW_COLLATERAL = 'repay_and_withdraw_collateral',
   WITHDRAW_COLLATERAL = 'withdraw_collateral',
+  RESCUE_TOKEN = 'rescue_token',
 }
 
 export enum TransactionDirection {


### PR DESCRIPTION
## Summary
This PR adds a new token rescue feature that allows users to recover USDC that was accidentally sent to their signer wallet on Ethereum instead of their Solid Safe wallet.

## Key Changes
- **New rescue token page** (`app/(protected)/rescue-token.tsx`): A dedicated UI for the token recovery flow that displays:
  - Stuck USDC balance in the signer wallet
  - Destination Safe wallet address
  - Required ETH gas fees with helpful tooltip
  - Action button to initiate the rescue transaction

- **New rescue token hook** (`hooks/useRescueToken.ts`): Core logic for executing the rescue transaction that:
  - Validates user wallet and Safe addresses
  - Creates a Turnkey passkey-authenticated account
  - Executes an ERC20 transfer of USDC to the user's Safe wallet
  - Waits for transaction confirmation and validates success
  - Includes comprehensive error handling and Sentry logging

- **Gas estimation**: Intelligently estimates gas costs for the USDC transfer with:
  - On-chain gas estimation when user has USDC balance
  - Fallback gas estimate (65,000 units) when estimation fails
  - Proper fee calculation using maxFeePerGas or gasPrice

- **Navigation and routing**: 
  - Added rescue-token route to protected layout with slide animation
  - Added RESCUE_TOKEN path constant for navigation

## Notable Implementation Details
- Uses Turnkey's passkey authentication for secure transaction signing
- Implements a workaround for `signTypedData` by routing through raw sign (consistent with existing `useUser.safeAA` pattern)
- Includes user-friendly error messages and success toasts with Etherscan links
- Validates sufficient ETH balance before allowing rescue attempt
- Properly handles edge cases like zero USDC balance and gas estimation failures

https://claude.ai/code/session_01U9boKN8kBrUytLY72BfSbB