### PR TITLE
Add Bangladesh minimum card deposit requirement to issuance flow

### DIFF
--- a/app/(protected)/(tabs)/card/details.tsx
+++ b/app/(protected)/(tabs)/card/details.tsx
@@ -31,9 +31,11 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { Text } from '@/components/ui/text';
+import { path } from '@/constants/path';
 import { useCardDetails } from '@/hooks/useCardDetails';
 import { useCardDetailsReveal } from '@/hooks/useCardDetailsReveal';
 import { useCardProvider } from '@/hooks/useCardProvider';
+import { useCardStatus } from '@/hooks/useCardStatus';
 import { useCardWithdrawals } from '@/hooks/useCardWithdrawals';
 import { useCustomer } from '@/hooks/useCustomer';
 import { useDimension } from '@/hooks/useDimension';
@@ -41,16 +43,32 @@ import { freezeCard, unfreezeCard } from '@/lib/api';
 import { getAsset } from '@/lib/assets';
 import { isProduction } from '@/lib/config';
 import { CardHolderName, CardProvider, CardStatus, FreezeInitiator, KycStatus } from '@/lib/types';
-import { cn } from '@/lib/utils/utils';
+import { cn, hasMetCardDeposit, requiresCardDeposit } from '@/lib/utils/utils';
 import { useCardWelcomePopupStore } from '@/store/useCardWelcomePopupStore';
 
 export default function CardDetails() {
+  const router = useRouter();
   const { data: cardDetails, isLoading, refetch } = useCardDetails();
+  const { data: cardStatusResponse } = useCardStatus();
   const { provider } = useCardProvider();
   const { data: customer } = useCustomer();
   const { isScreenMedium } = useDimension();
 
   useCardWithdrawals({ limit: 10 }, { refetchInterval: 300000 });
+
+  // BD users must fund their card with a minimum deposit before they can use
+  // it. Card details is the authoritative gate: bounce unfunded BD users back
+  // to the issuance flow no matter how they got here (card creation redirect,
+  // home card widget, dashboard banner, deep link).
+  const mustDepositFirst =
+    requiresCardDeposit(cardStatusResponse?.country) &&
+    !hasMetCardDeposit(cardStatusResponse?.cardCollateralDeposited);
+
+  useEffect(() => {
+    if (mustDepositFirst) {
+      router.replace(path.CARD_ACTIVATE);
+    }
+  }, [mustDepositFirst, router]);
 
   const [isFreezing, setIsFreezing] = useState(false);
   const [isCardFlipped, setIsCardFlipped] = useState(false);
@@ -159,7 +177,7 @@ export default function CardDetails() {
   // Desktop layout
   if (isScreenMedium) {
     return (
-      <PageLayout desktopOnly isLoading={isLoading} stickyHeader={stickyHeader}>
+      <PageLayout desktopOnly isLoading={isLoading || mustDepositFirst} stickyHeader={stickyHeader}>
         <View className="mx-auto w-full max-w-7xl px-4 pb-12">
           {/* Row 1: Spending Balance Card + Card Image */}
           <View className="mt-12 flex-row gap-6">
@@ -209,7 +227,7 @@ export default function CardDetails() {
 
   // Mobile layout
   return (
-    <PageLayout isLoading={isLoading} stickyHeader={stickyHeader}>
+    <PageLayout isLoading={isLoading || mustDepositFirst} stickyHeader={stickyHeader}>
       <View className="mx-auto w-full max-w-lg px-4">
         <View className="flex-1">
           <BalanceDisplay amount={availableAmount} />

--- a/app/(protected)/(tabs)/card/index.tsx
+++ b/app/(protected)/(tabs)/card/index.tsx
@@ -5,7 +5,7 @@ import CardWaitlistPage from '@/components/CardWaitlist/CardWaitlistPage';
 import PageLayout from '@/components/PageLayout';
 import { useCardStatus } from '@/hooks/useCardStatus';
 import { RainApplicationStatus } from '@/lib/types';
-import { hasCard, hasCardStatusWithRainApplication } from '@/lib/utils';
+import { getActiveCardRoute, hasCard, hasCardStatusWithRainApplication } from '@/lib/utils';
 
 export default function Card() {
   const { data: cardStatus, isLoading } = useCardStatus();
@@ -17,7 +17,10 @@ export default function Card() {
   }
 
   if (userHasCard) {
-    return <Redirect href="/card/details" />;
+    // BD users who haven't met the minimum card deposit are sent to the
+    // issuance flow (activate) to complete the deposit step; everyone else
+    // goes straight to card details.
+    return <Redirect href={getActiveCardRoute(cardStatus)} />;
   }
 
   return <CardWaitlistPage />;

--- a/app/(protected)/(tabs)/card/pending.tsx
+++ b/app/(protected)/(tabs)/card/pending.tsx
@@ -5,7 +5,7 @@ import { CardStatusPage } from '@/components/Card/CardStatusPage';
 import { path } from '@/constants/path';
 import { useCardStatus } from '@/hooks/useCardStatus';
 import { CardStatus, KycStatus, RainApplicationStatus } from '@/lib/types';
-import { hasCard } from '@/lib/utils';
+import { getActiveCardRoute, hasCard } from '@/lib/utils';
 
 const POLL_INTERVAL_MS = 5000;
 
@@ -18,7 +18,9 @@ export default function CardPending() {
 
     // User already has a card (e.g. status synced after this tab was open).
     if (hasCard(cardStatusResponse) && cardStatusResponse.status !== CardStatus.PENDING) {
-      router.replace(path.CARD_DETAILS);
+      // BD users still owe a minimum deposit — route them through the issuance
+      // flow (activate) rather than straight to card details.
+      router.replace(getActiveCardRoute(cardStatusResponse));
       return;
     }
 

--- a/app/(protected)/(tabs)/card/ready.tsx
+++ b/app/(protected)/(tabs)/card/ready.tsx
@@ -9,11 +9,10 @@ import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Text } from '@/components/ui/text';
 import { Underline } from '@/components/ui/underline';
-import { path } from '@/constants/path';
-import { CARD_STATUS_QUERY_KEY } from '@/hooks/useCardStatus';
+import { CARD_STATUS_QUERY_KEY, useCardStatus } from '@/hooks/useCardStatus';
 import { createCard, submitCardConsents } from '@/lib/api';
 import { CardStatus } from '@/lib/types';
-import { withRefreshToken } from '@/lib/utils';
+import { getActiveCardRoute, withRefreshToken } from '@/lib/utils';
 import { useCardWelcomePopupStore } from '@/store/useCardWelcomePopupStore';
 import { useCountryStore } from '@/store/useCountryStore';
 
@@ -52,6 +51,7 @@ const underlineProps = {
 export default function CardReady() {
   const router = useRouter();
   const queryClient = useQueryClient();
+  const { data: cardStatusResponse } = useCardStatus();
   const [activating, setActivating] = useState(false);
   const [consents, setConsents] = useState<ConsentState>(initialConsents);
 
@@ -109,7 +109,9 @@ export default function CardReady() {
 
       if (card.status !== CardStatus.PENDING) {
         setShouldShowWelcomePopup(true);
-        router.replace(path.CARD_DETAILS);
+        // BD users land on the issuance flow to complete the minimum-deposit
+        // step before reaching card details; everyone else goes to details.
+        router.replace(getActiveCardRoute(cardStatusResponse));
       } else {
         Toast.show({
           type: 'success',

--- a/constants/card.ts
+++ b/constants/card.ts
@@ -1,0 +1,13 @@
+/**
+ * Residence country (ISO 3166-1 alpha-2) whose users must fund their card with
+ * a minimum collateral deposit before they can spend. Bangladesh users were
+ * issuing cards without ever funding them (costing us card-creation fees), so
+ * the issuance flow now blocks on a minimum deposit for this country.
+ */
+export const CARD_DEPOSIT_REQUIRED_COUNTRY = 'BD';
+
+/** Minimum collateral a {@link CARD_DEPOSIT_REQUIRED_COUNTRY} user must deposit, in USD. */
+export const MINIMUM_CARD_DEPOSIT_USD = 5;
+
+/** {@link MINIMUM_CARD_DEPOSIT_USD} in cents (Rain reports collateral in cents). */
+export const MINIMUM_CARD_DEPOSIT_CENTS = MINIMUM_CARD_DEPOSIT_USD * 100;

--- a/hooks/useActivateCard.ts
+++ b/hooks/useActivateCard.ts
@@ -9,7 +9,12 @@ import { useCardSteps } from '@/hooks/useCardSteps';
 import { useCountryCheck } from '@/hooks/useCountryCheck';
 import { track } from '@/lib/analytics';
 import { CardStatus, KycStatus } from '@/lib/types';
-import { hasCard, hasCardStatusWithRainApplication } from '@/lib/utils';
+import {
+  hasCard,
+  hasCardStatusWithRainApplication,
+  hasMetCardDeposit,
+  requiresCardDeposit,
+} from '@/lib/utils';
 
 export function useActivateCard() {
   const router = useRouter();
@@ -74,9 +79,15 @@ export function useActivateCard() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  // Deposit-required (BD) users who haven't funded their card stay on the
+  // issuance flow so the "deposit at least $5" step is shown and actionable.
+  const isCardDepositRequired = requiresCardDeposit(cardStatusResponse?.country);
+  const cardDepositMet = hasMetCardDeposit(cardStatusResponse?.cardCollateralDeposited);
+
   // Redirect if user already has a Rain card (active/frozen/inactive)
   useEffect(() => {
     if (!userHasCard) return;
+    if (isCardDepositRequired && !cardDepositMet) return;
     if (
       cardStatus === CardStatus.ACTIVE ||
       cardStatus === CardStatus.FROZEN ||
@@ -84,7 +95,7 @@ export function useActivateCard() {
     ) {
       router.replace(path.CARD_DETAILS);
     }
-  }, [userHasCard, cardStatus, router]);
+  }, [userHasCard, cardStatus, router, isCardDepositRequired, cardDepositMet]);
 
   // Navigation handler for back button
   const handleGoBack = () => {

--- a/hooks/useCardSteps/__tests__/buildCardSteps.test.ts
+++ b/hooks/useCardSteps/__tests__/buildCardSteps.test.ts
@@ -1,0 +1,102 @@
+import { buildCardSteps } from '@/hooks/useCardSteps/stepHelpers';
+import { CardProvider, RainApplicationStatus } from '@/lib/types';
+
+// Keep the import light: stepHelpers only pulls these two helpers from the
+// (heavy) utils barrel, so we stub them with the real logic. jest.mock is
+// hoisted above the imports above, so stepHelpers sees the stub.
+jest.mock('@/lib/utils', () => ({
+  requiresCardDeposit: (country?: string | null) => country?.toUpperCase() === 'BD',
+  hasMetCardDeposit: (cents?: number | null) => (cents ?? 0) >= 500,
+}));
+
+const noop = () => {};
+
+type Options = Parameters<typeof buildCardSteps>[8];
+
+const build = ({
+  cardActivated = false,
+  options,
+}: {
+  cardActivated?: boolean;
+  options?: Options;
+} = {}) =>
+  buildCardSteps(
+    undefined, // cardsEndorsement
+    undefined, // customerRejectionReasons
+    cardActivated,
+    undefined, // activationBlocked
+    undefined, // activationBlockedReason
+    noop, // handleProceedToKyc
+    noop, // pushCardReady
+    noop, // pushCardDetails
+    {
+      cardIssuer: CardProvider.RAIN,
+      rainApplicationStatus: RainApplicationStatus.APPROVED,
+      ...options,
+    },
+  );
+
+describe('buildCardSteps - Bangladesh minimum-deposit step', () => {
+  it('does not add the deposit step for non-BD users', () => {
+    const steps = build({ options: { country: 'US' } });
+
+    expect(steps.map(s => s.title)).toEqual([
+      'Complete KYC',
+      'Activate your card',
+      'Start spending :)',
+    ]);
+    // Ids stay sequential and the activate step keeps id 2.
+    expect(steps.map(s => s.id)).toEqual([1, 2, 3]);
+  });
+
+  it('inserts the deposit step after "Activate your card" for BD users', () => {
+    const steps = build({ options: { country: 'BD' } });
+
+    expect(steps.map(s => s.title)).toEqual([
+      'Complete KYC',
+      'Activate your card',
+      'Deposit at least $5',
+      'Start spending :)',
+    ]);
+    // Numbered by position so the indicator shows 1..4 and activate stays id 2.
+    expect(steps.map(s => s.id)).toEqual([1, 2, 3, 4]);
+    expect(steps[1].id).toBe(2); // activate
+  });
+
+  it('offers the deposit action only once the card is activated and unfunded', () => {
+    const openDepositModal = jest.fn();
+
+    const beforeActivation = build({
+      cardActivated: false,
+      options: { country: 'BD', cardCollateralDeposited: 0, openDepositModal },
+    });
+    const depositStepBefore = beforeActivation[2];
+    expect(depositStepBefore.completed).toBe(false);
+    expect(depositStepBefore.buttonText).toBeUndefined();
+    expect(depositStepBefore.onPress).toBeUndefined();
+
+    const afterActivation = build({
+      cardActivated: true,
+      options: { country: 'BD', cardCollateralDeposited: 300, openDepositModal },
+    });
+    const depositStepAfter = afterActivation[2];
+    expect(depositStepAfter.completed).toBe(false);
+    expect(depositStepAfter.buttonText).toBe('Deposit');
+    expect(depositStepAfter.onPress).toBe(openDepositModal);
+  });
+
+  it('marks the deposit step complete once the $5 minimum is met', () => {
+    const openDepositModal = jest.fn();
+    const steps = build({
+      cardActivated: true,
+      options: { country: 'BD', cardCollateralDeposited: 500, openDepositModal },
+    });
+
+    const depositStep = steps[2];
+    expect(depositStep.completed).toBe(true);
+    expect(depositStep.status).toBe('completed');
+    // No further action needed once funded.
+    expect(depositStep.buttonText).toBeUndefined();
+    expect(depositStep.onPress).toBeUndefined();
+  });
+});

--- a/hooks/useCardSteps/stepHelpers.ts
+++ b/hooks/useCardSteps/stepHelpers.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { Router } from 'expo-router';
 
 import { EndorsementStatus } from '@/components/BankTransfer/enums';
+import { MINIMUM_CARD_DEPOSIT_USD } from '@/constants/card';
 import { path } from '@/constants/path';
 import {
   BridgeCustomerEndorsement,
@@ -12,6 +13,7 @@ import {
   KycWarning,
   RainApplicationStatus,
 } from '@/lib/types';
+import { hasMetCardDeposit, requiresCardDeposit } from '@/lib/utils';
 
 import { getStepButtonText, getStepDescription, isStepButtonDisabled } from './kycDisplayHelpers';
 import { Step } from './types';
@@ -34,6 +36,12 @@ export function buildCardSteps(
     kycStatus?: KycStatus | null;
     kycWarnings?: KycWarning[] | null;
     handleRainKYCPress?: () => void;
+    /** KYC residence country (ISO alpha-2); enables the BD minimum-deposit step. */
+    country?: string | null;
+    /** Total collateral deposited to the card, in cents (BD users). */
+    cardCollateralDeposited?: number | null;
+    /** Opens the existing "deposit to card" popup. */
+    openDepositModal?: () => void;
   },
 ): Step[] {
   const stepOptions =
@@ -66,9 +74,14 @@ export function buildCardSteps(
       ? options.handleRainKYCPress
       : handleProceedToKyc;
 
-  return [
+  // Bangladesh users must fund their card with a minimum collateral deposit
+  // before spending. The step is inserted after "Activate your card" and is
+  // marked complete from the summed positive Rain collateral the backend returns.
+  const showDepositStep = requiresCardDeposit(options?.country);
+  const cardDepositMet = hasMetCardDeposit(options?.cardCollateralDeposited);
+
+  const steps: Omit<Step, 'id'>[] = [
     {
-      id: 1,
       title: 'Complete KYC',
       description,
       completed: isKycComplete || cardActivated,
@@ -78,7 +91,6 @@ export function buildCardSteps(
       onPress: isButtonDisabled ? undefined : kycStepOnPress,
     },
     {
-      id: 2,
       title: 'Activate your card',
       description: orderCardDesc,
       completed: cardActivated,
@@ -86,16 +98,35 @@ export function buildCardSteps(
       buttonText: activationBlocked || !isKycComplete ? undefined : 'Activate card',
       onPress: activationBlocked || !isKycComplete ? undefined : pushCardReady,
     },
-    {
-      id: 3,
-      title: 'Start spending :)',
-      description: 'Congratulations! your card is ready',
-      buttonText: 'To the card',
-      completed: false,
-      status: cardActivated ? 'completed' : 'pending',
-      onPress: pushCardDetails,
-    },
   ];
+
+  if (showDepositStep) {
+    steps.push({
+      title: `Deposit at least $${MINIMUM_CARD_DEPOSIT_USD}`,
+      description: cardDepositMet
+        ? 'Your card is funded — you’re ready to spend.'
+        : `Add at least $${MINIMUM_CARD_DEPOSIT_USD} to your card to start spending.`,
+      completed: cardDepositMet,
+      status: cardDepositMet ? 'completed' : 'pending',
+      // A card must be activated before it can be funded, so only offer the
+      // deposit action once step 2 is done and the minimum isn't met yet.
+      buttonText: cardActivated && !cardDepositMet ? 'Deposit' : undefined,
+      onPress: cardActivated && !cardDepositMet ? options?.openDepositModal : undefined,
+    });
+  }
+
+  steps.push({
+    title: 'Start spending :)',
+    description: 'Congratulations! your card is ready',
+    buttonText: 'To the card',
+    completed: false,
+    status: cardActivated ? 'completed' : 'pending',
+    onPress: pushCardDetails,
+  });
+
+  // Number steps by position so the indicator shows 1..N sequentially and the
+  // activate step stays id 2 (used by the "Card creation pending" override).
+  return steps.map((step, index) => ({ ...step, id: index + 1 }));
 }
 
 /**

--- a/hooks/useCardSteps/useCardSteps.ts
+++ b/hooks/useCardSteps/useCardSteps.ts
@@ -3,6 +3,7 @@ import Toast from 'react-native-toast-message';
 import { useRouter } from 'expo-router';
 import { useShallow } from 'zustand/react/shallow';
 
+import { CARD_DEPOSIT_MODAL } from '@/constants/modals';
 import { path } from '@/constants/path';
 import { TRACKING_EVENTS } from '@/constants/tracking-events';
 import { useCustomer, useKycLinkFromBridge } from '@/hooks/useCustomer';
@@ -13,6 +14,7 @@ import { openIntercom } from '@/lib/intercom';
 import { redirectToRainVerification } from '@/lib/rainVerification';
 import { CardProvider, CardStatusResponse, KycStatus, RainApplicationStatus } from '@/lib/types';
 import { withRefreshToken } from '@/lib/utils';
+import { useCardDepositStore } from '@/store/useCardDepositStore';
 import { useCountryStore } from '@/store/useCountryStore';
 import { useKycStore } from '@/store/useKycStore';
 
@@ -99,6 +101,13 @@ export function useCardSteps(
   // Card activation state and handlers
   const { cardActivated, activatingCard, syncCardActivationState, pushCardDetails, pushCardReady } =
     useCardActivation(router);
+
+  // Opens the existing "deposit to card" popup (used by the BD minimum-deposit step).
+  const setCardDepositModal = useCardDepositStore(state => state.setModal);
+  const openDepositModal = useCallback(
+    () => setCardDepositModal(CARD_DEPOSIT_MODAL.OPEN_INTERNAL_FORM),
+    [setCardDepositModal],
+  );
 
   // Sync card activation state with server
   useEffect(() => {
@@ -252,6 +261,9 @@ export function useCardSteps(
           kycStatus: cardStatusResponse?.kycStatus,
           kycWarnings: cardStatusResponse?.kycWarnings,
           handleRainKYCPress: cardIssuer === CardProvider.RAIN ? handleRainKYCPress : undefined,
+          country: cardStatusResponse?.country,
+          cardCollateralDeposited: cardStatusResponse?.cardCollateralDeposited,
+          openDepositModal,
         },
       ),
     [
@@ -263,11 +275,14 @@ export function useCardSteps(
       cardStatusResponse?.rainApplicationStatus,
       cardStatusResponse?.kycStatus,
       cardStatusResponse?.kycWarnings,
+      cardStatusResponse?.country,
+      cardStatusResponse?.cardCollateralDeposited,
       handleProceedToKyc,
       pushCardReady,
       pushCardDetails,
       cardIssuer,
       handleRainKYCPress,
+      openDepositModal,
     ],
   );
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -466,6 +466,17 @@ export interface CardStatusResponse {
   rainApplicationStatus?: RainApplicationStatus;
   /** Rain: link for needsVerification redirect */
   applicationExternalVerificationLink?: { url: string; params: Record<string, string> };
+  /**
+   * User's KYC residence country (ISO 3166-1 alpha-2, e.g. "BD"). Drives the
+   * country-specific issuance steps (the Bangladesh minimum-deposit step).
+   */
+  country?: string;
+  /**
+   * Total Rain collateral the user has deposited to their card, in cents. Only
+   * populated for countries that require a minimum card deposit (Bangladesh),
+   * so the UI can mark the "deposit at least $5" step complete.
+   */
+  cardCollateralDeposited?: number;
 }
 
 export interface SubmitPersonaKycRequest {

--- a/lib/utils/utils.ts
+++ b/lib/utils/utils.ts
@@ -1,4 +1,5 @@
 import { Platform } from 'react-native';
+import { Href } from 'expo-router';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { type ClassValue, clsx } from 'clsx';
 import { formatDistanceToNow, isBefore, subDays } from 'date-fns';
@@ -6,6 +7,8 @@ import { twMerge } from 'tailwind-merge';
 import { Address, keccak256, toHex } from 'viem';
 
 import { getUsdcAddress } from '@/constants/bridge';
+import { CARD_DEPOSIT_REQUIRED_COUNTRY, MINIMUM_CARD_DEPOSIT_CENTS } from '@/constants/card';
+import { path } from '@/constants/path';
 import { refreshToken } from '@/lib/api';
 import {
   ADDRESSES,
@@ -395,3 +398,28 @@ export const hasCard = (cardStatus: CardStatusResponse | null | undefined): bool
 export const hasCardStatusWithRainApplication = (
   cardStatus: CardStatusResponse | null | undefined,
 ): boolean => Boolean(cardStatus?.rainApplicationStatus);
+
+/**
+ * Whether the user's residence country requires a minimum card deposit before
+ * spending (Bangladesh). Uses the KYC residence country from the backend
+ * (`cardStatus.country`), not the IP/manual country, so the rule matches the
+ * user's actual `country`.
+ */
+export const requiresCardDeposit = (country: string | null | undefined): boolean =>
+  country?.toUpperCase() === CARD_DEPOSIT_REQUIRED_COUNTRY;
+
+/** Whether the user has deposited at least the minimum required collateral (cents). */
+export const hasMetCardDeposit = (depositedCents: number | null | undefined): boolean =>
+  (depositedCents ?? 0) >= MINIMUM_CARD_DEPOSIT_CENTS;
+
+/**
+ * Where an active-card user should land. Users from a deposit-required country
+ * who haven't met the minimum are kept in the issuance flow (activate page) so
+ * they complete the "deposit at least $5" step instead of being sent to an
+ * empty, cost-incurring card. Everyone else goes to card details.
+ */
+export const getActiveCardRoute = (cardStatus: CardStatusResponse | null | undefined): Href =>
+  requiresCardDeposit(cardStatus?.country) &&
+  !hasMetCardDeposit(cardStatus?.cardCollateralDeposited)
+    ? path.CARD_ACTIVATE
+    : path.CARD_DETAILS;


### PR DESCRIPTION
## Summary
This PR implements a country-specific card issuance step for Bangladesh users, requiring them to deposit a minimum of $5 to their card before they can spend. The change prevents card creation fees from being incurred on unfunded cards by blocking progression until the minimum deposit is met.

## Key Changes

- **New deposit step in card issuance flow**: Added a "Deposit at least $5" step that appears after card activation for Bangladesh users (identified by KYC residence country "BD")
  - Step is marked complete once the user deposits the $5 minimum
  - Only becomes actionable (shows "Deposit" button) after card activation
  - Integrated into the existing step progression with sequential numbering

- **New utility functions** (`lib/utils/utils.ts`):
  - `requiresCardDeposit()`: Checks if user's residence country requires a minimum deposit
  - `hasMetCardDeposit()`: Verifies if deposited collateral meets the minimum threshold
  - `getActiveCardRoute()`: Routes active-card users appropriately (issuance flow for unfunded BD users, card details for everyone else)

- **New constants** (`constants/card.ts`):
  - `CARD_DEPOSIT_REQUIRED_COUNTRY`: Set to "BD"
  - `MINIMUM_CARD_DEPOSIT_USD`: Set to 5
  - `MINIMUM_CARD_DEPOSIT_CENTS`: Derived constant for backend communication

- **Updated card step builder** (`hooks/useCardSteps/stepHelpers.ts`):
  - Modified `buildCardSteps()` to conditionally insert the deposit step
  - Changed step ID assignment to be positional (1..N) rather than hardcoded
  - Added options for country, collateral amount, and deposit modal callback

- **Navigation updates**: Modified card routing across multiple pages to use `getActiveCardRoute()` so BD users without sufficient deposits stay in the issuance flow rather than being sent to card details

- **Comprehensive test coverage** (`hooks/useCardSteps/__tests__/buildCardSteps.test.ts`):
  - Tests for non-BD users (no deposit step)
  - Tests for BD users (deposit step inserted correctly)
  - Tests for step availability based on card activation and deposit status
  - Tests for step completion when minimum is met

## Implementation Details

- The deposit step uses existing backend data (`cardCollateralDeposited` from `CardStatusResponse`) to determine completion status
- The deposit action reuses the existing deposit modal infrastructure via `useCardDepositStore`
- Step numbering is now dynamic based on whether the deposit step is shown, ensuring the "Activate your card" step always has ID 2 (used by other parts of the system)
- The change is backward compatible—non-BD users see no difference in the issuance flow

https://claude.ai/code/session_01Q8RkBTYoUHcrMfyHX7fuEP