### PR TITLE
fix: correct card-deposit activity display, dedup, and premature success

### DIFF
--- a/app/(protected)/(tabs)/activity/[clientTxId].tsx
+++ b/app/(protected)/(tabs)/activity/[clientTxId].tsx
@@ -18,7 +18,7 @@ import { Button } from '@/components/ui/button';
 import { Text } from '@/components/ui/text';
 import { Underline } from '@/components/ui/underline';
 import { path } from '@/constants/path';
-import { TRANSACTION_DETAILS } from '@/constants/transaction';
+import { getTransactionCategory, TRANSACTION_DETAILS } from '@/constants/transaction';
 import { useActivity } from '@/hooks/useActivity';
 import useCancelOnchainWithdraw from '@/hooks/useCancelOnchainWithdraw';
 import { useCardProvider } from '@/hooks/useCardProvider';
@@ -502,14 +502,9 @@ export default function ActivityDetail() {
     if (isDeposit && finalActivity?.status === TransactionStatus.SUCCESS) {
       return 'Complete';
     }
-    return transactionDetails?.category ?? 'Unknown';
-  }, [
-    finalActivity?.type,
-    finalActivity?.status,
-    finalActivity?.metadata?.destination,
-    isDeposit,
-    transactionDetails?.category,
-  ]);
+    if (!finalActivity) return 'Unknown';
+    return getTransactionCategory(finalActivity.type, finalActivity.title) ?? 'Unknown';
+  }, [finalActivity, isDeposit]);
 
   const tokenIcon = useMemo(
     () => (finalActivity ? getTokenIcon({ tokenSymbol: finalActivity.symbol, size: 75 }) : null),

--- a/components/Transaction/index.tsx
+++ b/components/Transaction/index.tsx
@@ -8,7 +8,7 @@ import RenderTokenIcon from '@/components/RenderTokenIcon';
 import ResponsiveDialog from '@/components/ResponsiveDialog';
 import { Button } from '@/components/ui/button';
 import { Text } from '@/components/ui/text';
-import { TRANSACTION_DETAILS } from '@/constants/transaction';
+import { getTransactionCategory, TRANSACTION_DETAILS } from '@/constants/transaction';
 import { useDimension } from '@/hooks/useDimension';
 import { useDirectDepositSession } from '@/hooks/useDirectDepositSession';
 import { getAsset } from '@/lib/assets';
@@ -221,7 +221,7 @@ const Transaction = ({
     if (isRefunded) return 'Refunded';
     if (isCancelled) return 'Cancelled';
     if (isSuccess && isDeposit) return 'Complete';
-    return transactionDetails?.category ?? 'Unknown';
+    return getTransactionCategory(type, title) ?? 'Unknown';
   };
 
   const formatTimestamp = () => {

--- a/constants/transaction.ts
+++ b/constants/transaction.ts
@@ -119,3 +119,46 @@ export const TRANSACTION_DETAILS: Record<TransactionType, TransactionDetails> = 
     category: TransactionCategory.WALLET_TRANSFER,
   },
 };
+
+/**
+ * Resolve the user-facing transaction category.
+ *
+ * BRIDGE_DEPOSIT is dual-use: the same type backs both real cross-chain
+ * bridges (→ "External wallet transfer") and "Deposit … to Card" deposits
+ * where soUSD/USDC is bridged from Fuse to the card funding address. The
+ * static map can't tell them apart, so a savings→card deposit was showing as
+ * "External wallet transfer". Relabel the card variant (title contains
+ * "Card", matching the backend's title convention for card deposits) as
+ * "Card deposit".
+ */
+export const getTransactionCategory = (
+  type: TransactionType,
+  title?: string,
+): TransactionCategory | undefined => {
+  if (type === TransactionType.BRIDGE_DEPOSIT && title?.toLowerCase().includes('card')) {
+    return TransactionCategory.CARD_DEPOSIT;
+  }
+  return TRANSACTION_DETAILS[type]?.category;
+};
+
+/**
+ * Card-deposit activity types that bridge from Fuse to the destination (card
+ * funding / Rain collateral) via Stargate/LayerZero. Their SOURCE-chain receipt
+ * confirms within seconds, but the funds take minutes to arrive — so a
+ * source-chain receipt success must NOT mark them complete. The backend
+ * finalizes them to SUCCESS from the Rain collateral webhook (destination
+ * confirmation). Used to exclude them from client-side receipt polling, which
+ * otherwise flipped every card deposit to SUCCESS instantly.
+ */
+export const SOURCE_RECEIPT_NON_FINAL_TYPES: ReadonlySet<TransactionType> = new Set([
+  TransactionType.BRIDGE_DEPOSIT,
+  TransactionType.BORROW_AND_DEPOSIT_TO_CARD,
+  TransactionType.CARD_DEPOSIT,
+]);
+
+/**
+ * Whether an activity reaching a successful source-chain receipt can be treated
+ * as complete. False for cross-chain card deposits (see above).
+ */
+export const isSourceReceiptFinalizable = (type: TransactionType): boolean =>
+  !SOURCE_RECEIPT_NON_FINAL_TYPES.has(type);

--- a/hooks/useTransactionReceiptPolling.ts
+++ b/hooks/useTransactionReceiptPolling.ts
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useRef } from 'react';
 import { useQueries, useQuery } from '@tanstack/react-query';
 import { getTransactionReceipt } from 'viem/actions';
 
