### PR TITLE
Treat KYC DENIED status as final decision with no action button

### DIFF
--- a/hooks/useCardSteps/kycDisplayHelpers.ts
+++ b/hooks/useCardSteps/kycDisplayHelpers.ts
@@ -167,6 +167,8 @@ export function getKYCButtonText(
     case RainApplicationStatus.MANUAL_REVIEW:
       return 'Under Review';
     case RainApplicationStatus.DENIED:
+      // Final decision — verification cannot be overridden or resubmitted, so no action button.
+      return undefined;
     case RainApplicationStatus.LOCKED:
     case RainApplicationStatus.CANCELED:
       return 'Contact support';
@@ -187,11 +189,14 @@ export function isRainKYCButtonDisabled(
   rainApplicationStatus?: RainApplicationStatus | null,
 ): boolean {
   if (!rainApplicationStatus) return false;
-  // DENIED/LOCKED/CANCELED show "Contact support" and open Intercom — keep enabled
+  // No actionable button for APPROVED (step complete), PENDING/MANUAL_REVIEW (under review),
+  // or DENIED (final decision — cannot override or resubmit).
+  // LOCKED/CANCELED keep an enabled "Contact support" button that opens Intercom.
   return (
     rainApplicationStatus === RainApplicationStatus.APPROVED ||
     rainApplicationStatus === RainApplicationStatus.PENDING ||
-    rainApplicationStatus === RainApplicationStatus.MANUAL_REVIEW
+    rainApplicationStatus === RainApplicationStatus.MANUAL_REVIEW ||
+    rainApplicationStatus === RainApplicationStatus.DENIED
   );
 }
 
@@ -228,7 +233,7 @@ export function getStepDescription(
     if (warnings.length > 0) {
       return `We couldn't verify your identity:\n- ${formatKycWarnings(warnings)}`;
     }
-    return 'Your identity verification was declined. Please try again with a valid ID.';
+    return 'Your identity verification was declined. Please contact support for more information.';
   }
 
   // Didit resubmission or incomplete (including didit_forward_failed) — show reasons if available
@@ -329,9 +334,9 @@ export function getStepButtonText(
     return getKYCButtonText(options.rainApplicationStatus);
   }
 
-  // Didit KYC rejected — allow retry
+  // Didit KYC rejected — final decision; cannot be overridden or resubmitted, so no action button.
   if (options?.kycStatus === KycStatus.REJECTED) {
-    return 'Retry KYC';
+    return undefined;
   }
 
   // Didit incomplete — user needs to continue
@@ -392,6 +397,11 @@ export function isStepButtonDisabled(
 
   // Didit under review — disable button, user must wait
   if (options?.kycStatus === KycStatus.UNDER_REVIEW && !isRecognizedRainStatus) {
+    return true;
+  }
+
+  // Didit rejected — final decision, no action available
+  if (options?.kycStatus === KycStatus.REJECTED && !isRecognizedRainStatus) {
     return true;
   }
 

--- a/hooks/useCardSteps/useCardSteps.ts
+++ b/hooks/useCardSteps/useCardSteps.ts
@@ -196,11 +196,9 @@ export function useCardSteps(
     const status = cardStatusResponse?.rainApplicationStatus;
     const link = cardStatusResponse?.applicationExternalVerificationLink;
 
-    if (
-      status === RainApplicationStatus.DENIED ||
-      status === RainApplicationStatus.LOCKED ||
-      status === RainApplicationStatus.CANCELED
-    ) {
+    // DENIED is a final decision with no action — it renders no button, so it is not
+    // handled here. LOCKED/CANCELED still offer a "Contact support" button.
+    if (status === RainApplicationStatus.LOCKED || status === RainApplicationStatus.CANCELED) {
       openIntercom();
       return;
     }


### PR DESCRIPTION
## Summary
Updated KYC verification flow to treat DENIED status as a final decision that cannot be overridden or resubmitted, removing action buttons and preventing users from attempting retry actions.

## Key Changes
- **getKYCButtonText()**: Return `undefined` for `RainApplicationStatus.DENIED` instead of falling through to "Contact support"
- **isRainKYCButtonDisabled()**: Added `DENIED` to the list of statuses that disable the button, treating it as a non-actionable state
- **getStepDescription()**: Updated DENIED description from "Please try again with a valid ID" to "Please contact support for more information" to reflect that resubmission is not possible
- **getStepButtonText()**: Return `undefined` for `KycStatus.REJECTED` (Didit) instead of "Retry KYC", preventing retry attempts
- **isStepButtonDisabled()**: Added check to disable button for Didit `REJECTED` status when not a recognized Rain status
- **useCardSteps()**: Removed `DENIED` from the list of statuses that trigger Intercom opening, since DENIED now renders no button

## Implementation Details
The changes distinguish between three terminal KYC states:
- **DENIED/REJECTED**: Final decision with no action available (no button rendered)
- **LOCKED/CANCELED**: Final state but user can contact support (button enabled, opens Intercom)
- **APPROVED/PENDING/MANUAL_REVIEW**: Non-actionable states (button disabled but may be rendered)

This prevents users from attempting to resubmit or retry verification when their application has been definitively denied.

https://claude.ai/code/session_01S2muieprRUo3BGSh8yKBtR