### PR TITLE
feat(rewards): redirect to home when opt-in popup is dismissed

### DIFF
--- a/app/(protected)/(tabs)/rewards/index.tsx
+++ b/app/(protected)/(tabs)/rewards/index.tsx
@@ -115,7 +115,10 @@ export default function Rewards() {
             onSuccess: () => setWelcomeDismissed(true),
           })
         }
-        onClose={() => setWelcomeDismissed(true)}
+        onClose={() => {
+          setWelcomeDismissed(true);
+          router.replace(path.HOME);
+        }}
       />
     </PageLayout>
   );


### PR DESCRIPTION
Closing the rewards welcome popup without joining (close button, overlay click, or escape) now redirects to the home page instead of leaving the user on the otherwise-hidden /rewards page.


Claude-Session: https://claude.ai/code/session_01VRm5Qkyy5v8KseJUX2oydx