### PR TITLE
feat(balances): enable BSC chain to surface stuck funds

### DIFF
--- a/components/Send/TokenSelector.tsx
+++ b/components/Send/TokenSelector.tsx
@@ -11,6 +11,7 @@ import { useWalletTokens } from '@/hooks/useWalletTokens';
 import getTokenIcon from '@/lib/getTokenIcon';
 import { TokenBalance } from '@/lib/types';
 import { cn, formatNumber } from '@/lib/utils';
+import { getChain } from '@/lib/wagmi';
 import { useSendStore } from '@/store/useSendStore';
 
 import ToInput from './ToInput';
@@ -24,11 +25,25 @@ const TokenSelector: React.FC = () => {
       setModal: state.setModal,
     })),
   );
-  const { ethereumTokens, fuseTokens, polygonTokens, baseTokens, arbitrumTokens } = useWalletTokens();
+  const {
+    ethereumTokens,
+    fuseTokens,
+    polygonTokens,
+    baseTokens,
+    arbitrumTokens,
+    bscTokens,
+  } = useWalletTokens();
 
   // Combine and sort tokens by USD value (descending)
   const allTokens = useMemo(() => {
-    const combined = [...ethereumTokens, ...fuseTokens, ...polygonTokens, ...baseTokens, ...arbitrumTokens];
+    const combined = [
+      ...ethereumTokens,
+      ...fuseTokens,
+      ...polygonTokens,
+      ...baseTokens,
+      ...arbitrumTokens,
+      ...bscTokens,
+    ];
     return combined.sort((a, b) => {
       const balanceA = Number(formatUnits(BigInt(a.balance || '0'), a.contractDecimals));
       const balanceUSD_A = balanceA * (a.quoteRate || 0);
@@ -38,7 +53,7 @@ const TokenSelector: React.FC = () => {
 
       return balanceUSD_B - balanceUSD_A; // Descending order
     });
-  }, [ethereumTokens, fuseTokens, polygonTokens, baseTokens, arbitrumTokens]);
+  }, [ethereumTokens, fuseTokens, polygonTokens, baseTokens, arbitrumTokens, bscTokens]);
 
   const handleTokenSelect = useCallback(
     (token: TokenBalance) => {
@@ -86,7 +101,8 @@ const TokenSelector: React.FC = () => {
                     <View className="flex-1">
                       <Text className="text-lg font-semibold">{token.contractTickerSymbol}</Text>
                       <Text className="text-sm font-medium opacity-50">
-                        {token.contractTickerSymbol} on {getBridgeChain(token.chainId).name}
+                        {token.contractTickerSymbol} on{' '}
+                        {getBridgeChain(token.chainId)?.name ?? getChain(token.chainId)?.name}
                       </Text>
                     </View>
                   </View>

--- a/constants/tokens.ts
+++ b/constants/tokens.ts
@@ -1,7 +1,7 @@
 import { Token } from '@cryptoalgebra/fuse-sdk';
 
 import { ImageSourcePropType } from 'react-native';
-import { arbitrum, base, fuse, mainnet } from 'viem/chains';
+import { arbitrum, base, bsc, fuse, mainnet } from 'viem/chains';
 import {
   BUSD,
   FUSD_V2,
@@ -43,6 +43,7 @@ export const NATIVE_TOKENS: Record<number, string> = {
   [fuse.id]: 'fuse-network-token',
   [base.id]: 'ETH',
   [arbitrum.id]: 'ETH',
+  [bsc.id]: 'BNB',
 };
 
 /** CoinGecko API coin ids */
@@ -51,6 +52,7 @@ export const NATIVE_COINGECKO_TOKENS: Record<number, string> = {
   [fuse.id]: 'fuse-network-token',
   [base.id]: 'ethereum',
   [arbitrum.id]: 'ethereum',
+  [bsc.id]: 'binancecoin',
 };
 
 export const TOKEN_IMAGES: Record<string, ImageSourcePropType> = {

--- a/hooks/useBalances.ts
+++ b/hooks/useBalances.ts
@@ -1,7 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 import { formatUnits, parseUnits, zeroAddress } from 'viem';
 import { getBalance, readContract } from 'viem/actions';
-import { arbitrum, base, fuse, mainnet } from 'viem/chains';
+import { arbitrum, base, bsc, fuse, mainnet } from 'viem/chains';
 
 import { NATIVE_COINGECKO_TOKENS, NATIVE_TOKENS } from '@/constants/tokens';
 import { fetchCoinSimplePrice, fetchTokenList, fetchTokenPriceUsd } from '@/lib/api';
@@ -60,6 +60,7 @@ interface BalanceData {
   polygonTokens: TokenBalance[];
   baseTokens: TokenBalance[];
   arbitrumTokens: TokenBalance[];
+  bscTokens: TokenBalance[];
   tokens: TokenBalance[];
   unifiedTokens: UnifiedTokenBalance[];
   isLoading: boolean;
@@ -75,6 +76,7 @@ const FUSE_CHAIN_ID = 122;
 const POLYGON_CHAIN_ID = 137;
 const BASE_CHAIN_ID = 8453;
 const ARBITRUM_CHAIN_ID = 42161;
+const BSC_CHAIN_ID = 56;
 
 // ABI for AccountantWithRateProviders getRate function
 const ACCOUNTANT_ABI = [
@@ -106,25 +108,31 @@ const fetchTokenBalances = async (safeAddress: string) => {
     fuseResponse,
     polygonResponse,
     arbitrumResponse,
+    bscResponse,
     soUSDRate,
     soFUSERate,
     ethBalance,
     fuseBalance,
     baseBalance,
     arbitrumBalance,
+    bscBalance,
     ethPrice,
     fusePrice,
     basePrice,
     arbitrumPrice,
+    bscPrice,
     tokenList,
   ] = await Promise.allSettled([
     // Token balances via the data-source dispatcher (Alchemy primary,
-    // Blockscout fallback). Fuse (122) skips Alchemy entirely.
+    // Blockscout fallback). Fuse (122) skips Alchemy entirely. BSC (56)
+    // is Alchemy-only — Blockscout has no BSC instance and returns [] on
+    // Alchemy failure.
     fetchTokenBalancesWithFallback(BASE_CHAIN_ID, safeAddress),
     fetchTokenBalancesWithFallback(ETHEREUM_CHAIN_ID, safeAddress),
     fetchTokenBalancesWithFallback(FUSE_CHAIN_ID, safeAddress),
     fetchTokenBalancesWithFallback(POLYGON_CHAIN_ID, safeAddress),
     fetchTokenBalancesWithFallback(ARBITRUM_CHAIN_ID, safeAddress),
+    fetchTokenBalancesWithFallback(BSC_CHAIN_ID, safeAddress),
     readContract(publicClient(mainnet.id), {
       address: ADDRESSES.ethereum.accountant,
       abi: ACCOUNTANT_ABI,
@@ -147,10 +155,14 @@ const fetchTokenBalances = async (safeAddress: string) => {
     getBalance(publicClient(arbitrum.id), {
       address: safeAddress as `0x${string}`,
     }),
+    getBalance(publicClient(bsc.id), {
+      address: safeAddress as `0x${string}`,
+    }),
     fetchTokenPriceUsd(NATIVE_TOKENS[mainnet.id]),
     fetchTokenPriceUsd(NATIVE_TOKENS[fuse.id]),
     fetchTokenPriceUsd(NATIVE_TOKENS[base.id]),
     fetchTokenPriceUsd(NATIVE_TOKENS[arbitrum.id]),
+    fetchTokenPriceUsd(NATIVE_TOKENS[bsc.id]),
     fetchTokenList({
       isActive: true,
     }),
@@ -161,6 +173,7 @@ const fetchTokenBalances = async (safeAddress: string) => {
   let polygonTokens: TokenBalance[] = [];
   let baseTokens: TokenBalance[] = [];
   let arbitrumTokens: TokenBalance[] = [];
+  let bscTokens: TokenBalance[] = [];
   let soUSDRateNum = 0;
   let soFUSEQuoteRateUSD = 0;
 
@@ -297,6 +310,19 @@ const fetchTokenBalances = async (safeAddress: string) => {
     console.warn('Failed to fetch Arbitrum balances:', arbitrumResponse.reason);
   }
 
+  // Process BSC tokens
+  if (bscResponse.status === PromiseStatus.FULFILLED) {
+    bscTokens = bscResponse.value
+      .filter(
+        item =>
+          item.token.type === TokenType.ERC20 &&
+          filterTokenList(tokenListData, BSC_CHAIN_ID, getAddress(item)),
+      )
+      .map(item => convertBlockscoutToTokenBalance(item, BSC_CHAIN_ID));
+  } else {
+    console.warn('Failed to fetch BSC balances:', bscResponse.reason);
+  }
+
   // Process native token balances
   if (ethBalance.status === PromiseStatus.FULFILLED && Number(ethBalance.value)) {
     const ethPriceValue = ethPrice.status === PromiseStatus.FULFILLED ? Number(ethPrice.value) : 0;
@@ -383,12 +409,34 @@ const fetchTokenBalances = async (safeAddress: string) => {
     });
   }
 
+  if (bscBalance.status === PromiseStatus.FULFILLED && Number(bscBalance.value)) {
+    const bscPriceValue =
+      bscPrice.status === PromiseStatus.FULFILLED ? Number(bscPrice.value) : 0;
+    const bscBnbTokenFromList = tokenListData.find(
+      token => token.chainId === BSC_CHAIN_ID && token.symbol === 'BNB',
+    );
+    bscTokens.push({
+      contractTickerSymbol: 'BNB',
+      contractName: 'BNB',
+      contractAddress: zeroAddress,
+      balance: bscBalance.value.toString(),
+      quoteRate: bscPriceValue,
+      contractDecimals: 18,
+      type: TokenType.NATIVE,
+      verified: true,
+      chainId: BSC_CHAIN_ID,
+      commonId: bscBnbTokenFromList?.commonId,
+      tokenId: bscBnbTokenFromList?.tokenId,
+    });
+  }
+
   let allTokens = [
     ...ethereumTokens,
     ...fuseTokens,
     ...polygonTokens,
     ...baseTokens,
     ...arbitrumTokens,
+    ...bscTokens,
   ];
 
   const isZeroRate = (r: number | null | undefined) =>
@@ -546,6 +594,7 @@ const fetchTokenBalances = async (safeAddress: string) => {
   const polygonTokensFinal = allTokens.filter(t => t.chainId === POLYGON_CHAIN_ID);
   const baseTokensFinal = allTokens.filter(t => t.chainId === BASE_CHAIN_ID);
   const arbitrumTokensFinal = allTokens.filter(t => t.chainId === ARBITRUM_CHAIN_ID);
+  const bscTokensFinal = allTokens.filter(t => t.chainId === BSC_CHAIN_ID);
 
   return {
     ...totals,
@@ -554,6 +603,7 @@ const fetchTokenBalances = async (safeAddress: string) => {
     polygonTokens: polygonTokensFinal,
     baseTokens: baseTokensFinal,
     arbitrumTokens: arbitrumTokensFinal,
+    bscTokens: bscTokensFinal,
     tokens: allTokens,
     unifiedTokens,
   };
@@ -590,6 +640,7 @@ export const useBalances = (): BalanceData => {
     polygonTokens: [],
     baseTokens: [],
     arbitrumTokens: [],
+    bscTokens: [],
     tokens: [],
     unifiedTokens: [],
   };

--- a/hooks/useWalletTokens.ts
+++ b/hooks/useWalletTokens.ts
@@ -19,6 +19,7 @@ export const useWalletTokens = () => {
     polygonTokens,
     baseTokens,
     arbitrumTokens,
+    bscTokens,
     tokens,
     unifiedTokens,
     isLoading,
@@ -34,8 +35,16 @@ export const useWalletTokens = () => {
       fuseTokens.length > 0 ||
       polygonTokens.length > 0 ||
       baseTokens.length > 0 ||
-      arbitrumTokens.length > 0,
-    [ethereumTokens.length, fuseTokens.length, polygonTokens.length, baseTokens.length, arbitrumTokens.length],
+      arbitrumTokens.length > 0 ||
+      bscTokens.length > 0,
+    [
+      ethereumTokens.length,
+      fuseTokens.length,
+      polygonTokens.length,
+      baseTokens.length,
+      arbitrumTokens.length,
+      bscTokens.length,
+    ],
   );
 
   const uniqueTokens = useMemo(
@@ -69,6 +78,7 @@ export const useWalletTokens = () => {
     polygonTokens,
     baseTokens,
     arbitrumTokens,
+    bscTokens,
     tokens,
     unifiedTokens,
     uniqueTokens,

--- a/lib/wagmi.ts
+++ b/lib/wagmi.ts
@@ -6,6 +6,7 @@ import {
   arbitrum,
   base,
   baseSepolia,
+  bsc,
   fuse,
   mainnet,
   polygon,
@@ -15,7 +16,7 @@ import { EXPO_PUBLIC_ALCHEMY_API_KEY } from './config';
 
 polyfill();
 
-const chains: [Chain, ...Chain[]] = [fuse, mainnet, polygon, base, baseSepolia, arbitrum];
+const chains: [Chain, ...Chain[]] = [fuse, mainnet, polygon, base, baseSepolia, arbitrum, bsc];
 
 export const getChain = (chainId: number): Chain | undefined => {
   return chains.find((chain: Chain) => chain.id === chainId);
@@ -28,6 +29,7 @@ export const rpcUrls: Record<number, string> = {
   [base.id]: `https://base-mainnet.g.alchemy.com/v2/${EXPO_PUBLIC_ALCHEMY_API_KEY}`,
   [baseSepolia.id]: `https://base-sepolia.g.alchemy.com/v2/${EXPO_PUBLIC_ALCHEMY_API_KEY}`,
   [arbitrum.id]: `https://arb-mainnet.g.alchemy.com/v2/${EXPO_PUBLIC_ALCHEMY_API_KEY}`,
+  [bsc.id]: `https://bnb-mainnet.g.alchemy.com/v2/${EXPO_PUBLIC_ALCHEMY_API_KEY}`,
 };
 
 const transports: Record<number, ReturnType<typeof http>> = {
@@ -37,6 +39,7 @@ const transports: Record<number, ReturnType<typeof http>> = {
   [base.id]: http(rpcUrls[base.id]),
   [baseSepolia.id]: http(rpcUrls[baseSepolia.id]),
   [arbitrum.id]: http(rpcUrls[arbitrum.id]),
+  [bsc.id]: http(rpcUrls[bsc.id]),
 };
 
 export const publicClient = (chainId: number) =>


### PR DESCRIPTION
Cherry-pick of the BSC enablement to `master`. Companion PR opens against `qa`.

## Summary
Enable BSC (chain 56) so users who accidentally sent BEP-20 tokens (e.g. Binance-Peg USDC from tx [0x7f395780](https://bscscan.com/tx/0x7f395780ef7ecb84e410eddcc4b2116a1b4d6966a9f445476c5400f273ec6986)) to their Solid safe address can see and transfer those funds.

### Changes
- `constants/alchemy.ts` — BSC added to Alchemy supported chains (`bnb-mainnet.g.alchemy.com`).
- `lib/wagmi.ts` — BSC wired into chains array, RPC URLs, and transports.
- `constants/tokens.ts` — BNB added to `NATIVE_TOKENS` and `NATIVE_COINGECKO_TOKENS`.
- `hooks/useBalances.ts` — fetches BSC ERC-20s via Alchemy dispatcher + native BNB via viem, processes into new `bscTokens` array.
- `hooks/useWalletTokens.ts` — re-exports `bscTokens`, includes in `hasTokens`.
- `components/Send/TokenSelector.tsx` — combines BSC into the token list; falls back to viem's chain name when `BRIDGE_TOKENS` has no entry for the chain.

### Data source
BSC is Alchemy-only — public Blockscout has no BSC instance. The existing `fetchTokenBalancesWithFallback` dispatcher returns `[]` from the Blockscout path if Alchemy fails.

### Backend action required (not in this PR)
Insert Binance-Peg USDC into the production `swap-tokens` collection:

```json
{
  "name": "Binance-Peg USD Coin",
  "symbol": "USDC",
  "address": "0x8AC76a51cc950d9822D68b83fE1Ad97B32Cd580d",
  "decimals": 18,
  "chainId": 56,
  "isActive": true
}
```

Note: 18 decimals (not 6 like canonical USDC).

## Test plan
- [ ] Insert BSC USDC row into `swap-tokens` collection in production Mongo.
- [ ] Confirm BSC USDC balance appears in wallet for the affected user's safe address.
- [ ] Send a small test amount of BSC USDC out via the Send flow to an external address.
- [ ] Verify existing chain balances still render correctly.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ThYo8D5jLeC2PfaiSGC7Ud)_