### PR TITLE
Suppress client Amplitude for server-side emitted events

### DIFF
--- a/app/signup/creating.tsx
+++ b/app/signup/creating.tsx
@@ -254,16 +254,23 @@ export default function SignupCreating() {
         attribution_channel: attributionChannel,
       });
 
-      track(TRACKING_EVENTS.SIGNUP_COMPLETED, {
-        user_id: user._id,
-        username: user.username,
-        email: user.email,
-        referral_code: referralCode,
-        safe_address: safeAddress,
-        has_passkey: selectedUser.hasPasskey,
-        ...attributionData,
-        attribution_channel: attributionChannel,
-      });
+      // Amplitude is emitted server-side as "Account Created" (backend signup
+      // flow); suppress the client Amplitude event to avoid double-counting.
+      // Firebase + GTM still fire here to preserve web conversion attribution.
+      track(
+        TRACKING_EVENTS.SIGNUP_COMPLETED,
+        {
+          user_id: user._id,
+          username: user.username,
+          email: user.email,
+          referral_code: referralCode,
+          safe_address: safeAddress,
+          has_passkey: selectedUser.hasPasskey,
+          ...attributionData,
+          attribution_channel: attributionChannel,
+        },
+        { amplitude: false },
+      );
 
       // Navigate to home/notifications or redirectFrom page
       setStep('complete');

--- a/hooks/useBorrowAndDepositToCard.ts
+++ b/hooks/useBorrowAndDepositToCard.ts
@@ -133,13 +133,23 @@ const useBorrowAndDepositToCard = (): BridgeResult => {
           throw err;
         }
 
-        track(TRACKING_EVENTS.BRIDGE_TO_ARBITRUM_COMPLETED, {
-          amount: amountToBorrow,
-          transaction_hash: transactionResult.transactionHash,
-          from_chain: fuse.id,
-          to_chain: EXPO_PUBLIC_CARD_FUNDING_CHAIN_ID,
-          source: 'useBridgeToCard',
-        });
+        // Amplitude is emitted server-side as "Card Borrow Completed" (backend
+        // CardWelcomeBonusCron, once the BORROW_AND_DEPOSIT_TO_CARD activity
+        // settles on the card funding chain); suppress the client Amplitude event
+        // to avoid double-counting. Firebase + GTM still fire. Note: the generic
+        // bridge/swap-to-card hooks (useBridgeToCard, useSwapAndBridgeToCard) are
+        // NOT borrows and keep firing Amplitude.
+        track(
+          TRACKING_EVENTS.BRIDGE_TO_ARBITRUM_COMPLETED,
+          {
+            amount: amountToBorrow,
+            transaction_hash: transactionResult.transactionHash,
+            from_chain: fuse.id,
+            to_chain: EXPO_PUBLIC_CARD_FUNDING_CHAIN_ID,
+            source: 'useBridgeToCard',
+          },
+          { amplitude: false },
+        );
 
         Sentry.addBreadcrumb({
           message: 'Bridge to Card transaction successful',

--- a/hooks/useCardDepositPoller.ts
+++ b/hooks/useCardDepositPoller.ts
@@ -125,14 +125,21 @@ export const useCardDepositPoller = () => {
             // Track deposit completed via fallback mechanism
             // Note: This should rarely trigger since SSE is the primary update mechanism
             // If this fires frequently, investigate SSE reliability
-            track(TRACKING_EVENTS.CARD_DEPOSIT_COMPLETED, {
-              amount: Number(activity.amount),
-              token_symbol: activity.symbol,
-              chain_id: activity.chainId,
-              tx_hash: activity.hash,
-              // Flag to identify updates from fallback vs SSE in analytics
-              source: 'fallback_poller',
-            });
+            // Amplitude is emitted server-side as "Card Deposit Completed" (backend
+            // connect-wallet deposit workflow, CARD category); suppress client
+            // Amplitude to avoid double-counting. Firebase + GTM still fire.
+            track(
+              TRACKING_EVENTS.CARD_DEPOSIT_COMPLETED,
+              {
+                amount: Number(activity.amount),
+                token_symbol: activity.symbol,
+                chain_id: activity.chainId,
+                tx_hash: activity.hash,
+                // Flag to identify updates from fallback vs SSE in analytics
+                source: 'fallback_poller',
+              },
+              { amplitude: false },
+            );
           }),
         );
 

