### PR TITLE
Remove "contact support" wording from final-denial step-1 descriptions

### DIFF
--- a/hooks/useCardSteps/kycDisplayHelpers.ts
+++ b/hooks/useCardSteps/kycDisplayHelpers.ts
@@ -133,7 +133,7 @@ export function getKYCDescription(
     case RainApplicationStatus.MANUAL_REVIEW:
       return "Your application is being reviewed by our team. We'll update you when a decision is reached.";
     case RainApplicationStatus.DENIED:
-      return "We couldn't verify your identity. Please contact support for more information.";
+      return "We couldn't verify your identity.";
     case RainApplicationStatus.LOCKED:
       return 'Your application is on hold. Contact support for assistance.';
     case RainApplicationStatus.CANCELED:
@@ -233,7 +233,7 @@ export function getStepDescription(
     if (warnings.length > 0) {
       return `We couldn't verify your identity:\n- ${formatKycWarnings(warnings)}`;
     }
-    return 'Your identity verification was declined. Please contact support for more information.';
+    return 'Your identity verification was declined.';
   }
 
   // Didit resubmission or incomplete (including didit_forward_failed) — show reasons if available


### PR DESCRIPTION
## Summary
Follow-up to the final-denial action-button removal (#2115). The first step ("Complete KYC") on `/card/activate` no longer renders an action button for final-denial KYC states, but the **descriptions still told users to "contact support for more information."** Since those decisions can't be overridden or resubmitted, this removes that wording so the copy doesn't imply an action support can't take.

## Change (`hooks/useCardSteps/kycDisplayHelpers.ts`)
- **`getKYCDescription`** (Rain `DENIED`): `"We couldn't verify your identity. Please contact support for more information."` → `"We couldn't verify your identity."`
- **`getStepDescription`** (Didit `REJECTED` fallback): `"Your identity verification was declined. Please contact support for more information."` → `"Your identity verification was declined."`

## Left untouched
- Rain `LOCKED`/`CANCELED` keep their "Contact support" copy and button (not final denials — support can still assist).
- The Didit `REJECTED` *with-warnings* branch is unchanged (it lists the specific rejection reasons).

ESLint passes on the changed file.

https://claude.ai/code/session_01S2muieprRUo3BGSh8yKBtR

---
_Generated by [Claude Code](https://claude.ai/code/session_01S2muieprRUo3BGSh8yKBtR)_