### PR TITLE
Add platform-specific filtering for promotion banners

### DIFF
--- a/components/Dashboard/HomeBanners.tsx
+++ b/components/Dashboard/HomeBanners.tsx
@@ -26,6 +26,9 @@ import { PanGestureProvider, usePanGesture } from './PanGestureContext';
 import type { PanGesture } from 'react-native-gesture-handler';
 import type { SharedValue } from 'react-native-reanimated';
 
+const PLATFORM_KEY: 'web' | 'android' | 'ios' =
+  Platform.OS === 'ios' ? 'ios' : Platform.OS === 'android' ? 'android' : 'web';
+
 type BannerData = React.ReactElement[];
 
 type BannerItemProps = {
@@ -134,8 +137,11 @@ const HomeBannersContent = ({ data: propData }: HomeBannersContentProps) => {
   const HAS_MULTIPLE_VIEWS = VIEW_COUNT > 1;
 
   const defaultData = useMemo(() => {
-    if (promotionsBanner?.length) {
-      const sorted = [...promotionsBanner].sort((a, b) => a.sort - b.sort);
+    const platformBanners = promotionsBanner?.filter(
+      item => !item.platforms || item.platforms[PLATFORM_KEY] !== false,
+    );
+    if (platformBanners?.length) {
+      const sorted = [...platformBanners].sort((a, b) => a.sort - b.sort);
       return sorted.map((item, i) => (
         <PromoImageBanner
           key={`promo-${item.slug}-${i}`}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1647,12 +1647,19 @@ export interface WhatsNew {
   createdAt: string;
 }
 
+export interface PromotionsBannerPlatforms {
+  web: boolean;
+  android: boolean;
+  ios: boolean;
+}
+
 export interface PromotionsBannerItem {
   imageURL: string;
   mobileImageURL?: string;
   slug: string;
   sort: number;
   link?: string;
+  platforms?: PromotionsBannerPlatforms;
 }
 
 export type PromotionsBannerResponse = PromotionsBannerItem[];


### PR DESCRIPTION
## Summary
This PR adds support for platform-specific visibility control of promotion banners, allowing banners to be selectively shown or hidden on web, Android, and iOS platforms.

## Key Changes
- Added `PromotionsBannerPlatforms` interface to define platform visibility flags (web, android, ios)
- Extended `PromotionsBannerItem` type with optional `platforms` field for platform-specific configuration
- Introduced `PLATFORM_KEY` constant to detect the current platform at runtime
- Updated `HomeBannersContent` to filter promotion banners based on platform availability before rendering

## Implementation Details
- The platform detection uses React Native's `Platform.OS` to determine the current environment
- Banners without a `platforms` field are shown on all platforms (backward compatible)
- Banners with `platforms` defined are filtered out if their platform flag is explicitly set to `false`
- Filtering occurs before sorting and rendering, ensuring only applicable banners are processed

https://claude.ai/code/session_01WGVVdgpzhPCbh9ADiYLNZw