--- a/hooks/useDepositFromEOA.ts
+++ b/hooks/useDepositFromEOA.ts
@@ -785,21 +785,28 @@ const useDepositFromEOA = (
       });
 
       // Track deposit success with attribution for ROI measurement
-      track(TRACKING_EVENTS.DEPOSIT_COMPLETED, {
-        user_id: user?.userId,
-        safe_address: user?.safeAddress,
-        eoa_address: eoaAddress,
-        amount,
-        transaction_hash: txHash,
-        deposit_type: 'connected_wallet',
-        deposit_method: isEthereum ? 'ethereum_direct' : 'cross_chain_bridge',
-        chain_id: srcChainId,
-        chain_name: isEthereum ? 'ethereum' : BRIDGE_TOKENS[srcChainId]?.name,
-        is_sponsor: isSponsor,
-        is_first_deposit: !user?.isDeposited,
-        ...attributionData,
-        attribution_channel: attributionChannel,
-      });
+      // Amplitude is emitted server-side as "Savings Deposit Completed" (backend
+      // connect-wallet deposit workflow); suppress the client Amplitude event to
+      // avoid double-counting. Firebase + GTM still fire for web attribution.
+      track(
+        TRACKING_EVENTS.DEPOSIT_COMPLETED,
+        {
+          user_id: user?.userId,
+          safe_address: user?.safeAddress,
+          eoa_address: eoaAddress,
+          amount,
+          transaction_hash: txHash,
+          deposit_type: 'connected_wallet',
+          deposit_method: isEthereum ? 'ethereum_direct' : 'cross_chain_bridge',
+          chain_id: srcChainId,
+          chain_name: isEthereum ? 'ethereum' : BRIDGE_TOKENS[srcChainId]?.name,
+          is_sponsor: isSponsor,
+          is_first_deposit: !user?.isDeposited,
+          ...attributionData,
+          attribution_channel: attributionChannel,
+        },
+        { amplitude: false },
+      );
 
       trackIdentity(user?.userId, {
         last_deposit_amount: parseFloat(amount),

--- a/hooks/useDepositFromEOAEth.ts
+++ b/hooks/useDepositFromEOAEth.ts
@@ -274,21 +274,28 @@ const useDepositFromEOAEth = (
               },
             });
 
-            track(TRACKING_EVENTS.DEPOSIT_COMPLETED, {
-              user_id: user?.userId,
-              safe_address: user?.safeAddress,
-              eoa_address: eoaAddress,
-              amount,
-              transaction_hash: txHash,
-              deposit_type: 'connected_wallet',
-              deposit_method: 'eth_direct',
-              chain_id: srcChainId,
-              chain_name: 'ethereum',
-              is_sponsor: isSponsor,
-              is_first_deposit: !user?.isDeposited,
-              ...attributionData,
-              attribution_channel: attributionChannel,
-            });
+            // Amplitude emitted server-side as "Savings Deposit Completed";
+            // suppress client Amplitude to avoid double-counting (Firebase + GTM
+            // still fire).
+            track(
+              TRACKING_EVENTS.DEPOSIT_COMPLETED,
+              {
+                user_id: user?.userId,
+                safe_address: user?.safeAddress,
+                eoa_address: eoaAddress,
+                amount,
+                transaction_hash: txHash,
+                deposit_type: 'connected_wallet',
+                deposit_method: 'eth_direct',
+                chain_id: srcChainId,
+                chain_name: 'ethereum',
+                is_sponsor: isSponsor,
+                is_first_deposit: !user?.isDeposited,
+                ...attributionData,
+                attribution_channel: attributionChannel,
+              },
+              { amplitude: false },
+            );
 
             trackIdentity(user?.userId, {
               last_deposit_amount: parseFloat(amount),
@@ -416,21 +423,28 @@ const useDepositFromEOAEth = (
               },
             });
 
