### PR TITLE
fix(tabs): respect bottom safe-area inset in custom tab bar

### DIFF
--- a/components/CustomTabBar.tsx
+++ b/components/CustomTabBar.tsx
@@ -1,11 +1,24 @@
 import { useEffect, useRef, useState } from 'react';
 import { Animated, Platform, Pressable, StyleSheet, View, type ViewStyle } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import * as Haptics from 'expo-haptics';
 import { BottomTabBarProps } from '@react-navigation/bottom-tabs';
 import { CommonActions } from '@react-navigation/native';
 
 import TabBarBackground from '@/components/ui/TabBarBackground';
 import { Text } from '@/components/ui/text';
+
+// Height of the visible content zone (icons + labels + top padding) that sits
+// above the bottom safe-area inset. Combined with the dynamic bottom inset this
+// reproduces the original height of 80 (45 + 35) on devices without a large
+// system bar, while keeping the icon/label band a constant size everywhere.
+const TAB_BAR_CONTENT_HEIGHT = 45;
+// Baseline bottom spacing. Matches the previously hardcoded paddingBottom so
+// devices whose safe-area inset is smaller — notched iOS (~34), gesture-nav
+// Android (~16-24) and web (0) — keep their exact current layout. Only devices
+// with a larger inset (e.g. Android 3-button navigation, ~48) get extra spacing
+// so the tab bar clears the system navigation bar instead of overlapping it.
+const TAB_BAR_MIN_BOTTOM_INSET = 35;
 
 type TabButtonProps = {
   label: string;
@@ -106,11 +119,24 @@ function TabButton({ label, icon, isFocused, onPress, onLongPress }: TabButtonPr
 const VISIBLE_TAB_NAMES = ['index', 'savings', 'card', 'activity'];
 
 export function CustomTabBar({ state, descriptors, navigation }: BottomTabBarProps) {
+  const insets = useSafeAreaInsets();
+
+  // Lift the tab bar above the system navigation bar / home indicator using the
+  // real bottom inset, never shrinking below the legacy baseline. Read-only —
+  // this does not alter the inset context, so other components (ResponsiveModal,
+  // SafeAreaView, ScrollViews) are unaffected.
+  const bottomInset = Math.max(insets.bottom, TAB_BAR_MIN_BOTTOM_INSET);
+
   // Filter to only show the main visible tabs
   const visibleRoutes = state.routes.filter(route => VISIBLE_TAB_NAMES.includes(route.name));
 
   return (
-    <View style={styles.tabBar}>
+    <View
+      style={[
+        styles.tabBar,
+        { height: TAB_BAR_CONTENT_HEIGHT + bottomInset, paddingBottom: bottomInset },
+      ]}
+    >
       {TabBarBackground && <TabBarBackground />}
       {visibleRoutes.map(route => {
         const { options } = descriptors[route.key];
@@ -166,9 +192,8 @@ export function CustomTabBar({ state, descriptors, navigation }: BottomTabBarPro
 const styles = StyleSheet.create({
   tabBar: {
     flexDirection: 'row',
-    height: 80,
+    // height and paddingBottom are applied dynamically from the safe-area inset
     paddingTop: 10,
-    paddingBottom: 35,
     backgroundColor: Platform.OS === 'web' ? 'rgba(18, 18, 18, 0.7)' : 'transparent',
     borderTopWidth: 0,
     position: 'absolute',


### PR DESCRIPTION
## Summary

Backport of #2161 (merged to `qa`) onto `master` via cherry-pick of `edb00867`.

The mobile tab bar (`components/CustomTabBar.tsx`) used a hardcoded `paddingBottom: 35` / `height: 80`, unlike react-navigation's default `BottomTabBar` which adds `insets.bottom`. With edge-to-edge enabled on Android (Expo SDK 55 default), devices with a 3-button navigation bar (~48px inset) render the tab labels behind the system navigation. iOS notch (~34px) and Android gesture-nav (~16–24px) are ≤ 35px, which is why the issue was Android-3-button-specific and not reported on iOS.

## Changes
- Drive the tab bar's `height` and `paddingBottom` from `useSafeAreaInsets()`.
- Floor the bottom spacing at the previous `35px` baseline via `Math.max(insets.bottom, 35)`, so every device whose inset is ≤ 35 (notched iOS, gesture-nav Android, web) keeps a **byte-for-byte identical layout**, and only devices with a larger inset (Android 3-button nav) get the bar lifted to clear the system bar.
- Keep the icon/label content band a constant `45px` so icons render unchanged.
- Move the now-dynamic `height`/`paddingBottom` out of the static `StyleSheet`.

## Why it's safe
- `useSafeAreaInsets()` is a read-only consumer of the safe-area context — it does not alter insets for any other component (`ResponsiveModal`, `SafeAreaView`, `ScrollView`).
- Background transparency is untouched: the container stays `transparent` and `TabBarBackground` still fills it via `absoluteFill`.
- The tab bar height is exposed only through `BottomTabBarHeightContext`, which no screen consumes, so no scene layout shifts.

## Notes
- Cherry-pick required a one-line import merge: `master`'s newer `CustomTabBar` (animated focus transitions, `CommonActions` navigation, color constants) is fully preserved; only the `useSafeAreaInsets` import was added alongside the existing `react` / `react-native` imports.
- Verified: `eslint components/CustomTabBar.tsx` passes; diff vs `master` is the fix only (1 file, +28/-3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018e9GKc95TRVG3rNi3WGJHt

---
_Generated by [Claude Code](https://claude.ai/code/session_018e9GKc95TRVG3rNi3WGJHt)_