### PR TITLE
Disable swap functionality on iOS platform

### DIFF
--- a/components/Activity/ActivityTransactions.tsx
+++ b/components/Activity/ActivityTransactions.tsx
@@ -432,7 +432,7 @@ export default function ActivityTransactions({
             </Text>
             {tab === ActivityTab.WALLET && (
               <Text className="mt-2 text-center text-sm text-muted-foreground">
-                Start by making a swap or sending tokens
+                Start by making a deposit or creating a card
               </Text>
             )}
           </>

--- a/components/Rewards/EarnPointsSection.tsx
+++ b/components/Rewards/EarnPointsSection.tsx
@@ -1,4 +1,4 @@
-import { ActivityIndicator, View } from 'react-native';
+import { ActivityIndicator, Platform, View } from 'react-native';
 
 import { Text } from '@/components/ui/text';
 import { useDimension } from '@/hooks/useDimension';
@@ -59,7 +59,10 @@ const EarnPointsSection = () => {
     ];
   };
 
-  const earningMethods = getEarningMethods();
+  // Swap is not available on iOS, so exclude it from the earning methods there.
+  const earningMethods = getEarningMethods().filter(
+    method => Platform.OS !== 'ios' || method.title !== 'Swap',
+  );
 
   return (
     <View className="gap-6 rounded-twice bg-card p-6 md:gap-10 md:p-10">

--- a/components/Rewards/TierFeesTable.tsx
+++ b/components/Rewards/TierFeesTable.tsx
@@ -1,3 +1,5 @@
+import { Platform } from 'react-native';
+
 import { RewardsTier, TierBenefits } from '@/lib/types';
 
 import RewardTable, { RewardTableRow } from './RewardTable';
@@ -31,10 +33,15 @@ const TierFeesTable = ({ tierBenefits }: TierFeesTableProps) => {
       label: 'Bank deposit',
       values: sortedTiers.map(tier => tier.bankDeposit),
     },
-    {
-      label: 'Swaps',
-      values: sortedTiers.map(tier => tier.swapFees),
-    },
+    // Swap is not available on iOS, so omit the swap fees row there.
+    ...(Platform.OS === 'ios'
+      ? []
+      : [
+          {
+            label: 'Swaps',
+            values: sortedTiers.map(tier => tier.swapFees),
+          },
+        ]),
     {
       label: 'Support',
       values: sortedTiers.map(tier => tier.support),

--- a/components/Swap/SwapModalProvider.tsx
+++ b/components/Swap/SwapModalProvider.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useMemo } from 'react';
-import { View } from 'react-native';
+import { Platform, View } from 'react-native';
 import { useRouter } from 'expo-router';
 import { useShallow } from 'zustand/react/shallow';
 
@@ -135,6 +135,11 @@ const SwapModalProvider = () => {
     transaction,
     handleTransactionStatusPress,
   ]);
+
+  // Swap is not available on iOS — never render the swap modal there.
+  if (Platform.OS === 'ios') {
+    return null;
+  }
 
   return (
     <ResponsiveModal

--- a/components/Unstake/RegularWithdrawForm.tsx
+++ b/components/Unstake/RegularWithdrawForm.tsx
@@ -230,7 +230,7 @@ const RegularWithdrawForm = () => {
       setModal(UNSTAKE_MODAL.OPEN_TRANSACTION_STATUS);
       Toast.show({
         type: 'success',
-        text1: 'Swap transaction submitted',
+        text1: 'Withdrawal transaction submitted',
         text2: `${data.amount} ${selectedToken?.contractTickerSymbol || 'soUSD'}`,
         props: {
           link: `https://etherscan.io/tx/${transaction.transactionHash}`,
@@ -243,7 +243,7 @@ const RegularWithdrawForm = () => {
     } catch (_error) {
       Toast.show({
         type: 'error',
-        text1: 'Error while swapping',
+        text1: 'Error while withdrawing',
       });
     }
   };

--- a/components/Wallet/WalletCard.tsx
+++ b/components/Wallet/WalletCard.tsx
@@ -1,4 +1,4 @@
-import { Pressable, View } from 'react-native';
+import { Platform, Pressable, View } from 'react-native';
 
 import WalletIcon from '@/assets/images/wallet';
 import CountUp from '@/components/CountUp';
@@ -73,7 +73,7 @@ const WalletCard = ({ balance, className, tokens, isLoading, decimalPlaces }: Wa
             content={
               <Text className="max-w-[16.2rem] text-base">
                 Displaying top three tokens by balance. Wallet can contain any ERC-20 and native
-                token in Ethereum and Fuse for Swap and Send.
+                token in Ethereum and Fuse for {Platform.OS === 'ios' ? 'Send' : 'Swap and Send'}.
               </Text>
             }
           />

--- a/constants/faqs.tsx
+++ b/constants/faqs.tsx
@@ -19,7 +19,7 @@ const faqs: Faq[] = [
   {
     question: 'What is SoUSD?',
     answer:
-      'SoUSD is a **yield-bearing stablecoin**. Unlike typical 1:1 pegged stablecoins, SoUSD represents your share in a growing vault. Its value **increases over time** as interest accrues — no need to stake or manage positions.\n\nSoUSD is gasless, cross-chain, and composable — ready for use in payments, swaps, lending, and more.',
+      'SoUSD is a **yield-bearing stablecoin**. Unlike typical 1:1 pegged stablecoins, SoUSD represents your share in a growing vault. Its value **increases over time** as interest accrues — no need to stake or manage positions.\n\nSoUSD is gasless, cross-chain, and composable — ready for use in payments, lending, and more.',
   },
   {
     question: "Why didn't I receive 1 SoUSD per 1 USDC?",


### PR DESCRIPTION
## Summary
This PR disables swap-related functionality on iOS while maintaining full feature support on Android and other platforms. The changes align with platform-specific constraints and update related UI text and error messages accordingly.

## Key Changes
- **SwapModalProvider**: Added platform check to prevent rendering the swap modal on iOS
- **TierFeesTable**: Conditionally omit the "Swaps" fees row from the rewards tier table on iOS
- **EarnPointsSection**: Filter out "Swap" from the earning methods list on iOS
- **WalletCard**: Updated tooltip text to reflect platform-specific capabilities ("Send" only on iOS, "Swap and Send" on other platforms)
- **RegularWithdrawForm**: Fixed misleading toast messages that incorrectly referenced "Swap" instead of "Withdrawal" operations
- **ActivityTransactions**: Updated empty state message to reflect available actions on iOS
- **FAQs**: Removed reference to "swaps" from SoUSD description to be platform-agnostic

## Implementation Details
- Used React Native's `Platform.OS` API to detect iOS at runtime
- Maintained backward compatibility with existing Android/web functionality
- Applied consistent pattern across multiple components for conditional rendering
- Fixed unrelated copy issues in withdrawal-related error messages

https://claude.ai/code/session_01AFxT4kNs1QGYn8JGpDTuGH