-            track(TRACKING_EVENTS.DEPOSIT_COMPLETED, {
-              user_id: user?.userId,
-              safe_address: user?.safeAddress,
-              eoa_address: eoaAddress,
-              amount,
-              transaction_hash: txHash,
-              deposit_type: 'connected_wallet',
-              deposit_method: 'eth_direct',
-              chain_id: srcChainId,
-              chain_name: 'ethereum',
-              is_sponsor: isSponsor,
-              is_first_deposit: !user?.isDeposited,
-              ...attributionData,
-              attribution_channel: attributionChannel,
-            });
+            // Amplitude emitted server-side as "Savings Deposit Completed";
+            // suppress client Amplitude to avoid double-counting (Firebase + GTM
+            // still fire).
+            track(
+              TRACKING_EVENTS.DEPOSIT_COMPLETED,
+              {
+                user_id: user?.userId,
+                safe_address: user?.safeAddress,
+                eoa_address: eoaAddress,
+                amount,
+                transaction_hash: txHash,
+                deposit_type: 'connected_wallet',
+                deposit_method: 'eth_direct',
+                chain_id: srcChainId,
+                chain_name: 'ethereum',
+                is_sponsor: isSponsor,
+                is_first_deposit: !user?.isDeposited,
+                ...attributionData,
+                attribution_channel: attributionChannel,
+              },
+              { amplitude: false },
+            );
 
             trackIdentity(user?.userId, {
               last_deposit_amount: parseFloat(amount),

--- a/hooks/useDepositFromEOAFuse.ts
+++ b/hooks/useDepositFromEOAFuse.ts
@@ -275,21 +275,28 @@ const useDepositFromEOAFuse = (
             });
 
             // Track deposit success with attribution for ROI measurement
-            track(TRACKING_EVENTS.DEPOSIT_COMPLETED, {
-              user_id: user?.userId,
-              safe_address: user?.safeAddress,
-              eoa_address: eoaAddress,
-              amount,
-              transaction_hash: txHash,
-              deposit_type: 'connected_wallet',
-              deposit_method: 'fuse_direct',
-              chain_id: srcChainId,
-              chain_name: 'fuse',
-              is_sponsor: isSponsor,
-              is_first_deposit: !user?.isDeposited,
-              ...attributionData,
-              attribution_channel: attributionChannel,
-            });
+            // Amplitude emitted server-side as "Savings Deposit Completed";
+            // suppress client Amplitude to avoid double-counting (Firebase + GTM
+            // still fire).
+            track(
+              TRACKING_EVENTS.DEPOSIT_COMPLETED,
+              {
+                user_id: user?.userId,
+                safe_address: user?.safeAddress,
+                eoa_address: eoaAddress,
+                amount,
+                transaction_hash: txHash,
+                deposit_type: 'connected_wallet',
+                deposit_method: 'fuse_direct',
+                chain_id: srcChainId,
+                chain_name: 'fuse',
+                is_sponsor: isSponsor,
+                is_first_deposit: !user?.isDeposited,
+                ...attributionData,
+                attribution_channel: attributionChannel,
+              },
+              { amplitude: false },
+            );
 
             trackIdentity(user?.userId, {
               last_deposit_amount: parseFloat(amount),
@@ -395,21 +402,27 @@ const useDepositFromEOAFuse = (
           },
         });
 
-        track(TRACKING_EVENTS.DEPOSIT_COMPLETED, {
-          user_id: user?.userId,
-          safe_address: user?.safeAddress,
-          eoa_address: eoaAddress,
-          amount,
-          transaction_hash: txHash,
-          deposit_type: 'connected_wallet',
-          deposit_method: 'fuse_direct',
-          chain_id: srcChainId,
-          chain_name: 'fuse',
-          is_sponsor: isSponsor,
-          is_first_deposit: !user?.isDeposited,
-          ...attributionData,
-          attribution_channel: attributionChannel,
-        });
+        // Amplitude emitted server-side as "Savings Deposit Completed"; suppress
+        // client Amplitude to avoid double-counting (Firebase + GTM still fire).
+        track(
+          TRACKING_EVENTS.DEPOSIT_COMPLETED,
+          {
+            user_id: user?.userId,
+            safe_address: user?.safeAddress,
+            eoa_address: eoaAddress,
+            amount,
+            transaction_hash: txHash,
+            deposit_type: 'connected_wallet',
+            deposit_method: 'fuse_direct',
+            chain_id: srcChainId,
+            chain_name: 'fuse',
+            is_sponsor: isSponsor,
+            is_first_deposit: !user?.isDeposited,
+            ...attributionData,
+            attribution_channel: attributionChannel,
+          },
+          { amplitude: false },
+        );
 
         trackIdentity(user?.userId, {
           last_deposit_amount: parseFloat(amount),

--- a/hooks/useDepositFromSolidEth.ts
+++ b/hooks/useDepositFromSolidEth.ts
@@ -242,18 +242,25 @@ const useDepositFromSolidEth = (
             data: { amount, safeAddress, srcChainId, isSponsor },
           });
 
-          track(TRACKING_EVENTS.DEPOSIT_COMPLETED, {
-            user_id: user?.userId,
-            safe_address: user?.safeAddress,
-            amount,
-            deposit_type: 'solid_wallet',
-            deposit_method: 'eth_solid',
-            chain_id: srcChainId,
-            is_sponsor: isSponsor,
-            is_first_deposit: !user?.isDeposited,
-            ...attributionData,
-            attribution_channel: attributionChannel,
-          });
+          // Amplitude emitted server-side as "Savings Deposit Completed";
+          // suppress client Amplitude to avoid double-counting (Firebase + GTM
+          // still fire).
+          track(
+            TRACKING_EVENTS.DEPOSIT_COMPLETED,
+            {
+              user_id: user?.userId,
+              safe_address: user?.safeAddress,
+              amount,
+              deposit_type: 'solid_wallet',
+              deposit_method: 'eth_solid',
+              chain_id: srcChainId,
+              is_sponsor: isSponsor,
+              is_first_deposit: !user?.isDeposited,
+              ...attributionData,
+              attribution_channel: attributionChannel,
+            },
+            { amplitude: false },
+          );
 
           trackIdentity(user?.userId!, {
             last_deposit_amount: parseFloat(amount),

--- a/hooks/useDepositFromSolidUsdc.ts
+++ b/hooks/useDepositFromSolidUsdc.ts
@@ -246,19 +246,27 @@ const useDepositFromSolidUsdc = (
               ? 'usdc_solid_bridge_card'
               : 'usdc_solid_bridge';
 
-          track(TRACKING_EVENTS.DEPOSIT_COMPLETED, {
-            user_id: user?.userId,
-            safe_address: user?.safeAddress,
-            amount,
-            deposit_type: 'solid_wallet',
-            deposit_method: depositMethod,
-            deposit_destination: isCard ? 'card' : 'savings',
-            chain_id: srcChainId,
-            is_sponsor: isSponsor,
-            is_first_deposit: !user?.isDeposited,
-            ...attributionData,
-            attribution_channel: attributionChannel,
-          });
+          // Amplitude emitted server-side by the backend connect-wallet deposit
+          // workflow ("Savings Deposit Completed" for savings, "Card Deposit
+          // Completed" for card); suppress client Amplitude to avoid double-
+          // counting. Firebase + GTM still fire for web attribution.
+          track(
+            TRACKING_EVENTS.DEPOSIT_COMPLETED,
+            {
+              user_id: user?.userId,
+              safe_address: user?.safeAddress,
+              amount,
+              deposit_type: 'solid_wallet',
+              deposit_method: depositMethod,
+              deposit_destination: isCard ? 'card' : 'savings',
+              chain_id: srcChainId,
+              is_sponsor: isSponsor,
+              is_first_deposit: !user?.isDeposited,
+              ...attributionData,
+              attribution_channel: attributionChannel,
+            },
+            { amplitude: false },
+          );
 
           trackIdentity(user?.userId!, {
             last_deposit_amount: parseFloat(amount),

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -205,8 +205,22 @@ const trackFirebaseEvent = async (event: string, params: Record<string, any>) =>
   }
 };
 
+export type TrackOptions = {
+  /**
+   * Whether to send this event to Amplitude. Defaults to true. Set to `false`
+   * for events that are now emitted server-side (backend Amplitude) to avoid
+   * double-counting. Firebase and GTM still fire, so web conversion / ad
+   * attribution is preserved.
+   */
+  amplitude?: boolean;
+};
+
 // Main track function with automatic attribution enrichment
-export const track = (event: string, params: Record<string, any> = {}) => {
+export const track = (
+  event: string,
+  params: Record<string, any> = {},
+  options: TrackOptions = {},
+) => {
   // Don't track events locally
   if (__DEV__) {
     return;
@@ -218,6 +232,8 @@ export const track = (event: string, params: Record<string, any> = {}) => {
       console.warn('Invalid event name provided to track():', event);
       return;
     }
+
+    const { amplitude = true } = options;
 
     // Get attribution data from store
     const attributionStore = useAttributionStore.getState();
@@ -244,9 +260,10 @@ export const track = (event: string, params: Record<string, any> = {}) => {
     // Sanitize all params once - remove undefined/null values and ensure serializable
     const sanitizedParams = sanitize(enrichedParams);
 
-    // Track to all providers in parallel
+    // Track to all providers in parallel. Amplitude can be opted out per-call
+    // for events now emitted server-side; Firebase + GTM always fire.
     Promise.allSettled([
-      Promise.resolve(trackAmplitudeEvent(event, sanitizedParams)),
+      amplitude ? Promise.resolve(trackAmplitudeEvent(event, sanitizedParams)) : undefined,
       trackFirebaseEvent(event, sanitizedParams),
       Promise.resolve(trackGTMEvent(event, sanitizedParams)),
     ]);


### PR DESCRIPTION
## Summary
This PR prevents double-counting of analytics events by suppressing client-side Amplitude tracking for events that are now emitted server-side by the backend. Firebase and GTM continue to fire to preserve web conversion and ad attribution.

## Key Changes
- Added `TrackOptions` type to `lib/analytics.ts` with an `amplitude` boolean flag (defaults to `true`)
- Updated the `track()` function to accept an optional `options` parameter and conditionally call `trackAmplitudeEvent()` based on the `amplitude` flag
- Suppressed client Amplitude (`{ amplitude: false }`) for the following events that are now emitted server-side:
  - **Deposit events**: `DEPOSIT_COMPLETED` in `useDepositFromEOAEth.ts`, `useDepositFromEOAFuse.ts`, `useDepositFromEOA.ts`, `useDepositFromSolidUsdc.ts`, and `useDepositFromSolidEth.ts`
  - **Signup event**: `SIGNUP_COMPLETED` in `app/signup/creating.tsx`
  - **Card/borrow events**: `BRIDGE_TO_ARBITRUM_COMPLETED` in `useBorrowAndDepositToCard.ts` and `CARD_DEPOSIT_COMPLETED` in `useCardDepositPoller.ts`
- Added explanatory comments to each suppressed event indicating which server-side event it corresponds to and confirming that Firebase + GTM still fire

## Implementation Details
- Firebase and GTM event tracking remain unaffected and continue to fire for all events, ensuring web conversion attribution is preserved
- The change is backward compatible—existing calls to `track()` without the options parameter continue to send to Amplitude by default
- Each modified call includes a comment explaining why Amplitude is suppressed and which backend event handles the server-side tracking

https://claude.ai/code/session_011g7dN8ScZ3Yr4U6fhYEsq5