### PR TITLE
Add tooltip support to rewards earning methods

### DIFF
--- a/components/Rewards/EarnPointsSection.tsx
+++ b/components/Rewards/EarnPointsSection.tsx
@@ -6,12 +6,24 @@ import { useRewardsConfig } from '@/hooks/useRewards';
 
 import RewardBenefit from './RewardBenefit';
 
+// Amount deposited counts toward Save points across every supported vault.
+const SAVE_DEPOSIT_TOOLTIP =
+  'Amount deposited is calculated across the USDC, FUSE and ETH vaults';
+
+interface EarningMethod {
+  icon: string;
+  title: string;
+  description: string;
+  tooltip?: string;
+  tooltipAnalyticsContext?: string;
+}
+
 const EarnPointsSection = () => {
   const { data: config, isLoading } = useRewardsConfig();
   const { isScreenMedium } = useDimension();
 
   // Format earning methods based on config
-  const getEarningMethods = () => {
+  const getEarningMethods = (): EarningMethod[] => {
     if (!config) {
       // Fallback values while loading
       return [
@@ -19,6 +31,8 @@ const EarnPointsSection = () => {
           icon: 'images/save-yellow.png',
           title: 'Save',
           description: 'Earn points for deposits',
+          tooltip: SAVE_DEPOSIT_TOOLTIP,
+          tooltipAnalyticsContext: 'rewards_save_deposit_vaults',
         },
         {
           icon: 'images/spend-yellow.png',
@@ -52,7 +66,13 @@ const EarnPointsSection = () => {
     const swapDesc = `${swapPoints.toLocaleString()} points per $1 swapped`;
 
     return [
-      { icon: 'images/save-yellow.png', title: 'Save', description: holdingDesc },
+      {
+        icon: 'images/save-yellow.png',
+        title: 'Save',
+        description: holdingDesc,
+        tooltip: SAVE_DEPOSIT_TOOLTIP,
+        tooltipAnalyticsContext: 'rewards_save_deposit_vaults',
+      },
       { icon: 'images/spend-yellow.png', title: 'Spend', description: spendDesc },
       { icon: 'images/invite-yellow.png', title: 'Invite friends', description: referralDesc },
       { icon: 'images/swap-yellow.png', title: 'Swap', description: swapDesc },
@@ -84,6 +104,8 @@ const EarnPointsSection = () => {
                 icon={method.icon}
                 title={method.title}
                 description={method.description}
+                tooltip={method.tooltip}
+                tooltipAnalyticsContext={method.tooltipAnalyticsContext}
               />
             </View>
           ))}

--- a/components/Rewards/RewardBenefit.tsx
+++ b/components/Rewards/RewardBenefit.tsx
@@ -2,6 +2,7 @@ import { ReactNode } from 'react';
 import { View } from 'react-native';
 import { Image } from 'expo-image';
 
+import TooltipPopover from '@/components/Tooltip';
 import { Text } from '@/components/ui/text';
 import { getAsset } from '@/lib/assets';
 
@@ -11,6 +12,8 @@ interface RewardBenefitProps {
   title: string;
   description: string;
   descriptionNode?: ReactNode;
+  tooltip?: string;
+  tooltipAnalyticsContext?: string;
   iconSize?: number;
 }
 
@@ -20,8 +23,27 @@ const RewardBenefit = ({
   title,
   description,
   descriptionNode,
+  tooltip,
+  tooltipAnalyticsContext,
   iconSize = 50,
 }: RewardBenefitProps) => {
+  const renderDescription = () => {
+    if (descriptionNode) {
+      return descriptionNode;
+    }
+
+    if (tooltip) {
+      return (
+        <View className="flex-row items-center gap-1">
+          <Text className="shrink text-base opacity-70">{description}</Text>
+          <TooltipPopover text={tooltip} analyticsContext={tooltipAnalyticsContext} />
+        </View>
+      );
+    }
+
+    return <Text className="text-base opacity-70">{description}</Text>;
+  };
+
   return (
     <View className="flex-row items-center gap-2">
       {iconText ? (
@@ -40,9 +62,7 @@ const RewardBenefit = ({
       ) : null}
       <View className="min-w-0 flex-1">
         <Text className="text-lg font-semibold leading-5">{title}</Text>
-        <View className="mt-0.5">
-          {descriptionNode ?? <Text className="text-base opacity-70">{description}</Text>}
-        </View>
+        <View className="mt-0.5">{renderDescription()}</View>
       </View>
     </View>
   );


### PR DESCRIPTION
## Summary
Added tooltip support to the rewards earning methods display, specifically for the "Save" earning method to clarify which vaults are included in deposit calculations.

## Key Changes
- Created `EarningMethod` interface in `EarnPointsSection.tsx` to define the structure of earning methods with optional `tooltip` and `tooltipAnalyticsContext` properties
- Added `SAVE_DEPOSIT_TOOLTIP` constant explaining that deposits are calculated across USDC, FUSE, and ETH vaults
- Updated both fallback and config-based earning methods to include tooltip information for the "Save" method
- Enhanced `RewardBenefit` component to accept and render tooltips:
  - Added `tooltip` and `tooltipAnalyticsContext` props
  - Implemented `renderDescription()` method to conditionally render description with tooltip icon when tooltip is provided
  - Integrated `TooltipPopover` component to display tooltip with analytics tracking
- Passed tooltip props from `EarnPointsSection` to `RewardBenefit` components

## Implementation Details
- The tooltip is displayed inline next to the description text using a flex row layout with proper spacing
- Tooltip rendering is conditional and maintains backward compatibility with existing `descriptionNode` prop
- Analytics context is passed through to track tooltip interactions

https://claude.ai/code/session_01WY4gmLNFkLrMCWKX3KcaKB