### PR TITLE
Refine passkey FAQ modal layout

### DIFF
--- a/components/PasskeyFaqModal.tsx
+++ b/components/PasskeyFaqModal.tsx
@@ -23,10 +23,11 @@ const PasskeyFaqModal = ({ isOpen, onOpenChange }: PasskeyFaqModalProps) => {
       onOpenChange={onOpenChange}
       trigger={null}
       contentKey="passkey-faq"
-      contentClassName="md:max-w-md"
+      contentClassName="md:max-w-[40rem] md:px-4 md:pt-4"
+      containerClassName="gap-0"
       shouldAnimate={false}
     >
-      <View className="gap-6">
+      <View>
         <View className="items-center">
           <LottieView
             source={require('@/assets/animations/vault.json')}
@@ -36,8 +37,10 @@ const PasskeyFaqModal = ({ isOpen, onOpenChange }: PasskeyFaqModalProps) => {
             resizeMode="contain"
           />
         </View>
-        <Text className="native:text-2xl text-xl font-semibold">Passkey FAQ</Text>
-        <FAQ faqs={passkeyFaqs} />
+        <View className="gap-6">
+          <Text className="native:text-2xl text-xl font-semibold">Passkey FAQ</Text>
+          <FAQ faqs={passkeyFaqs} />
+        </View>
       </View>
     </ResponsiveModal>
   );


### PR DESCRIPTION
Follow-up layout refinements to the passkey FAQ modal (original feature merged via #2143).

### Changes
- **Wider modal:** desktop `max-width` 28rem → **40rem**.
- **Tighter top spacing:** removed the gap between the close button → vault and vault → title, since the vault Lottie already includes its own top/bottom spacing. The gap between the title and the FAQ list is preserved.
- **Padding:** reduced desktop modal padding from 2rem → **1rem**.

All scoped to `components/PasskeyFaqModal.tsx` (props + child grouping only — no changes to the shared `ResponsiveModal`). `tsc`, `eslint`, and `prettier` clean.

https://claude.ai/code/session_01C4Jn2RkCUkojpkS83nynmg

---
_Generated by [Claude Code](https://claude.ai/code/session_01C4Jn2RkCUkojpkS83nynmg)_