### PR TITLE
Track user platform (iOS/Android/Web) for quest verification

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -46,6 +46,7 @@ import { getInfoClient } from '@/graphql/clients';
 import { useAttributionInitialization } from '@/hooks/useAttributionInitialization';
 import { usePushNotifications } from '@/hooks/usePushNotifications';
 import { useTrackingTransparency } from '@/hooks/useTrackingTransparency';
+import { useTrackUserPlatform } from '@/hooks/useTrackUserPlatform';
 import { useWhatsNew } from '@/hooks/useWhatsNew';
 import { initAnalytics, track, trackScreen } from '@/lib/analytics';
 import { EXPO_PUBLIC_ENVIRONMENT, isProduction } from '@/lib/config';
@@ -202,6 +203,9 @@ export default Sentry.wrap(function RootLayout() {
 
   // Push notification lifecycle: token refresh + notification tap handling
   usePushNotifications();
+
+  // Record platform (ios/android/web) on the user once per session
+  useTrackUserPlatform();
 
   // App Tracking Transparency (iOS only)
   const {

--- a/hooks/useTrackUserPlatform.ts
+++ b/hooks/useTrackUserPlatform.ts
@@ -1,0 +1,32 @@
+import { useEffect, useRef } from 'react';
+import { Platform } from 'react-native';
+
+import { trackUserPlatform } from '@/lib/api';
+import { useUserStore } from '@/store/useUserStore';
+
+const SUPPORTED_PLATFORMS = new Set<typeof Platform.OS>(['ios', 'android', 'web']);
+
+/**
+ * Records the current platform (ios/android/web) on the authenticated user's
+ * `platforms` array so backend quest checks (e.g. Layer3 "download the native
+ * app") can verify which surfaces a user has actually opened the app from.
+ * Fires once per app launch per authenticated session.
+ */
+export function useTrackUserPlatform() {
+  const isAuthenticated = useUserStore(state =>
+    state.users.some(u => u.selected && !!u.tokens?.accessToken),
+  );
+  const hasTrackedRef = useRef(false);
+
+  useEffect(() => {
+    if (!isAuthenticated) return;
+    if (hasTrackedRef.current) return;
+    if (!SUPPORTED_PLATFORMS.has(Platform.OS)) return;
+
+    hasTrackedRef.current = true;
+    trackUserPlatform(Platform.OS).catch(err => {
+      hasTrackedRef.current = false;
+      console.warn('Failed to track user platform:', err);
+    });
+  }, [isAuthenticated]);
+}

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -2775,6 +2775,21 @@ export const removePushToken = async (token: string) => {
   return response.json();
 };
 
+export const trackUserPlatform = async (platform: typeof Platform.OS) => {
+  const jwt = getJWTToken();
+  const response = await fetch(`${EXPO_PUBLIC_FLASH_API_BASE_URL}/accounts/v1/users/platforms`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...getPlatformHeaders(),
+      ...(jwt ? { Authorization: `Bearer ${jwt}` } : {}),
+    },
+    credentials: 'include',
+    body: JSON.stringify({ platform }),
+  });
+  if (!response.ok) throw response;
+};
+
 export const fetchSavingsSummary = async (
   vault: string = 'USDC',
 ): Promise<SavingsSummaryResponse> => {


### PR DESCRIPTION
## Summary
Add platform tracking functionality to record which surfaces (iOS, Android, or Web) users have accessed the app from. This enables backend quest checks to verify platform-specific requirements, such as Layer3's "download the native app" quest.

## Changes
- **New hook `useTrackUserPlatform`**: Automatically records the current platform once per authenticated session on app launch
  - Fires only when user is authenticated
  - Prevents duplicate tracking with a ref-based guard
  - Gracefully handles failures with error logging
  - Supports iOS, Android, and Web platforms

- **New API endpoint `trackUserPlatform`**: POST request to `/accounts/v1/users/platforms` that sends the platform identifier to the backend
  - Includes JWT authentication when available
  - Uses standard platform headers and credentials

- **Integration in root layout**: Hook is initialized at the app root level to ensure it runs once per session for all authenticated users

## Implementation Details
- Uses `useRef` to ensure the platform is tracked only once per session, even if the authentication state changes
- Silently fails with a console warning if the API call fails, allowing the app to continue functioning
- Only tracks supported platforms (iOS, Android, Web) to avoid sending invalid values

https://claude.ai/code/session_0189ZJf487m6dczN4NKQhbrK