### PR TITLE
Remove price change percentage display from chart tooltips

### DIFF
--- a/components/AreaChart.tsx
+++ b/components/AreaChart.tsx
@@ -57,7 +57,6 @@ const ChartContent = ({
   const [tooltipData, setTooltipData] = useState<{
     price: string;
     date: string;
-    priceChange: number | null;
   } | null>(null);
 
   const { currentIndex, isActive } = LineChart.useChart();
@@ -84,16 +83,9 @@ const ChartContent = ({
             return `$${formatNumber(value)}`;
           };
 
-          const prevData = index > 0 ? data[index - 1] : null;
-          const change =
-            prevData && currentData
-              ? calculatePercentageChange(prevData.value, currentData.value)
-              : null;
-
           setTooltipData({
             price: formatToolTip ? formatToolTip(currentData.value) : format(currentData.value),
             date: formatChartTooltipDate(currentData.time),
-            priceChange: change,
           });
           setTooltipVisible(true);
         }
@@ -267,20 +259,7 @@ const ChartContent = ({
           <Text style={{ fontSize: 16, fontWeight: '600', color: '#18181B' }}>
             {tooltipData.price}
           </Text>
-          <View style={{ flexDirection: 'row', alignItems: 'center', gap: 8, marginTop: 4 }}>
-            {tooltipData.priceChange !== null && (
-              <Text
-                style={{
-                  fontSize: 14,
-                  fontWeight: '600',
-                  color: tooltipData.priceChange < 0 ? '#EF4444' : '#22C55E',
-                }}
-              >
-                {formatNumber(tooltipData.priceChange, 2)}%
-              </Text>
-            )}
-            <Text style={{ fontSize: 14, color: '#9CA3AF' }}>{tooltipData.date}</Text>
-          </View>
+          <Text style={{ fontSize: 14, color: '#9CA3AF', marginTop: 4 }}>{tooltipData.date}</Text>
         </View>
       )}
     </>

--- a/components/AreaChart.web.tsx
+++ b/components/AreaChart.web.tsx
@@ -83,9 +83,7 @@ const Chart = ({
           tickLine={false}
         />
 
-        <Tooltip
-          content={<ChartTooltip data={chartData} formatToolTip={formatToolTip} isPriceChange />}
-        />
+        <Tooltip content={<ChartTooltip data={chartData} formatToolTip={formatToolTip} />} />
 
         <Area
           type="linear"

--- a/components/ChartTooltip.tsx
+++ b/components/ChartTooltip.tsx
@@ -4,7 +4,7 @@ import { useShallow } from 'zustand/react/shallow';
 
 import { Text } from '@/components/ui/text';
 import { ChartPayload } from '@/lib/types';
-import { cn, formatNumber } from '@/lib/utils';
+import { formatNumber } from '@/lib/utils';
 import { formatChartTooltipDate } from '@/lib/utils/chartDate';
 import { useCoinStore } from '@/store/useCoinStore';
 
@@ -17,7 +17,6 @@ interface ChartTooltipProps {
   payload?: TooltipPayload[];
   data?: ChartPayload[];
   formatToolTip?: (value: number | null) => string;
-  isPriceChange?: boolean;
 }
 
 export function calculatePercentageChange(oldValue: number, newValue: number) {
@@ -28,22 +27,14 @@ export function calculatePercentageChange(oldValue: number, newValue: number) {
   return ((newValue - oldValue) / oldValue) * 100;
 }
 
-const ChartTooltip = ({
-  active,
-  payload,
-  data,
-  formatToolTip,
-  isPriceChange,
-}: ChartTooltipProps) => {
-  const { selectedPrice, selectedPriceChange, setSelectedPriceChange, setSelectedPrice } =
-    useCoinStore(
-      useShallow(state => ({
-        selectedPrice: state.selectedPrice,
-        selectedPriceChange: state.selectedPriceChange,
-        setSelectedPriceChange: state.setSelectedPriceChange,
-        setSelectedPrice: state.setSelectedPrice,
-      })),
-    );
+const ChartTooltip = ({ active, payload, data, formatToolTip }: ChartTooltipProps) => {
+  const { selectedPrice, setSelectedPriceChange, setSelectedPrice } = useCoinStore(
+    useShallow(state => ({
+      selectedPrice: state.selectedPrice,
+      setSelectedPriceChange: state.setSelectedPriceChange,
+      setSelectedPrice: state.setSelectedPrice,
+    })),
+  );
   const [currentTimestamp, setCurrentTimestamp] = useState<number | string>(0);
   const prevPayloadRef = useRef<any>(null);
 
@@ -100,21 +91,9 @@ const ChartTooltip = ({
         <Text className="text-lg font-semibold text-primary-foreground">
           {formatToolTip ? formatToolTip(selectedPrice) : format(selectedPrice)}
         </Text>
-        <View className="flex-row gap-2">
-          {isPriceChange && selectedPriceChange && (
-            <Text
-              className={cn(
-                'text-sm font-semibold',
-                selectedPriceChange < 0 ? 'text-red-500' : 'text-green-500',
-              )}
-            >
-              {formatNumber(selectedPriceChange, 2)}%
-            </Text>
-          )}
-          <Text className="text-sm text-muted-foreground">
-            {formatChartTooltipDate(currentTimestamp)}
-          </Text>
-        </View>
+        <Text className="text-sm text-muted-foreground">
+          {formatChartTooltipDate(currentTimestamp)}
+        </Text>
       </View>
     </View>
   );


### PR DESCRIPTION
## Summary
This PR removes the price change percentage feature from chart tooltips across all chart components. The percentage change calculation and conditional rendering logic has been stripped out, simplifying the tooltip UI to display only the price and date information.

## Key Changes
- **ChartTooltip.tsx**: 
  - Removed `isPriceChange` prop from component interface
  - Removed `cn` utility import (no longer needed)
  - Removed `selectedPriceChange` from store subscription
  - Removed conditional rendering of percentage change text with color styling
  - Simplified tooltip layout to show only price and date

- **AreaChart.tsx**:
  - Removed `priceChange` field from tooltip data state
  - Removed percentage change calculation logic (`calculatePercentageChange` call)
  - Removed conditional rendering of price change percentage in native tooltip UI
  - Simplified tooltip data structure to only track price and date

- **AreaChart.web.tsx**:
  - Removed `isPriceChange` prop when passing to `ChartTooltip` component

## Implementation Details
The changes maintain the core tooltip functionality while reducing visual complexity. The percentage change calculation logic remains exported from `ChartTooltip.tsx` but is no longer used by any components. The tooltip now consistently displays only the formatted price and formatted date across both web and native implementations.

https://claude.ai/code/session_01KE3gjUzyjkEN8ntFCkDTNC