### PR TITLE
Surface Didit KYC warnings on step 1, including under-review

### DIFF
--- a/hooks/useCardSteps/kycDisplayHelpers.ts
+++ b/hooks/useCardSteps/kycDisplayHelpers.ts
@@ -73,7 +73,10 @@ const DIDIT_WARNING_DESCRIPTIONS: Record<string, string> = {
   SCREEN_CAPTURE_DETECTED: 'A photo of a screen was detected — please use the original document',
   PRINTED_COPY_DETECTED: 'A printed copy was detected — please use the original document',
   PORTRAIT_MANIPULATION_DETECTED: 'The portrait on the document appears to have been altered',
-  POSSIBLE_DUPLICATED_USER: 'A duplicate account was detected',
+  POSSIBLE_DUPLICATED_USER: 'This identity is already linked to another verified account',
+  DUPLICATED_IP: 'This network has already been used to verify another account',
+  DUPLICATED_DEVICE: 'This device has already been used to verify another account',
+  DUPLICATED_DEVICE_FINGERPRINT: 'This device has already been used to verify another account',
   DOCUMENT_NUMBER_NOT_DETECTED: 'Document number could not be read',
   NAME_NOT_DETECTED: 'Name could not be read from the document',
   DATE_OF_BIRTH_NOT_DETECTED: 'Date of birth could not be read from the document',
@@ -230,22 +233,31 @@ export function getStepDescription(
 
   // Didit KYC rejected or expired before reaching Rain — show rejection reasons
   if (options?.kycStatus === KycStatus.REJECTED) {
-    if (warnings.length > 0) {
-      return `We couldn't verify your identity:\n- ${formatKycWarnings(warnings)}`;
+    const formatted = formatKycWarnings(warnings);
+    if (formatted) {
+      return `We couldn't verify your identity:\n- ${formatted}`;
     }
     return 'Your identity verification was declined.';
   }
 
   // Didit resubmission or incomplete (including didit_forward_failed) — show reasons if available
   if (options?.kycStatus === KycStatus.INCOMPLETE && !isRecognizedRainStatus) {
-    if (warnings.length > 0) {
-      return `Additional verification required:\n- ${formatKycWarnings(warnings)}`;
+    const formatted = formatKycWarnings(warnings);
+    if (formatted) {
+      return `Additional verification required:\n- ${formatted}`;
     }
     return 'Additional verification steps are required. Please continue to complete the process.';
   }
 
-  // Didit under review — user should wait
+  // Didit under review — user should wait. Duplicate IP/device filters land here
+  // (Didit sets these to "review" so the suspicious applicant doesn't reach Rain).
+  // When warnings are attached, surface them so the user knows what is being checked
+  // instead of a generic "few minutes" copy for what is actually a manual review.
   if (options?.kycStatus === KycStatus.UNDER_REVIEW && !isRecognizedRainStatus) {
+    const formatted = formatKycWarnings(warnings);
+    if (formatted) {
+      return `Your application is under additional review:\n- ${formatted}\n\nWe'll update you when the review is complete.`;
+    }
     return 'Your information is being reviewed. This usually takes a few minutes.';
   }
 


### PR DESCRIPTION
## Summary
For a Didit `under_review` user (e.g. held due to a duplicate device/IP fingerprint), step 1 of `/card/activate` wasn't surfacing the warning reasons — on `qa` it only showed a generic *"being reviewed"* message. This lists the attached reasons so the user knows what's being checked.

## Changes (`hooks/useCardSteps/kycDisplayHelpers.ts`)
- **`under_review`** step-1 description now surfaces the attached Didit warnings (*"Your application is under additional review: …"*), falling back to the generic *"few minutes"* copy when there are none. (This branch existed on `master` but not `qa`.)
- **`REJECTED` / `INCOMPLETE` / `under_review`** branches key off the formatted result instead of the raw `warnings.length`, so a warning set that produces no display text no longer renders an empty `- ` bullet.
- Added `DUPLICATED_DEVICE_FINGERPRINT` (+ duplicate IP/device) to the friendly-copy map.

**All** attached warnings are shown — no `log_type` filtering — so the user gets the full picture.

## Note on the missing button
The disabled **"Under Review"** button already renders for a Didit `under_review` user (`getStepButtonText` → `"Under Review"`, disabled). The screenshot's denied copy + no button is the **Rain `DENIED`** render, which only appears if `rainApplicationStatus: "denied"` reaches the client. If this `under_review` user still shows the denied screen on a fresh build, share the `/cards/status` response and I'll trace it.

ESLint passes. `kycDisplayHelpers.ts` is kept identical to the master-targeted branch (#2126).

https://claude.ai/code/session_01S2muieprRUo3BGSh8yKBtR