### PR TITLE
Add deep linking support for push notifications

### DIFF
--- a/hooks/usePushNotifications.ts
+++ b/hooks/usePushNotifications.ts
@@ -1,13 +1,26 @@
 import { useEffect } from 'react';
 import { Platform } from 'react-native';
 import * as Notifications from 'expo-notifications';
-import { useRouter } from 'expo-router';
+import { Href, useRouter } from 'expo-router';
 import messaging from '@react-native-firebase/messaging';
 
 import { path } from '@/constants/path';
 import { registerPushToken } from '@/lib/api';
 import { registerForPushNotificationsAsync } from '@/lib/registerForPushNotifications';
 import { useUserStore } from '@/store/useUserStore';
+
+/**
+ * Map a push notification's `type` (set by the backend) to an in-app route.
+ * Card payment notifications open the card screen; anything else goes home.
+ */
+function getNotificationRoute(type?: string): Href {
+  switch (type) {
+    case 'card-transaction':
+      return path.CARD;
+    default:
+      return path.HOME;
+  }
+}
 
 /**
  * Manages push notification lifecycle: token refresh and notification tap handling.
@@ -39,12 +52,13 @@ export function usePushNotifications() {
       }
     });
 
-    // Handle notification taps (user taps a notification from the system tray)
+    // Handle notification taps (user taps a notification from the system tray).
+    // Deep-link based on the `type` the backend set in the notification data;
+    // fall back to home for anything unrecognised.
     const notificationResponseSubscription = Notifications.addNotificationResponseReceivedListener(
-      _response => {
-        // Future: read _response.notification.request.content.data.route for deep linking
-        // e.g., router.replace(_response.notification.request.content.data.route as any);
-        router.replace(path.HOME);
+      response => {
+        const data = response.notification.request.content.data as { type?: string } | undefined;
+        router.replace(getNotificationRoute(data?.type));
       },
     );
 


### PR DESCRIPTION
## Summary
Implemented dynamic deep linking for push notifications based on the notification type sent by the backend, replacing the hardcoded navigation to the home screen.

## Key Changes
- Added `getNotificationRoute()` helper function that maps notification types to in-app routes
  - `card-transaction` notifications now navigate to the card screen
  - Unknown types default to the home screen
- Updated the notification response listener to extract the `type` from notification data and use it for routing
- Improved code comments to document the deep linking behavior and fallback logic
- Added proper TypeScript typing for the notification data object

## Implementation Details
- The `getNotificationRoute()` function uses a switch statement for extensibility, making it easy to add new notification types in the future
- The notification data is safely typed as `{ type?: string } | undefined` to handle cases where the backend may not include type information
- The implementation maintains backward compatibility by defaulting to home navigation for unrecognized types

https://claude.ai/code/session_01Wxoh4LSUztzSkDBgb66n67