### PR TITLE
Add account recovery prompt after failed login

### DIFF
--- a/app/onboarding.tsx
+++ b/app/onboarding.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useState } from 'react';
-import { ActivityIndicator, useWindowDimensions, View } from 'react-native';
+import { ActivityIndicator, Pressable, useWindowDimensions, View } from 'react-native';
 import Animated, {
   useAnimatedReaction,
   useAnimatedScrollHandler,
@@ -11,6 +11,7 @@ import Toast from 'react-native-toast-message';
 import { scheduleOnRN } from 'react-native-worklets';
 import { Image } from 'expo-image';
 import { useRouter } from 'expo-router';
+import { ChevronRight } from 'lucide-react-native';
 import { useShallow } from 'zustand/react/shallow';
 
 import LoginKeyIcon from '@/assets/images/login_key_icon';
@@ -45,12 +46,14 @@ export default function Onboarding() {
   const isLoginPending = loginInfo.status === Status.PENDING;
   const { width: screenWidth, height: screenHeight } = useWindowDimensions();
   const [currentIndex, setCurrentIndex] = useState(0);
+  const [showRecoveryLink, setShowRecoveryLink] = useState(false);
   const scrollX = useSharedValue(0);
 
   // Responsive layout for small screens (iPhone SE)
   const isSmallScreen = screenHeight < 700;
-  // Fixed button area height - content area uses flex: 1 to fill remaining space
-  const buttonAreaHeight = isSmallScreen ? 200 : 240;
+  // Fixed button area height - content area uses flex: 1 to fill remaining space.
+  // Grows to fit the account-recovery prompt that appears after a failed login.
+  const buttonAreaHeight = (isSmallScreen ? 200 : 240) + (showRecoveryLink ? 44 : 0);
 
   // Track screen width as shared value for use in worklets
   const widthSV = useSharedValue(screenWidth);
@@ -84,6 +87,8 @@ export default function Onboarding() {
   const handleLoginPress = useCallback(async () => {
     // Mark onboarding as seen
     setHasSeenOnboarding(true);
+    // Hide any previous recovery prompt while retrying
+    setShowRecoveryLink(false);
 
     try {
       await handleLogin();
@@ -92,12 +97,13 @@ export default function Onboarding() {
         // User not found — redirect to signup
         router.replace(path.SIGNUP_EMAIL);
       } else {
-        // Other errors — show toast and stay on onboarding
+        // Other errors — show toast, stay on onboarding, and offer account recovery
         Toast.show({
           type: 'error',
           text1: 'Login failed',
           text2: error?.message || 'Something went wrong. Please try again.',
         });
+        setShowRecoveryLink(true);
       }
     }
   }, [handleLogin, router, setHasSeenOnboarding]);
@@ -107,12 +113,31 @@ export default function Onboarding() {
     router.replace(path.SIGNUP_EMAIL);
   }, [router, setHasSeenOnboarding]);
 
+  const handleRecoverAccount = useCallback(() => {
+    router.push(path.RECOVERY);
+  }, [router]);
+
   const handleHelpCenter = useCallback(() => {
     // TODO: Add help center link
     // Linking.openURL(HELP_CENTER_URL);
   }, []);
 
   const filteredOnboardingData = ONBOARDING_DATA.filter(slide => slide?.platform !== false);
+
+  // Surfaced below the Login button after a failed login attempt so users who
+  // can't authenticate (e.g. lost passkey) can start account recovery.
+  const recoveryLink = showRecoveryLink ? (
+    <View className="flex-row flex-wrap items-center justify-center">
+      <Text className="text-sm text-white/60">Have trouble logging in? </Text>
+      <Pressable
+        onPress={handleRecoverAccount}
+        className="flex-row items-center web:hover:opacity-70"
+      >
+        <Text className="text-sm font-bold text-white">Recover your account</Text>
+        <ChevronRight color="white" size={16} className="ml-0.5" />
+      </Pressable>
+    </View>
+  ) : null;
 
   // Mobile Layout
   if (!isDesktop) {
@@ -182,6 +207,9 @@ export default function Onboarding() {
                       <Text className="text-base font-bold">Login</Text>
                     )}
                   </Button>
+
+                  {/* Account recovery prompt — only after a failed login */}
+                  {recoveryLink}
 
                   {/* Dev-only Dummy Login */}
                   {/* {__DEV__ && (
@@ -284,6 +312,9 @@ export default function Onboarding() {
                   </View>
                 )}
               </Button>
+
+              {/* Account recovery prompt — only after a failed login */}
+              {recoveryLink}
 
               {/* Dev-only Dummy Login */}
               {__DEV__ && (


### PR DESCRIPTION
## Summary
Added an account recovery flow to the onboarding screen that appears after a failed login attempt, allowing users who can't authenticate (e.g., lost passkey) to initiate account recovery.

## Key Changes
- **New state management**: Added `showRecoveryLink` state to track when to display the recovery prompt
- **Dynamic button area**: Updated `buttonAreaHeight` calculation to expand by 44px when the recovery prompt is visible, ensuring proper layout on small screens
- **Recovery prompt UI**: Created a new `recoveryLink` component that displays "Have trouble logging in?" text with a "Recover your account" button and chevron icon
- **Login flow updates**: 
  - Hide recovery prompt when user initiates a new login attempt
  - Show recovery prompt only on non-user-not-found errors (other login failures)
  - Redirect to signup flow for user-not-found errors (existing behavior)
- **Navigation handler**: Added `handleRecoverAccount` callback to navigate to the recovery path
- **Imports**: Added `Pressable` from react-native and `ChevronRight` icon from lucide-react-native

## Implementation Details
- The recovery prompt is conditionally rendered in both mobile and desktop layouts
- The prompt only appears after a failed login attempt (not on initial load)
- The button area height dynamically adjusts to accommodate the recovery prompt, preventing layout shifts
- The recovery link is hidden when the user attempts to login again, providing a clean retry experience

https://claude.ai/code/session_01XjRWJf4pdceZr2njmQEEd8