### PR TITLE
Add account recovery prompt after failed login (qa)

### DIFF
--- a/app/onboarding.tsx
+++ b/app/onboarding.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useState } from 'react';
-import { ActivityIndicator, useWindowDimensions, View } from 'react-native';
+import { ActivityIndicator, Pressable, useWindowDimensions, View } from 'react-native';
 import Animated, {
   useAnimatedReaction,
   useAnimatedScrollHandler,
@@ -11,6 +11,7 @@ import Toast from 'react-native-toast-message';
 import { scheduleOnRN } from 'react-native-worklets';
 import { Image } from 'expo-image';
 import { useRouter } from 'expo-router';
+import { ChevronRight } from 'lucide-react-native';
 import { useShallow } from 'zustand/react/shallow';
 
 import LoginKeyIcon from '@/assets/images/login_key_icon';
@@ -45,12 +46,14 @@ export default function Onboarding() {
   const isLoginPending = loginInfo.status === Status.PENDING;
   const { width: screenWidth, height: screenHeight } = useWindowDimensions();
   const [currentIndex, setCurrentIndex] = useState(0);
+  const [showRecoveryLink, setShowRecoveryLink] = useState(false);
   const scrollX = useSharedValue(0);
 
   // Responsive layout for small screens (iPhone SE)
   const isSmallScreen = screenHeight < 700;
-  // Fixed button area height - content area uses flex: 1 to fill remaining space
-  const buttonAreaHeight = isSmallScreen ? 200 : 240;
+  // Fixed button area height - content area uses flex: 1 to fill remaining space.
+  // Grows to fit the account-recovery prompt that appears after a failed login.
+  const buttonAreaHeight = (isSmallScreen ? 200 : 240) + (showRecoveryLink ? 44 : 0);
 
   // Track screen width as shared value for use in worklets
   const widthSV = useSharedValue(screenWidth);
@@ -84,6 +87,8 @@ export default function Onboarding() {
   const handleLoginPress = useCallback(async () => {
     // Mark onboarding as seen
     setHasSeenOnboarding(true);
+    // Hide any previous recovery prompt while retrying
+    setShowRecoveryLink(false);
 
     try {
       await handleLogin();
@@ -92,12 +97,13 @@ export default function Onboarding() {
         // User not found — redirect to signup
         router.replace(path.SIGNUP_EMAIL);
       } else {
-        // Other errors — show toast and stay on onboarding
+        // Other errors — show toast, stay on onboarding, and offer account recovery
         Toast.show({
           type: 'error',
           text1: 'Login failed',
           text2: error?.message || 'Something went wrong. Please try again.',
         });
+        setShowRecoveryLink(true);
       }
     }
   }, [handleLogin, router, setHasSeenOnboarding]);
@@ -107,12 +113,31 @@ export default function Onboarding() {
     router.replace(path.SIGNUP_EMAIL);
   }, [router, setHasSeenOnboarding]);
 
+  const handleRecoverAccount = useCallback(() => {
+    router.push(path.RECOVERY);
+  }, [router]);
+
   const handleHelpCenter = useCallback(() => {
     // TODO: Add help center link
     // Linking.openURL(HELP_CENTER_URL);
   }, []);
 
   const filteredOnboardingData = ONBOARDING_DATA.filter(slide => slide?.platform !== false);
+
+  // Surfaced below the Login button after a failed login attempt so users who
+  // can't authenticate (e.g. lost passkey) can start account recovery.
+  const recoveryLink = showRecoveryLink ? (
+    <View className="flex-row flex-wrap items-center justify-center">
+      <Text className="text-sm text-white/60">Have trouble logging in? </Text>
+      <Pressable
+        onPress={handleRecoverAccount}
+        className="flex-row items-center web:hover:opacity-70"
+      >
+        <Text className="text-sm font-bold text-white">Recover your account</Text>
+        <ChevronRight color="white" size={16} className="ml-0.5" />
+      </Pressable>
+    </View>
+  ) : null;
 
   // Mobile Layout
   if (!isDesktop) {
@@ -182,6 +207,9 @@ export default function Onboarding() {
                       <Text className="text-base font-bold">Login</Text>
                     )}
                   </Button>
+
+                  {/* Account recovery prompt — only after a failed login */}
+                  {recoveryLink}
 
                   {/* Dev-only Dummy Login */}
                   {/* {__DEV__ && (
@@ -284,6 +312,9 @@ export default function Onboarding() {
                   </View>
                 )}
               </Button>
+
+              {/* Account recovery prompt — only after a failed login */}
+              {recoveryLink}
 
               {/* Dev-only Dummy Login */}
               {__DEV__ && (


### PR DESCRIPTION
## Summary
Targets `qa`. Same change as #2120 (merged into `master`), cherry-picked onto `qa` so this PR contains only the onboarding change.

Adds an account-recovery prompt to the onboarding screen that appears after a failed login attempt, letting users who can't authenticate (e.g. lost passkey) start account recovery.

## Key Changes
- **`showRecoveryLink` state** tracks when to display the recovery prompt.
- **Recovery prompt UI**: "Have trouble logging in?" lead-in + a "Recover your account" link with a right chevron (`ChevronRight`), rendered below the Login button in both the mobile and desktop layouts.
- **Login flow**: prompt is hidden when the user retries login, and shown only on non-404 login failures (404 still redirects to signup).
- **Navigation**: `handleRecoverAccount` navigates to the in-app recovery flow (`path.RECOVERY`).
- **Dynamic button area**: `buttonAreaHeight` grows by 44px while the prompt is visible so it isn't clipped by the fixed-height bottom section on small screens.
- **Imports**: `Pressable` (react-native) and `ChevronRight` (lucide-react-native).

## Notes
- Single file changed: `app/onboarding.tsx` (+35 / -4).
- Linated/typechecked manually only — the dev dependencies require the private `@meawallet` registry, which isn't reachable in the authoring environment.

https://claude.ai/code/session_01XjRWJf4pdceZr2njmQEEd8

---
_Generated by [Claude Code](https://claude.ai/code/session_01XjRWJf4pdceZr2njmQEEd8)_