### PR TITLE
Surface Didit KYC warnings on step 1, including under-review (master)

### DIFF
--- a/hooks/useCardSteps/kycDisplayHelpers.ts
+++ b/hooks/useCardSteps/kycDisplayHelpers.ts
@@ -76,6 +76,7 @@ const DIDIT_WARNING_DESCRIPTIONS: Record<string, string> = {
   POSSIBLE_DUPLICATED_USER: 'This identity is already linked to another verified account',
   DUPLICATED_IP: 'This network has already been used to verify another account',
   DUPLICATED_DEVICE: 'This device has already been used to verify another account',
+  DUPLICATED_DEVICE_FINGERPRINT: 'This device has already been used to verify another account',
   DOCUMENT_NUMBER_NOT_DETECTED: 'Document number could not be read',
   NAME_NOT_DETECTED: 'Name could not be read from the document',
   DATE_OF_BIRTH_NOT_DETECTED: 'Date of birth could not be read from the document',
@@ -232,28 +233,30 @@ export function getStepDescription(
 
   // Didit KYC rejected or expired before reaching Rain — show rejection reasons
   if (options?.kycStatus === KycStatus.REJECTED) {
-    if (warnings.length > 0) {
-      return `We couldn't verify your identity:\n- ${formatKycWarnings(warnings)}`;
+    const formatted = formatKycWarnings(warnings);
+    if (formatted) {
+      return `We couldn't verify your identity:\n- ${formatted}`;
     }
     return 'Your identity verification was declined.';
   }
 
   // Didit resubmission or incomplete (including didit_forward_failed) — show reasons if available
   if (options?.kycStatus === KycStatus.INCOMPLETE && !isRecognizedRainStatus) {
-    if (warnings.length > 0) {
-      return `Additional verification required:\n- ${formatKycWarnings(warnings)}`;
+    const formatted = formatKycWarnings(warnings);
+    if (formatted) {
+      return `Additional verification required:\n- ${formatted}`;
     }
     return 'Additional verification steps are required. Please continue to complete the process.';
   }
 
-  // Didit under review — user should wait. Duplicate IP/device filters land
-  // here (Didit dashboard sets them to "review" so the suspicious applicant
-  // doesn't reach Rain). When warnings are attached, surface them so the user
-  // knows what's being checked instead of seeing a generic "few minutes" copy
-  // for what is actually a manual review.
+  // Didit under review — user should wait. Duplicate IP/device filters land here
+  // (Didit sets these to "review" so the suspicious applicant doesn't reach Rain).
+  // When warnings are attached, surface them so the user knows what is being checked
+  // instead of a generic "few minutes" copy for what is actually a manual review.
   if (options?.kycStatus === KycStatus.UNDER_REVIEW && !isRecognizedRainStatus) {
-    if (warnings.length > 0) {
-      return `Your application is under additional review:\n- ${formatKycWarnings(warnings)}\n\nWe'll update you when the review is complete.`;
+    const formatted = formatKycWarnings(warnings);
+    if (formatted) {
+      return `Your application is under additional review:\n- ${formatted}\n\nWe'll update you when the review is complete.`;
     }
     return 'Your information is being reviewed. This usually takes a few minutes.';
   }


### PR DESCRIPTION
## Summary
Keeps `master` in sync with the qa-targeted branch (#2125) for the Didit `under_review` warnings display on step 1 of `/card/activate`. `master` already surfaces the attached warnings under review; this is the friendly-copy + robustness portion.

## Changes (`hooks/useCardSteps/kycDisplayHelpers.ts`)
- Added `DUPLICATED_DEVICE_FINGERPRINT` to the friendly-copy map, so the reported user sees *"This device has already been used to verify another account"* instead of Didit's raw `short_description`.
- **`REJECTED` / `INCOMPLETE` / `under_review`** branches key off the formatted result instead of the raw `warnings.length`, so a warning set that produces no display text no longer renders an empty `- ` bullet.
- Comment tidy on the `under_review` branch.

**All** attached warnings are shown — no `log_type` filtering.

## Note on the missing button
The disabled **"Under Review"** button already renders for a Didit `under_review` user (`getStepButtonText` → `"Under Review"`, disabled). The screenshot's denied copy + no button is the **Rain `DENIED`** render, which only appears if `rainApplicationStatus: "denied"` reaches the client. If this `under_review` user still shows the denied screen on a fresh build, share the `/cards/status` response and I'll trace it.

ESLint passes. `kycDisplayHelpers.ts` is kept identical to the qa-targeted branch (#2125).

https://claude.ai/code/session_01S2muieprRUo3BGSh8yKBtR