### PR TITLE
fix(tabs): add extra bottom clearance on Android for tall nav bars

### DIFF
--- a/components/CustomTabBar.tsx
+++ b/components/CustomTabBar.tsx
@@ -19,6 +19,13 @@ const TAB_BAR_CONTENT_HEIGHT = 45;
 // with a larger inset (e.g. Android 3-button navigation, ~48) get extra spacing
 // so the tab bar clears the system navigation bar instead of overlapping it.
 const TAB_BAR_MIN_BOTTOM_INSET = 35;
+// Extra clearance added on top of the *real* inset on Android only. Android
+// system navigation bars sit flush with the bottom inset, and the icon+label
+// content slightly overflows the visible band, so on devices with a tall
+// navigation bar (3-button nav) the label can still touch it. Added to the real
+// inset (not the floor) so gesture-nav devices barely change; iOS (thin home
+// indicator) and web have no such overlap and are deliberately excluded.
+const TAB_BAR_ANDROID_EXTRA_INSET = 16;
 
 type TabButtonProps = {
   label: string;
@@ -122,10 +129,14 @@ export function CustomTabBar({ state, descriptors, navigation }: BottomTabBarPro
   const insets = useSafeAreaInsets();
 
   // Lift the tab bar above the system navigation bar / home indicator using the
-  // real bottom inset, never shrinking below the legacy baseline. Read-only —
-  // this does not alter the inset context, so other components (ResponsiveModal,
-  // SafeAreaView, ScrollViews) are unaffected.
-  const bottomInset = Math.max(insets.bottom, TAB_BAR_MIN_BOTTOM_INSET);
+  // real bottom inset (plus a little extra on Android, see constant), never
+  // shrinking below the legacy baseline. Read-only — this does not alter the
+  // inset context, so other components (ResponsiveModal, SafeAreaView,
+  // ScrollViews) are unaffected.
+  const bottomInset = Math.max(
+    insets.bottom + (Platform.OS === 'android' ? TAB_BAR_ANDROID_EXTRA_INSET : 0),
+    TAB_BAR_MIN_BOTTOM_INSET,
+  );
 
   // Filter to only show the main visible tabs
   const visibleRoutes = state.routes.filter(route => VISIBLE_TAB_NAMES.includes(route.name));


### PR DESCRIPTION
## Summary

Follow-up to #2164 (v1, already merged to `master`). After the initial safe-area fix, the tab **label** still grazes tall Android 3-button navigation bars: the icon+label content slightly overflows the visible band and dips below the inset line, so even with `paddingBottom = insets.bottom` the label touches the system bar.

## Change
- Add `TAB_BAR_ANDROID_EXTRA_INSET = 16`, applied **on top of the real inset, on Android only**.
- Because it's added to the real inset (not the 35px floor), **gesture-nav Android devices barely change** (their inset is below the floor), while **3-button-nav devices get lifted clear** of the system bar.
- **iOS** (thin home indicator) and **web** have no such overlap and are explicitly excluded, so they stay **byte-for-byte unchanged**.

```
bottomInset = max(insets.bottom + (Android ? 16 : 0), 35)
```

## Safety
Same guarantees as #2164: `useSafeAreaInsets()` is read-only (no inset-context mutation → `ResponsiveModal`/`SafeAreaView`/`ScrollView` unaffected); background transparency untouched; tab bar height is exposed only via `BottomTabBarHeightContext`, which no screen consumes.

Verified: `eslint components/CustomTabBar.tsx` passes; diff vs `master` is the v2 delta only (1 file, +15/−4). The equivalent change for `qa` is in a parallel PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018e9GKc95TRVG3rNi3WGJHt

---
_Generated by [Claude Code](https://claude.ai/code/session_018e9GKc95TRVG3rNi3WGJHt)_