### PR TITLE
fix(analytics): fire enriched Page Viewed on web

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -195,6 +195,7 @@ export const queryClient = new QueryClient({
 export default Sentry.wrap(function RootLayout() {
   const [appIsReady, setAppIsReady] = useState(false);
   const [splashScreenHidden, setSplashScreenHidden] = useState(false);
+  const [analyticsReady, setAnalyticsReady] = useState(false);
 
   const hasSelectedUser = useUserStore(state => state.users.some(u => u.selected));
 
@@ -220,7 +221,9 @@ export default Sentry.wrap(function RootLayout() {
     if (!splashScreenHidden) return;
     if (Platform.OS === 'ios' && !attReady) return;
 
-    initAnalytics(isTrackingAllowed).catch(e => console.warn('Analytics init error:', e));
+    initAnalytics(isTrackingAllowed)
+      .catch(e => console.warn('Analytics init error:', e))
+      .finally(() => setAnalyticsReady(true));
   }, [splashScreenHidden, attReady, isTrackingAllowed]);
 
   useEffect(() => {
@@ -310,8 +313,14 @@ export default Sentry.wrap(function RootLayout() {
   // - Amplitude: tracks on all platforms
   // - Firebase: tracks on web only
   useEffect(() => {
+    // Wait until analytics is initialized before tracking screen views. On
+    // web the SDK has no proxy/serverUrl configured until init() runs, so an
+    // early Page Viewed would be queued and flushed to the wrong endpoint (or
+    // lost). Gating on analyticsReady also re-fires this effect once init
+    // completes, capturing the landing screen with full attribution context.
+    if (!analyticsReady) return;
     trackScreen(pathname, params);
-  }, [pathname, params]);
+  }, [pathname, params, analyticsReady]);
 
   useEffect(() => {
     if (fontError) {
@@ -324,14 +333,14 @@ export default Sentry.wrap(function RootLayout() {
   }
 
   return (
-    <SafeAreaProvider style={{ flex: 1 }} onLayout={onLayoutRootView}>
+    <SafeAreaProvider style={{ flex: 1 }}>
       <TurnkeyProvider>
         <LazyThirdwebProvider>
           <WagmiProvider config={config}>
             <QueryClientProvider client={queryClient}>
               <ApolloProvider client={getInfoClient()}>
                 <Intercom>
-                  <GestureHandlerRootView style={{ flex: 1 }}>
+                  <GestureHandlerRootView style={{ flex: 1 }} onLayout={onLayoutRootView}>
                     <BottomSheetModalProvider>
                       {Platform.OS === 'web' && (
                         <Head>

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -215,6 +215,29 @@ export type TrackOptions = {
   amplitude?: boolean;
 };
 
+// Enrich event params with attribution + device/session context so every
+// event (including screen views) carries the same top-level properties
+// (utm_source, utm_campaign, attribution_channel, ...) instead of burying
+// them in a nested object. Shared by track() and trackAmplitudeScreen().
+const enrichEventParams = (params: Record<string, any>) => {
+  const attributionData = useAttributionStore.getState().getAttributionForEvent();
+
+  return {
+    ...params,
+    // Attribution data (UTM params, referral codes, etc.)
+    ...attributionData,
+    // Attribution channel for easier filtering
+    attribution_channel: getAttributionChannel(attributionData),
+    // Device/session tracking for anonymous-to-identified user bridging
+    amplitude_device_id: getAmplitudeDeviceId(),
+    amplitude_session_id: getAmplitudeSessionId(),
+    // Platform context
+    platform: Platform.OS,
+    // Timestamp
+    timestamp: Date.now(),
+  };
+};
+
 // Main track function with automatic attribution enrichment
 export const track = (
   event: string,
@@ -235,30 +258,9 @@ export const track = (
 
     const { amplitude = true } = options;
 
-    // Get attribution data from store
-    const attributionStore = useAttributionStore.getState();
-    const attributionData = attributionStore.getAttributionForEvent();
-    const deviceId = getAmplitudeDeviceId();
-    const sessionId = getAmplitudeSessionId();
-
-    // Enrich params with attribution and device context
-    const enrichedParams = {
-      ...params,
-      // Attribution data (UTM params, referral codes, etc.)
-      ...attributionData,
-      // Attribution channel for easier filtering
-      attribution_channel: getAttributionChannel(attributionData),
-      // Device/session tracking for anonymous-to-identified user bridging
-      amplitude_device_id: deviceId,
-      amplitude_session_id: sessionId,
-      // Platform context
-      platform: Platform.OS,
-      // Timestamp
-      timestamp: Date.now(),
-    };
-
-    // Sanitize all params once - remove undefined/null values and ensure serializable
-    const sanitizedParams = sanitize(enrichedParams);
+    // Enrich with attribution + device context, then sanitize once
+    // (remove undefined/null values and ensure serializable).
+    const sanitizedParams = sanitize(enrichEventParams(params));
 
     // Track to all providers in parallel. Amplitude can be opted out per-call
     // for events now emitted server-side; Firebase + GTM always fire.
@@ -280,10 +282,14 @@ const trackAmplitudeScreen = (pathname: string, params: Record<string, any>) => 
   }
 
   try {
-    trackAmplitude(AmplitudeEvent.PAGE_VIEWED, {
-      pathname,
-      params,
-    });
+    // Enrich with attribution + device context and flatten route params to
+    // top-level properties so utm_source / utm_campaign are queryable in
+    // Amplitude (matching how track() enriches every other event), instead
+    // of arriving as a nested `params` object.
+    trackAmplitude(
+      AmplitudeEvent.PAGE_VIEWED,
+      sanitize(enrichEventParams({ pathname, ...params })),
+    );
   } catch (error) {
     console.error('Error tracking Amplitude screen:', error);
   }


### PR DESCRIPTION
Cherry-picks the analytics fix from #2127 (merged to `qa`) onto `master`.

## Why
On web, `Page Viewed` never fired. `initAnalytics` is gated behind `splashScreenHidden`, which only flips inside `onLayoutRootView`. That `onLayout` was attached to `SafeAreaProvider`, which doesn't forward an arbitrary `onLayout` to its underlying view on web (it only wires its own inset measurement) — so the callback never ran and analytics was never initialized. Native works because the native `SafeAreaProvider` forwards `onLayout`.

## Changes
- **Move `onLayout` → `GestureHandlerRootView`** (keeping master's `style={{ flex: 1 }}`), which passes it through to a react-native-web `View` (fires via `ResizeObserver`) on web and lays out normally on native. This is the blocker — nothing fired without it.
- **Gate `trackScreen` behind a new `analyticsReady` flag** set once `initAnalytics` resolves, so the first (landing) `Page Viewed` fires after init instead of being queued before the Amplitude proxy `serverUrl` is configured and flushed to the wrong endpoint.
- **Enrich the Amplitude `Page Viewed`** via a shared `enrichEventParams()` helper so UTM/attribution fields land as top-level, queryable properties (`utm_source`, `utm_campaign`, …) and route params are flattened instead of nested under a `params` object. Kept on the Amplitude-only path to avoid double-counting in Firebase/GTM.

## Notes
Cherry-pick of `a6a67057`. The only conflict (`app/_layout.tsx`) came from master's "streamline loading states" refactor, which had already added `style={{ flex: 1 }}` to both providers; resolved by keeping that styling while applying the `onLayout` move. `lib/analytics.ts` applied without conflict.

https://claude.ai/code/session_01KR9AG8hkYVigCMsQmDKGS2

---
_Generated by [Claude Code](https://claude.ai/code/session_01KR9AG8hkYVigCMsQmDKGS2)_