### PR TITLE
Treat KYC DENIED status as final decision with no action button (master)

### DIFF
--- a/hooks/useCardSteps/kycDisplayHelpers.ts
+++ b/hooks/useCardSteps/kycDisplayHelpers.ts
@@ -169,6 +169,8 @@ export function getKYCButtonText(
     case RainApplicationStatus.MANUAL_REVIEW:
       return 'Under Review';
     case RainApplicationStatus.DENIED:
+      // Final decision — verification cannot be overridden or resubmitted, so no action button.
+      return undefined;
     case RainApplicationStatus.LOCKED:
     case RainApplicationStatus.CANCELED:
       return 'Contact support';
@@ -189,11 +191,14 @@ export function isRainKYCButtonDisabled(
   rainApplicationStatus?: RainApplicationStatus | null,
 ): boolean {
   if (!rainApplicationStatus) return false;
-  // DENIED/LOCKED/CANCELED show "Contact support" and open Intercom — keep enabled
+  // No actionable button for APPROVED (step complete), PENDING/MANUAL_REVIEW (under review),
+  // or DENIED (final decision — cannot override or resubmit).
+  // LOCKED/CANCELED keep an enabled "Contact support" button that opens Intercom.
   return (
     rainApplicationStatus === RainApplicationStatus.APPROVED ||
     rainApplicationStatus === RainApplicationStatus.PENDING ||
-    rainApplicationStatus === RainApplicationStatus.MANUAL_REVIEW
+    rainApplicationStatus === RainApplicationStatus.MANUAL_REVIEW ||
+    rainApplicationStatus === RainApplicationStatus.DENIED
   );
 }
 
@@ -230,7 +235,7 @@ export function getStepDescription(
     if (warnings.length > 0) {
       return `We couldn't verify your identity:\n- ${formatKycWarnings(warnings)}`;
     }
-    return 'Your identity verification was declined. Please try again with a valid ID.';
+    return 'Your identity verification was declined. Please contact support for more information.';
   }
 
   // Didit resubmission or incomplete (including didit_forward_failed) — show reasons if available
@@ -338,9 +343,9 @@ export function getStepButtonText(
     return getKYCButtonText(options.rainApplicationStatus);
   }
 
-  // Didit KYC rejected — allow retry
+  // Didit KYC rejected — final decision; cannot be overridden or resubmitted, so no action button.
   if (options?.kycStatus === KycStatus.REJECTED) {
-    return 'Retry KYC';
+    return undefined;
   }
 
   // Didit incomplete — user needs to continue
@@ -401,6 +406,11 @@ export function isStepButtonDisabled(
 
   // Didit under review — disable button, user must wait
   if (options?.kycStatus === KycStatus.UNDER_REVIEW && !isRecognizedRainStatus) {
+    return true;
+  }
+
+  // Didit rejected — final decision, no action available
+  if (options?.kycStatus === KycStatus.REJECTED && !isRecognizedRainStatus) {
     return true;
   }
 

--- a/hooks/useCardSteps/useCardSteps.ts
+++ b/hooks/useCardSteps/useCardSteps.ts
@@ -196,11 +196,9 @@ export function useCardSteps(
     const status = cardStatusResponse?.rainApplicationStatus;
     const link = cardStatusResponse?.applicationExternalVerificationLink;
 
-    if (
-      status === RainApplicationStatus.DENIED ||
-      status === RainApplicationStatus.LOCKED ||
-      status === RainApplicationStatus.CANCELED
-    ) {
+    // DENIED is a final decision with no action — it renders no button, so it is not
+    // handled here. LOCKED/CANCELED still offer a "Contact support" button.
+    if (status === RainApplicationStatus.LOCKED || status === RainApplicationStatus.CANCELED) {
       openIntercom();
       return;
     }


### PR DESCRIPTION
## Summary
Promotes the KYC final-decision change from `qa` (#2115) to `master` via cherry-pick of commit `a87901e`.

On `/card/activate`, the first step ("Complete KYC") now renders **no action button** when KYC reaches a final denied decision, for both providers:

| State | Before | After |
|-------|--------|-------|
| **Rain** `DENIED` | "Contact support" button (opened Intercom) | No button |
| **Didit** `REJECTED` | "Retry KYC" button | No button |

These are final decisions that cannot be manually overridden or resubmitted, so both buttons were misleading dead ends.

## Key Changes (`hooks/useCardSteps/`)
- **`getKYCButtonText`**: Rain `DENIED` returns no button text (`LOCKED`/`CANCELED` keep "Contact support" since support can still assist with those).
- **`isRainKYCButtonDisabled`**: `DENIED` now has no actionable `onPress`.
- **`getStepButtonText`**: Didit `REJECTED` returns no button text.
- **`isStepButtonDisabled`**: Didit `REJECTED` has no `onPress`.
- **`getStepDescription`**: the Didit `REJECTED` fallback no longer says "Please try again with a valid ID".
- **`useCardSteps` (`handleRainKYCPress`)**: dropped the now-unreachable `DENIED → Intercom` branch.

## Left untouched
- **Rain `LOCKED`/`CANCELED`** keep "Contact support" — their copy ("on hold" / "start over") indicates support can still help; they aren't final denials.
- **Bridge endorsement `REVOKED`** still shows "Retry KYC" — a legitimately retryable state.

## Notes
- Cherry-picked from commit `a87901e` (merged to `qa` in #2115). The cherry-pick applied cleanly onto `master`.
- Verified: `tsc --noEmit` clean for the changed files; ESLint passes on both files.

https://claude.ai/code/session_01S2muieprRUo3BGSh8yKBtR

---
_Generated by [Claude Code](https://claude.ai/code/session_01S2muieprRUo3BGSh8yKBtR)_