+import { isSourceReceiptFinalizable } from '@/constants/transaction';
 import { useActivityActions } from '@/hooks/useActivityActions';
 import { ActivityEvent, TransactionStatus } from '@/lib/types';
 import { publicClient } from '@/lib/wagmi';
@@ -17,7 +18,11 @@ export const useTransactionReceiptPolling = (activity: ActivityEvent | null | un
     !!activity &&
     activity.status === TransactionStatus.PROCESSING &&
     !!activity.hash &&
-    !!activity.chainId;
+    !!activity.chainId &&
+    // Cross-chain card deposits stay PROCESSING after the source tx mines —
+    // the bridge to the card funding address takes minutes and is confirmed by
+    // the Rain collateral webhook, not the source-chain receipt.
+    isSourceReceiptFinalizable(activity.type);
 
   return useQuery({
     queryKey: ['tx-receipt-poll', activity?.clientTxId, activity?.hash],
@@ -70,6 +75,9 @@ export const useProcessingActivitiesPolling = (activities: ActivityEvent[]) => {
           a.status === TransactionStatus.PROCESSING &&
           a.hash &&
           a.chainId &&
+          // Don't finalize cross-chain card deposits on their source-chain
+          // receipt; they complete via the Rain collateral webhook.
+          isSourceReceiptFinalizable(a.type) &&
           !confirmedRef.current.has(a.clientTxId),
       ),
     [activities],

--- a/lib/getTokenIcon.tsx
+++ b/lib/getTokenIcon.tsx
@@ -17,6 +17,10 @@ const getTokenIcon = ({ logoUrl, tokenSymbol, size = 24 }: GetTokenIconProps): T
   // Fallback to default token icons based on symbol
   switch (tokenSymbol?.toUpperCase()) {
     case 'USDC':
+    // Bridged USDC variants (e.g. USDC.e on Fuse/Arbitrum, used by the
+    // borrow-and-deposit-to-card flow) share the USDC icon. Without this the
+    // detail page fell back to the "U" placeholder.
+    case 'USDC.E':
       return {
         type: 'image',
         source: getAsset('images/usdc-4x.png'),

--- a/lib/utils/__tests__/card-deposit-activity.test.ts
+++ b/lib/utils/__tests__/card-deposit-activity.test.ts
@@ -1,0 +1,108 @@
+/// <reference types="jest" />
+import { getTransactionCategory, isSourceReceiptFinalizable } from '@/constants/transaction';
+import {
+  ActivityEvent,
+  TransactionCategory,
+  TransactionStatus,
+  TransactionType,
+} from '@/lib/types';
+import { deduplicateTransactions } from '@/lib/utils/deduplicateTransactions';
+
+function makeActivity(overrides: Partial<ActivityEvent> = {}): ActivityEvent {
+  return {
+    clientTxId: 'tx-1',
+    type: TransactionType.CARD_DEPOSIT,
+    status: TransactionStatus.SUCCESS,
+    amount: '0.01',
+    symbol: 'USDC',
+    timestamp: '1781426763',
+    title: 'Deposit to Card',
+    ...overrides,
+  } as ActivityEvent;
+}
+
+describe('deduplicateTransactions — connect-wallet card deposit', () => {
+  // Real shape from a Wallet-source Rain card deposit: the frontend creates the
+  // base trackingId activity (with the on-chain hash) and the backend Temporal
+  // workflow creates `${trackingId}_card`. They must render as ONE row.
+  const frontend = makeActivity({
+    clientTxId: 'mqdjhtjp-g038q1a0',
+    title: 'Deposit USDC to Card',
+    userOpHash: '0x92d8602bde4171b6686544d4d2fa61ba0b5db07cb4458da85a94ae6347a1b527',
+    hash: '0x7843ea7492494d0adfb3b913c6bfb2f87daf5a6f6714a12df6c79387d60664cb',
+    toAddress: '0x9e852a0d1bd9738d52b90a5e907138575822d69e',
+    metadata: { source: 'transaction-hook' },
+  });
+  const backendCard = makeActivity({
+    clientTxId: 'mqdjhtjp-g038q1a0_card',
+    title: 'Deposit to Card',
+    userOpHash: '0x4acf1672858e422d8a760b2ffde946f3ad90d4bfe0965a77d8e2150bf9f665f3',
+    toAddress: '0xcf06a945cecc2651b78d055b6246ae1622c9e966',
+    metadata: {},
+  });
+
+  it('collapses trackingId and trackingId_card into a single row', () => {
+    const result = deduplicateTransactions([backendCard, frontend]);
+    expect(result).toHaveLength(1);
+  });
+
+  it('keeps the row carrying the on-chain hash (the explorer link)', () => {
+    const result = deduplicateTransactions([backendCard, frontend]);
+    expect(result[0].clientTxId).toBe('mqdjhtjp-g038q1a0');
+    expect(result[0].hash).toBe(frontend.hash);
+  });
+
+  it('still keeps a savings deposit and its _savings step separate', () => {
+    const base = makeActivity({
+      clientTxId: 'dep-1',
+      type: TransactionType.DEPOSIT,
+      title: 'Deposit USDC',
+      hash: '0x1111111111111111111111111111111111111111111111111111111111111111',
+    });
+    const savings = makeActivity({
+      clientTxId: 'dep-1_savings',
+      type: TransactionType.DEPOSIT,
+      title: 'Deposit soUSD to Savings',
+    });
+    const result = deduplicateTransactions([base, savings]);
+    expect(result).toHaveLength(2);
+  });
+});
+
+describe('getTransactionCategory', () => {
+  it('labels a card-bound bridge_deposit as Card deposit', () => {
+    expect(getTransactionCategory(TransactionType.BRIDGE_DEPOSIT, 'Deposit soUSD to Card')).toBe(
+      TransactionCategory.CARD_DEPOSIT,
+    );
+  });
+
+  it('leaves a real bridge_deposit as External wallet transfer', () => {
+    expect(getTransactionCategory(TransactionType.BRIDGE_DEPOSIT, 'Bridge to Arbitrum')).toBe(
+      TransactionCategory.EXTERNAL_WALLET_TRANSFER,
+    );
+  });
+
+  it('falls back to the static category for other types', () => {
+    expect(getTransactionCategory(TransactionType.CARD_TRANSACTION, 'Card Deposit')).toBe(
+      TransactionCategory.CARD_DEPOSIT,
+    );
+    expect(getTransactionCategory(TransactionType.SEND, 'Sent USDC')).toBe(
+      TransactionCategory.WALLET_TRANSFER,
+    );
+  });
+});
+
+describe('isSourceReceiptFinalizable', () => {
+  // Cross-chain card deposits must NOT be marked complete on their source-chain
+  // receipt — they bridge for minutes and finalize via the Rain webhook.
+  it('is false for cross-chain card deposit types', () => {
+    expect(isSourceReceiptFinalizable(TransactionType.BRIDGE_DEPOSIT)).toBe(false);
+    expect(isSourceReceiptFinalizable(TransactionType.BORROW_AND_DEPOSIT_TO_CARD)).toBe(false);
+    expect(isSourceReceiptFinalizable(TransactionType.CARD_DEPOSIT)).toBe(false);
+  });
+
+  it('is true for same-chain types resolved by a source-chain receipt', () => {
+    expect(isSourceReceiptFinalizable(TransactionType.SEND)).toBe(true);
+    expect(isSourceReceiptFinalizable(TransactionType.CARD_TRANSACTION)).toBe(true);
+  });
+});

--- a/lib/utils/deduplicateTransactions.ts
+++ b/lib/utils/deduplicateTransactions.ts
@@ -32,6 +32,23 @@ function isDuplicate(a: ActivityEvent, b: ActivityEvent): boolean {
     }
   }
 
+  // A connect-wallet card deposit creates TWO card_deposit activities for the
+  // same user action: the frontend's optimistic one (trackingId) and the
+  // backend Temporal workflow's card-funding one (`${trackingId}_card`).
+  // Unlike the savings flow above (two distinct user-visible steps), these are
+  // the same step — collapse them so the deposit shows once. The keep-decision
+  // below prefers the row with an on-chain hash (the frontend doc), which
+  // carries the explorer link.
+  if (a.clientTxId && b.clientTxId && a.clientTxId !== b.clientTxId) {
+    const aIsCard = a.clientTxId.endsWith('_card');
+    const bIsCard = b.clientTxId.endsWith('_card');
+    if (aIsCard !== bIsCard) {
+      const cardId = aIsCard ? a.clientTxId : b.clientTxId;
+      const otherId = aIsCard ? b.clientTxId : a.clientTxId;
+      if (cardId === `${otherId}_card`) return true;
+    }
+  }
+
   // Normalize hash values for comparison (lowercase, trim)
   const normalizeHash = (hash: string | undefined) => hash?.toLowerCase().trim();
   const aHash = normalizeHash(a.hash);


### PR DESCRIPTION
Addresses four card-deposit activity issues, all Rain-era:

- Instant SUCCESS: useProcessingActivitiesPolling / useTransactionReceiptPolling marked any PROCESSING activity SUCCESS as soon as its SOURCE-chain receipt mined. Stargate card deposits (BRIDGE_DEPOSIT, BORROW_AND_DEPOSIT_TO_CARD) confirm on Fuse in seconds but take minutes to bridge, so they flipped to SUCCESS before the funds arrived. Exclude cross-chain card-deposit types from source-receipt promotion (new isSourceReceiptFinalizable); they now finalize via the Rain collateral webhook (destination confirmation).

- "External wallet transfer" mislabel: BRIDGE_DEPOSIT is dual-use (real bridges AND "Deposit … to Card"), but the static category map labels it EXTERNAL_WALLET_TRANSFER. Add getTransactionCategory to relabel the card variant (title contains "Card") as "Card deposit", used by both the list row and the detail page.

- Duplicate row: a connect-wallet card deposit creates two card_deposit activities — the frontend's trackingId and the backend workflow's `${trackingId}_card`. Collapse them in deduplicateTransactions (keeping the row with the on-chain hash), mirroring the savings two-step special-case.

- "U" placeholder icon: USDC.e (borrow-and-deposit-to-card symbol) missed the 'USDC' case in getTokenIcon (toUpperCase → 'USDC.E') and fell back to the DefaultTokenIcon placeholder on the detail page. Map USDC.E to the USDC icon.