### PR TITLE
Fix home card layout stability during loading states

### DIFF
--- a/components/Home/FinishSetupModal.tsx
+++ b/components/Home/FinishSetupModal.tsx
@@ -83,11 +83,8 @@ const FinishSetupModal = ({ isOpen, onClose, steps, firstIncomplete }: FinishSet
 
         <View className="gap-5">
           {firstIncomplete && (
-            <Button
-              className="h-14 rounded-2xl border-0 bg-button-earning web:hover:bg-button-earning web:hover:brightness-110"
-              onPress={handleCta}
-            >
-              <Text className="text-base font-bold text-primary">{firstIncomplete.cta}</Text>
+            <Button variant="brand" className="h-14 rounded-2xl" onPress={handleCta}>
+              <Text className="text-base font-bold">{firstIncomplete.cta}</Text>
             </Button>
           )}
           <Pressable

--- a/components/Home/HomeCashbackCard.tsx
+++ b/components/Home/HomeCashbackCard.tsx
@@ -14,6 +14,12 @@ interface HomeCashbackCardProps {
   className?: string;
 }
 
+// Fixed height for the stat value so the loading skeleton and the loaded amount
+// occupy exactly the same vertical space. Without this the card shrinks while the
+// amount is loading and grows back once it resolves. Kept in sync with
+// HomeSavingsStatCard so the two cards stay the same height in every state.
+const STAT_VALUE_HEIGHT = Math.round(fontSize(1.875) * 1.3);
+
 /**
  * Compact "Cashback" stat card. Shows total cashback earned (from card details)
  * and the headline cashback rate. Sits next to the savings card on home.
@@ -37,34 +43,38 @@ const HomeCashbackCard = ({ className }: HomeCashbackCardProps) => {
         <View className="gap-1">
           <Text className="text-base font-medium text-muted-foreground">Cashback</Text>
           <View className="flex-row items-end gap-2">
-            {isLoading ? (
-              <Skeleton className="h-8 w-16 rounded-xl" />
-            ) : (
-              <CountUp
-                prefix="$"
-                count={cashbackUsd}
-                isTrailingZero={false}
-                decimalPlaces={cashbackUsd > 0 ? 2 : 0}
-                classNames={{
-                  wrapper: 'text-foreground',
-                  decimalSeparator: 'text-lg font-semibold',
-                }}
-                styles={{
-                  wholeText: {
-                    fontSize: fontSize(1.875),
-                    fontWeight: '600',
-                    fontFamily: 'MonaSans_600SemiBold',
-                    color: '#ffffff',
-                  },
-                  decimalText: {
-                    fontSize: fontSize(1.875),
-                    fontWeight: '600',
-                    fontFamily: 'MonaSans_600SemiBold',
-                    color: '#ffffff',
-                  },
-                }}
-              />
-            )}
+            <View style={{ height: STAT_VALUE_HEIGHT, justifyContent: 'flex-end' }}>
+              {isLoading ? (
+                <Skeleton className="w-16 rounded-xl" style={{ height: STAT_VALUE_HEIGHT }} />
+              ) : (
+                <CountUp
+                  prefix="$"
+                  count={cashbackUsd}
+                  isTrailingZero={false}
+                  decimalPlaces={cashbackUsd > 0 ? 2 : 0}
+                  classNames={{
+                    wrapper: 'text-foreground',
+                    decimalSeparator: 'text-lg font-semibold',
+                  }}
+                  styles={{
+                    wholeText: {
+                      fontSize: fontSize(1.875),
+                      lineHeight: STAT_VALUE_HEIGHT,
+                      fontWeight: '600',
+                      fontFamily: 'MonaSans_600SemiBold',
+                      color: '#ffffff',
+                    },
+                    decimalText: {
+                      fontSize: fontSize(1.875),
+                      lineHeight: STAT_VALUE_HEIGHT,
+                      fontWeight: '600',
+                      fontFamily: 'MonaSans_600SemiBold',
+                      color: '#ffffff',
+                    },
+                  }}
+                />
+              )}
+            </View>
             <Text className="mb-1 max-w-[5.5rem] text-xs leading-tight text-muted-foreground">
               Up to {percentage}% Cashback
             </Text>

--- a/components/Home/HomeSavingsStatCard.tsx
+++ b/components/Home/HomeSavingsStatCard.tsx
@@ -13,6 +13,11 @@ interface HomeSavingsStatCardProps {
   className?: string;
 }
 
+// Fixed height for the stat value so the loading skeleton and the loaded APY occupy
+// the same vertical space. Kept in sync with HomeCashbackCard so the two cards stay
+// the same height in every state (loading and loaded).
+const STAT_VALUE_HEIGHT = Math.round(fontSize(1.875) * 1.3);
+
 /**
  * Compact "Savings" stat card showing the headline savings APY.
  * Sits next to the cashback card on home and links to the savings screen.
@@ -32,20 +37,23 @@ const HomeSavingsStatCard = ({ className }: HomeSavingsStatCardProps) => {
         />
         <View className="gap-1">
           <Text className="text-base font-medium text-muted-foreground">Savings</Text>
-          {isAPYsLoading ? (
-            <Skeleton className="h-8 w-20 rounded-xl" />
-          ) : (
-            <Text
-              className="text-foreground"
-              style={{
-                fontSize: fontSize(1.875),
-                fontFamily: 'MonaSans_600SemiBold',
-                fontWeight: '600',
-              }}
-            >
-              {formatNumber(maxAPY ?? 0, 1)}%
-            </Text>
-          )}
+          <View style={{ height: STAT_VALUE_HEIGHT, justifyContent: 'flex-end' }}>
+            {isAPYsLoading ? (
+              <Skeleton className="w-20 rounded-xl" style={{ height: STAT_VALUE_HEIGHT }} />
+            ) : (
+              <Text
+                className="text-foreground"
+                style={{
+                  fontSize: fontSize(1.875),
+                  lineHeight: STAT_VALUE_HEIGHT,
+                  fontFamily: 'MonaSans_600SemiBold',
+                  fontWeight: '600',
+                }}
+              >
+                {formatNumber(maxAPY ?? 0, 1)}%
+              </Text>
+            )}
+          </View>
         </View>
       </View>
     </Pressable>

--- a/hooks/cardDetailsQueryOptions.ts
+++ b/hooks/cardDetailsQueryOptions.ts
@@ -6,6 +6,9 @@ const CARD_DETAILS = 'cardDetails';
 export const cardDetailsQueryOptions = () => ({
   queryKey: [CARD_DETAILS],
   queryFn: () => withRefreshToken(() => getCardDetails()),
-  staleTime: 5_000,
-  refetchInterval: 5_000,
+  // Card details (cashback totals, percentage, card metadata) change rarely, so we
+  // don't poll them. The live card balance is fetched separately in useCardDetails
+  // (the `cardBalance` query, polled every 5s). Polling details every 5s was causing
+  // the home cashback card to repeatedly fall back to its loading skeleton.
+  staleTime: 60_000,
 });


### PR DESCRIPTION
## Summary
This PR fixes layout instability on the home screen where stat cards (Cashback and Savings) would shrink while loading and grow back once data resolved. The changes ensure consistent card heights across all states and reduce unnecessary polling of card details.

## Key Changes

- **Fixed stat card height consistency**: Added a fixed `STAT_VALUE_HEIGHT` constant to both `HomeCashbackCard` and `HomeSavingsStatCard` that applies to both the loading skeleton and loaded content. This prevents the cards from changing size during the loading transition.

- **Improved skeleton and text alignment**: Wrapped stat values in a container with `justifyContent: 'flex-end'` and added `lineHeight` styling to ensure proper vertical alignment of both skeleton loaders and actual content.

- **Reduced card details polling**: Changed `cardDetailsQueryOptions` to use a 60-second stale time instead of 5-second polling. Card details (cashback totals, percentages, metadata) change infrequently and don't need constant polling. The live card balance is fetched separately via the `cardBalance` query which continues to poll every 5 seconds.

- **Simplified button styling**: Updated the CTA button in `FinishSetupModal` to use the `variant="brand"` prop instead of inline style classes for better maintainability.

## Implementation Details

- The `STAT_VALUE_HEIGHT` is calculated as `Math.round(fontSize(1.875) * 1.3)` to match the font size with appropriate line height multiplier
- Both cashback and savings cards use the same height constant to maintain visual alignment
- Removed the `h-8` class from skeletons since height is now controlled via inline styles
- The polling reduction should improve performance by reducing unnecessary network requests and preventing the cashback card from repeatedly showing its loading state

https://claude.ai/code/session_011pAKfpRFjbH5TJSfNimjJy