### PR TITLE
Refactor analytics enrichment and fix screen tracking initialization

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -195,6 +195,7 @@ export const queryClient = new QueryClient({
 export default Sentry.wrap(function RootLayout() {
   const [appIsReady, setAppIsReady] = useState(false);
   const [splashScreenHidden, setSplashScreenHidden] = useState(false);
+  const [analyticsReady, setAnalyticsReady] = useState(false);
 
   const hasSelectedUser = useUserStore(state => state.users.some(u => u.selected));
 
@@ -220,7 +221,9 @@ export default Sentry.wrap(function RootLayout() {
     if (!splashScreenHidden) return;
     if (Platform.OS === 'ios' && !attReady) return;
 
-    initAnalytics(isTrackingAllowed).catch(e => console.warn('Analytics init error:', e));
+    initAnalytics(isTrackingAllowed)
+      .catch(e => console.warn('Analytics init error:', e))
+      .finally(() => setAnalyticsReady(true));
   }, [splashScreenHidden, attReady, isTrackingAllowed]);
 
   useEffect(() => {
@@ -310,8 +313,14 @@ export default Sentry.wrap(function RootLayout() {
   // - Amplitude: tracks on all platforms
   // - Firebase: tracks on web only
   useEffect(() => {
+    // Wait until analytics is initialized before tracking screen views. On
+    // web the SDK has no proxy/serverUrl configured until init() runs, so an
+    // early Page Viewed would be queued and flushed to the wrong endpoint (or
+    // lost). Gating on analyticsReady also re-fires this effect once init
+    // completes, capturing the landing screen with full attribution context.
+    if (!analyticsReady) return;
     trackScreen(pathname, params);
-  }, [pathname, params]);
+  }, [pathname, params, analyticsReady]);
 
   useEffect(() => {
     if (fontError) {
@@ -324,14 +333,14 @@ export default Sentry.wrap(function RootLayout() {
   }
 
   return (
-    <SafeAreaProvider onLayout={onLayoutRootView}>
+    <SafeAreaProvider>
       <TurnkeyProvider>
         <LazyThirdwebProvider>
           <WagmiProvider config={config}>
             <QueryClientProvider client={queryClient}>
               <ApolloProvider client={getInfoClient()}>
                 <Intercom>
-                  <GestureHandlerRootView>
+                  <GestureHandlerRootView style={{ flex: 1 }} onLayout={onLayoutRootView}>
                     <BottomSheetModalProvider>
                       {Platform.OS === 'web' && (
                         <Head>

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -215,6 +215,29 @@ export type TrackOptions = {
   amplitude?: boolean;
 };
 
+// Enrich event params with attribution + device/session context so every
+// event (including screen views) carries the same top-level properties
+// (utm_source, utm_campaign, attribution_channel, ...) instead of burying
+// them in a nested object. Shared by track() and trackAmplitudeScreen().
+const enrichEventParams = (params: Record<string, any>) => {
+  const attributionData = useAttributionStore.getState().getAttributionForEvent();
+
+  return {
+    ...params,
+    // Attribution data (UTM params, referral codes, etc.)
+    ...attributionData,
+    // Attribution channel for easier filtering
+    attribution_channel: getAttributionChannel(attributionData),
+    // Device/session tracking for anonymous-to-identified user bridging
+    amplitude_device_id: getAmplitudeDeviceId(),
+    amplitude_session_id: getAmplitudeSessionId(),
+    // Platform context
+    platform: Platform.OS,
+    // Timestamp
+    timestamp: Date.now(),
+  };
+};
+
 // Main track function with automatic attribution enrichment
 export const track = (
   event: string,
@@ -235,30 +258,9 @@ export const track = (
 
     const { amplitude = true } = options;
 
-    // Get attribution data from store
-    const attributionStore = useAttributionStore.getState();
-    const attributionData = attributionStore.getAttributionForEvent();
-    const deviceId = getAmplitudeDeviceId();
-    const sessionId = getAmplitudeSessionId();
-
-    // Enrich params with attribution and device context
-    const enrichedParams = {
-      ...params,
-      // Attribution data (UTM params, referral codes, etc.)
-      ...attributionData,
-      // Attribution channel for easier filtering
-      attribution_channel: getAttributionChannel(attributionData),
-      // Device/session tracking for anonymous-to-identified user bridging
-      amplitude_device_id: deviceId,
-      amplitude_session_id: sessionId,
-      // Platform context
-      platform: Platform.OS,
-      // Timestamp
-      timestamp: Date.now(),
-    };
-
-    // Sanitize all params once - remove undefined/null values and ensure serializable
-    const sanitizedParams = sanitize(enrichedParams);
+    // Enrich with attribution + device context, then sanitize once
+    // (remove undefined/null values and ensure serializable).
+    const sanitizedParams = sanitize(enrichEventParams(params));
 
     // Track to all providers in parallel. Amplitude can be opted out per-call
     // for events now emitted server-side; Firebase + GTM always fire.
@@ -280,10 +282,14 @@ const trackAmplitudeScreen = (pathname: string, params: Record<string, any>) => 
   }
 
   try {
-    trackAmplitude(AmplitudeEvent.PAGE_VIEWED, {
-      pathname,
-      params,
-    });
+    // Enrich with attribution + device context and flatten route params to
+    // top-level properties so utm_source / utm_campaign are queryable in
+    // Amplitude (matching how track() enriches every other event), instead
+    // of arriving as a nested `params` object.
+    trackAmplitude(
+      AmplitudeEvent.PAGE_VIEWED,
+      sanitize(enrichEventParams({ pathname, ...params })),
+    );
   } catch (error) {
     console.error('Error tracking Amplitude screen:', error);
   }


### PR DESCRIPTION
## Summary
This PR refactors the analytics event enrichment logic to reduce duplication and fixes a timing issue where screen views were tracked before analytics initialization completed, potentially causing events to be sent to incorrect endpoints.

## Key Changes

- **Extract shared enrichment logic**: Created `enrichEventParams()` helper function that centralizes attribution, device context, and platform data enrichment. This function is now used by both `track()` and `trackAmplitudeScreen()` to ensure consistent event properties across all event types.

- **Fix screen tracking initialization**: Added `analyticsReady` state that gates screen view tracking until `initAnalytics()` completes. This prevents early screen views from being queued before the Amplitude SDK is properly configured with proxy/serverUrl settings on web.

- **Flatten route params in screen events**: Modified `trackAmplitudeScreen()` to flatten route params into top-level properties (matching `track()` behavior), making utm_source, utm_campaign, and other attribution data directly queryable in Amplitude instead of nested in a params object.

- **Reorganize layout component**: Moved `onLayout` callback from `SafeAreaProvider` to `GestureHandlerRootView` and added `flex: 1` style to ensure proper layout handling.

## Implementation Details

- The `enrichEventParams()` function consolidates all enrichment logic that was previously duplicated in the `track()` function, improving maintainability.
- Screen tracking now waits for analytics initialization, ensuring the landing screen is captured with full attribution context.
- The `analyticsReady` dependency in the screen tracking effect ensures the effect re-fires once initialization completes, capturing the initial route with proper context.

https://claude.ai/code/session_01KR9AG8hkYVigCMsQmDKGS2