### PR TITLE
feat(layer3): record user platform on app load for native-app quest

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -46,6 +46,7 @@ import { getInfoClient } from '@/graphql/clients';
 import { useAttributionInitialization } from '@/hooks/useAttributionInitialization';
 import { usePushNotifications } from '@/hooks/usePushNotifications';
 import { useTrackingTransparency } from '@/hooks/useTrackingTransparency';
+import { useTrackUserPlatform } from '@/hooks/useTrackUserPlatform';
 import { useWhatsNew } from '@/hooks/useWhatsNew';
 import { initAnalytics, track, trackScreen } from '@/lib/analytics';
 import { EXPO_PUBLIC_ENVIRONMENT, isProduction } from '@/lib/config';
@@ -202,6 +203,9 @@ export default Sentry.wrap(function RootLayout() {
 
   // Push notification lifecycle: token refresh + notification tap handling
   usePushNotifications();
+
+  // Record platform (ios/android/web) on the user once per session
+  useTrackUserPlatform();
 
   // App Tracking Transparency (iOS only)
   const {

--- a/hooks/useTrackUserPlatform.ts
+++ b/hooks/useTrackUserPlatform.ts
@@ -1,0 +1,32 @@
+import { useEffect, useRef } from 'react';
+import { Platform } from 'react-native';
+
+import { trackUserPlatform } from '@/lib/api';
+import { useUserStore } from '@/store/useUserStore';
+
+const SUPPORTED_PLATFORMS = new Set<typeof Platform.OS>(['ios', 'android', 'web']);
+
+/**
+ * Records the current platform (ios/android/web) on the authenticated user's
+ * `platforms` array so backend quest checks (e.g. Layer3 "download the native
+ * app") can verify which surfaces a user has actually opened the app from.
+ * Fires once per app launch per authenticated session.
+ */
+export function useTrackUserPlatform() {
+  const isAuthenticated = useUserStore(state =>
+    state.users.some(u => u.selected && !!u.tokens?.accessToken),
+  );
+  const hasTrackedRef = useRef(false);
+
+  useEffect(() => {
+    if (!isAuthenticated) return;
+    if (hasTrackedRef.current) return;
+    if (!SUPPORTED_PLATFORMS.has(Platform.OS)) return;
+
+    hasTrackedRef.current = true;
+    trackUserPlatform(Platform.OS).catch(err => {
+      hasTrackedRef.current = false;
+      console.warn('Failed to track user platform:', err);
+    });
+  }, [isAuthenticated]);
+}

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -2668,6 +2668,21 @@ export const removePushToken = async (token: string) => {
   return response.json();
 };
 
+export const trackUserPlatform = async (platform: typeof Platform.OS) => {
+  const jwt = getJWTToken();
+  const response = await fetch(`${EXPO_PUBLIC_FLASH_API_BASE_URL}/accounts/v1/users/platforms`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...getPlatformHeaders(),
+      ...(jwt ? { Authorization: `Bearer ${jwt}` } : {}),
+    },
+    credentials: 'include',
+    body: JSON.stringify({ platform }),
+  });
+  if (!response.ok) throw response;
+};
+
 export const fetchSavingsSummary = async (
   vault: string = 'USDC',
 ): Promise<SavingsSummaryResponse> => {


### PR DESCRIPTION
## Summary

Promotes the Layer3 native-app quest client-side tracking to master. Cherry-picked from #2105 (merged to qa).

- New `trackUserPlatform()` API function hitting `POST /accounts/v1/users/platforms`
- New `useTrackUserPlatform` hook — fires once per authenticated session with `Platform.OS`, in-memory ref guard prevents duplicate calls
- Wired into `app/_layout.tsx` next to `usePushNotifications()`

Pairs with backend PR Solid-Money/solid-backend#1479.

## Test plan

- [ ] Verify on qa first via #2105 before merging this
- [ ] Confirm POST hits `/accounts/v1/users/platforms` exactly once per app launch with the correct `Platform.OS` value

---
_Generated by [Claude Code](https://claude.ai/code/session_0189ZJf487m6dczN4NKQhbrK)_