### PR TITLE
[codex] Add mobile navbar glass overlay

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -56,6 +56,11 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
   icon: './assets/images/adaptive-icon.png',
   scheme: 'solid',
   userInterfaceStyle: 'automatic',
+  androidStatusBar: {
+    barStyle: 'light-content',
+    backgroundColor: '#00000000',
+    translucent: true,
+  },
   owner: 'fuseio',
   ios: {
     icon: './assets/images/ios-icon.png',

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,7 +1,7 @@
 import '@/global.css';
 
 import { useCallback, useEffect, useState } from 'react';
-import { Appearance, AppState, Platform } from 'react-native';
+import { Appearance, AppState, Platform, StatusBar } from 'react-native';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 import Toast from 'react-native-toast-message';
@@ -347,6 +347,9 @@ function RootLayout() {
 
   return (
     <SafeAreaProvider style={{ flex: 1 }}>
+      {Platform.OS === 'android' && (
+        <StatusBar translucent backgroundColor="transparent" barStyle="light-content" />
+      )}
       <TurnkeyProvider>
         <LazyThirdwebProvider>
           <WagmiProvider config={config}>

--- a/components/Dashboard/DashboardHeaderMobile.tsx
+++ b/components/Dashboard/DashboardHeaderMobile.tsx
@@ -24,7 +24,7 @@ const DashboardHeaderMobile = ({
 
   return (
     <View className="gap-8">
-      <View className="flex-row items-center justify-center pt-6">
+      <View className="flex-row items-center justify-center pt-1">
         <SavingCountUp
           prefix="$"
           balance={balance ?? 0}
@@ -38,21 +38,21 @@ const DashboardHeaderMobile = ({
           }}
           styles={{
             wholeText: {
-              fontSize: 60,
-              fontWeight: '600',
-              fontFamily: 'MonaSans_600SemiBold',
+              fontSize: 50,
+              fontWeight: '500',
+              fontFamily: 'MonaSans_500Medium',
               color: '#ffffff',
             },
             decimalText: {
-              fontSize: isScreenMedium ? 60 : 30,
-              fontWeight: isScreenMedium ? '600' : '400',
-              fontFamily: isScreenMedium ? 'MonaSans_600SemiBold' : 'MonaSans_400Regular',
-              color: '#ffffff',
+              fontSize: isScreenMedium ? 50 : 50,
+              fontWeight: isScreenMedium ? '500' : '500',
+              fontFamily: isScreenMedium ? 'MonaSans_500Medium' : 'MonaSans_500Medium',
+              color: '#666666',
             },
             decimalSeparator: {
-              fontSize: isScreenMedium ? 60 : 30,
-              fontWeight: isScreenMedium ? '600' : '400',
-              fontFamily: isScreenMedium ? 'MonaSans_600SemiBold' : 'MonaSans_400Regular',
+              fontSize: isScreenMedium ? 50 : 50,
+              fontWeight: isScreenMedium ? '500' : '500',
+              fontFamily: isScreenMedium ? 'MonaSans_500Medium' : 'MonaSans_500Medium',
               color: '#ffffff',
             },
           }}

--- a/components/Home/HomeCashbackCard.tsx
+++ b/components/Home/HomeCashbackCard.tsx
@@ -3,12 +3,13 @@ import { Image } from 'expo-image';
 import { useRouter } from 'expo-router';
 
 import CountUp from '@/components/CountUp';
+import { HOME_STAT_VALUE_TEXT_STYLE } from '@/components/Home/homeStatValueStyle';
 import Skeleton from '@/components/ui/skeleton';
 import { Text } from '@/components/ui/text';
 import { path } from '@/constants/path';
 import { useCardDetails } from '@/hooks/useCardDetails';
 import { getAsset } from '@/lib/assets';
-import { cn, fontSize } from '@/lib/utils';
+import { cn } from '@/lib/utils';
 
 interface HomeCashbackCardProps {
   className?: string;
@@ -48,21 +49,11 @@ const HomeCashbackCard = ({ className }: HomeCashbackCardProps) => {
                 decimalPlaces={cashbackUsd > 0 ? 2 : 0}
                 classNames={{
                   wrapper: 'text-foreground',
-                  decimalSeparator: 'text-lg font-semibold',
                 }}
                 styles={{
-                  wholeText: {
-                    fontSize: fontSize(2.25),
-                    fontWeight: '600',
-                    fontFamily: 'MonaSans_600SemiBold',
-                    color: '#ffffff',
-                  },
-                  decimalText: {
-                    fontSize: fontSize(2.25),
-                    fontWeight: '600',
-                    fontFamily: 'MonaSans_600SemiBold',
-                    color: '#ffffff',
-                  },
+                  wholeText: HOME_STAT_VALUE_TEXT_STYLE,
+                  decimalText: HOME_STAT_VALUE_TEXT_STYLE,
+                  decimalSeparator: HOME_STAT_VALUE_TEXT_STYLE,
                 }}
               />
             )}

--- a/components/Home/HomeSavingsStatCard.tsx
+++ b/components/Home/HomeSavingsStatCard.tsx
@@ -2,12 +2,13 @@ import { Pressable, View } from 'react-native';
 import { Image } from 'expo-image';
 import { useRouter } from 'expo-router';
 
+import { HOME_STAT_VALUE_TEXT_STYLE } from '@/components/Home/homeStatValueStyle';
 import Skeleton from '@/components/ui/skeleton';
 import { Text } from '@/components/ui/text';
 import { path } from '@/constants/path';
 import { useMaxAPY } from '@/hooks/useAnalytics';
 import { getAsset } from '@/lib/assets';
-import { cn, fontSize, formatNumber } from '@/lib/utils';
+import { cn, formatNumber } from '@/lib/utils';
 
 interface HomeSavingsStatCardProps {
   className?: string;
@@ -35,14 +36,7 @@ const HomeSavingsStatCard = ({ className }: HomeSavingsStatCardProps) => {
           {isAPYsLoading ? (
             <Skeleton className="h-8 w-20 rounded-xl" />
           ) : (
-            <Text
-              className="text-foreground"
-              style={{
-                fontSize: fontSize(2.25),
-                fontFamily: 'MonaSans_600SemiBold',
-                fontWeight: '600',
-              }}
-            >
+            <Text className="text-foreground" style={HOME_STAT_VALUE_TEXT_STYLE}>
               {formatNumber(maxAPY ?? 0, 1)}%
             </Text>
           )}

--- a/components/Home/HomeVirtualCard.tsx
+++ b/components/Home/HomeVirtualCard.tsx
@@ -4,11 +4,11 @@ import { useRouter } from 'expo-router';
 
 import CountUp from '@/components/CountUp';
 import HomeCardSetup from '@/components/Home/HomeCardSetup';
+import { HOME_STAT_VALUE_TEXT_STYLE } from '@/components/Home/homeStatValueStyle';
 import Skeleton from '@/components/ui/skeleton';
 import { Text } from '@/components/ui/text';
 import { path } from '@/constants/path';
 import { getAsset } from '@/lib/assets';
-import { fontSize } from '@/lib/utils';
 
 interface HomeVirtualCardProps {
   userHasCard: boolean;
@@ -32,6 +32,7 @@ const HomeVirtualCard = ({
   className,
 }: HomeVirtualCardProps) => {
   const router = useRouter();
+  const hasFractionalCardBalance = Math.round((cardBalance ?? 0) * 100) % 100 !== 0;
 
   if (!userHasCard) {
     return <HomeCardSetup depositCompleted={depositCompleted} className={className} />;
@@ -39,47 +40,44 @@ const HomeVirtualCard = ({
 
   return (
     <Pressable onPress={() => router.push(path.CARD_DETAILS)} className={className}>
-      <View className="overflow-hidden rounded-twice bg-card p-5">
-        <Text className="text-base font-medium text-muted-foreground">Virtual card</Text>
-        <View className="mt-3 flex-row items-center justify-between">
-          <View className="gap-1">
-            <Text className="text-base font-medium text-foreground">Card balance</Text>
-            {isLoading ? (
-              <Skeleton className="h-9 w-28 rounded-xl" />
-            ) : (
-              <CountUp
-                prefix="$"
-                count={cardBalance ?? 0}
-                isTrailingZero={false}
-                decimalPlaces={2}
-                classNames={{
-                  wrapper: 'text-foreground',
-                  decimalSeparator: 'text-2xl font-semibold',
-                }}
-                styles={{
-                  wholeText: {
-                    fontSize: fontSize(1.875),
-                    fontWeight: '600',
-                    fontFamily: 'MonaSans_600SemiBold',
-                    color: '#ffffff',
-                    marginRight: -1,
-                  },
-                  decimalText: {
-                    fontSize: fontSize(1.875),
-                    fontWeight: '600',
-                    fontFamily: 'MonaSans_600SemiBold',
-                    color: '#ffffff',
-                  },
-                }}
-              />
-            )}
-          </View>
-          <Image
-            source={getAsset('images/card.png')}
-            alt="Solid card"
-            style={{ width: 130, height: 90 }}
-            contentFit="contain"
-          />
+      <View className="relative overflow-hidden rounded-twice bg-card" style={{ height: 141 }}>
+        <Text
+          className="absolute font-medium text-muted-foreground"
+          style={{ fontSize: 14, left: 20, lineHeight: 15.4, top: 24 }}
+        >
+          Virtual card
+        </Text>
+        <Image
+          source={getAsset('images/card.png')}
+          alt="Solid card"
+          style={{ height: 68, position: 'absolute', right: 28, top: 36, width: 116 }}
+          contentFit="contain"
+        />
+        <Text
+          className="absolute font-semibold text-foreground"
+          style={{ fontSize: 18, left: 20, lineHeight: 21.6, top: 52 }}
+        >
+          Card balance
+        </Text>
+        <View className="absolute left-5" style={{ top: 72 }}>
+          {isLoading ? (
+            <Skeleton className="h-10 w-24 rounded-xl" />
+          ) : (
+            <CountUp
+              prefix="$"
+              count={cardBalance ?? 0}
+              isTrailingZero={false}
+              decimalPlaces={hasFractionalCardBalance ? 2 : 0}
+              classNames={{
+                wrapper: 'text-foreground',
+              }}
+              styles={{
+                wholeText: HOME_STAT_VALUE_TEXT_STYLE,
+                decimalText: HOME_STAT_VALUE_TEXT_STYLE,
+                decimalSeparator: HOME_STAT_VALUE_TEXT_STYLE,
+              }}
+            />
+          )}
         </View>
       </View>
     </Pressable>

--- a/components/Home/homeStatValueStyle.ts
+++ b/components/Home/homeStatValueStyle.ts
@@ -1,0 +1,11 @@
+import { TextStyle } from 'react-native';
+
+import { fontSize } from '@/lib/utils';
+
+export const HOME_STAT_VALUE_TEXT_STYLE: TextStyle = {
+  color: '#ffffff',
+  fontFamily: 'MonaSans_500Medium',
+  fontSize: fontSize(30 / 14),
+  fontWeight: '500',
+  lineHeight: 40,
+};

--- a/components/Navbar/NavbarMobile.tsx
+++ b/components/Navbar/NavbarMobile.tsx
@@ -1,4 +1,12 @@
-import { View } from 'react-native';
+import { type RefObject, useCallback, useEffect } from 'react';
+import { LayoutChangeEvent, StyleSheet, View } from 'react-native';
+import Animated, {
+  Easing,
+  useAnimatedStyle,
+  useSharedValue,
+  withTiming,
+} from 'react-native-reanimated';
+import { BlurView } from 'expo-blur';
 import { Image } from 'expo-image';
 
 import AccountCenterDropdown from '@/components/AccountCenter/AccountCenterDropdown.native';
@@ -8,11 +16,67 @@ import { getAsset } from '@/lib/assets';
 import RegisterButtons from './RegisterButtons';
 import WhatsNewButton from './WhatsNewButton';
 
-const NavbarMobile = () => {
+const GLASS_TRANSITION = {
+  duration: 320,
+  easing: Easing.out(Easing.cubic),
+};
+
+type NavbarMobileProps = {
+  blurTarget?: RefObject<View | null>;
+  onContentOffsetChange?: (height: number) => void;
+  showDivider?: boolean;
+  topInset?: number;
+};
+
+const NavbarMobile = ({
+  blurTarget,
+  onContentOffsetChange,
+  showDivider,
+  topInset = 0,
+}: NavbarMobileProps) => {
   const { user } = useUser();
+  const hasBlurTarget = !!blurTarget;
+  const isGlassVisible = hasBlurTarget && !!showDivider;
+  const glassProgress = useSharedValue(isGlassVisible ? 1 : 0);
+
+  useEffect(() => {
+    glassProgress.value = withTiming(isGlassVisible ? 1 : 0, GLASS_TRANSITION);
+  }, [glassProgress, isGlassVisible]);
+
+  const glassAnimatedStyle = useAnimatedStyle(() => ({
+    opacity: glassProgress.value,
+  }));
+  const dividerAnimatedStyle = useAnimatedStyle(() => ({
+    opacity: glassProgress.value,
+  }));
+
+  const handleLayout = useCallback(
+    (event: LayoutChangeEvent) => {
+      onContentOffsetChange?.(event.nativeEvent.layout.height);
+    },
+    [onContentOffsetChange],
+  );
 
   return (
-    <View className="bg-background">
+    <View
+      className="overflow-hidden bg-background"
+      onLayout={handleLayout}
+      style={topInset ? { paddingTop: topInset } : undefined}
+    >
+      {hasBlurTarget && (
+        <Animated.View pointerEvents="none" style={[styles.overlay, glassAnimatedStyle]}>
+          <BlurView
+            blurMethod="dimezisBlurView"
+            blurReductionFactor={2.4}
+            blurTarget={blurTarget}
+            intensity={56}
+            pointerEvents="none"
+            style={StyleSheet.absoluteFill}
+            tint="systemChromeMaterialDark"
+          />
+          <View pointerEvents="none" style={[styles.overlay, styles.glassOverlay]} />
+        </Animated.View>
+      )}
       <View className="flex-row items-center justify-between p-4">
         <Image
           source={getAsset('images/solid-logo-4x.png')}
@@ -32,8 +96,26 @@ const NavbarMobile = () => {
           <PointsNavButton />
         </Link> */}
       </View>
+      <Animated.View pointerEvents="none" style={[styles.divider, dividerAnimatedStyle]} />
     </View>
   );
 };
+
+const styles = StyleSheet.create({
+  overlay: {
+    ...StyleSheet.absoluteFillObject,
+  },
+  glassOverlay: {
+    backgroundColor: 'rgba(18, 18, 18, 0.66)',
+  },
+  divider: {
+    backgroundColor: 'rgba(102, 99, 101, 0.28)',
+    bottom: 0,
+    height: 1,
+    left: 0,
+    position: 'absolute',
+    right: 0,
+  },
+});
 
 export default NavbarMobile;

--- a/components/PageLayout.tsx
+++ b/components/PageLayout.tsx
@@ -1,12 +1,21 @@
-import { ReactNode } from 'react';
-import { ScrollView, View } from 'react-native';
-import { Edge, SafeAreaView } from 'react-native-safe-area-context';
+import { ReactNode, useCallback, useRef, useState } from 'react';
+import {
+  NativeScrollEvent,
+  NativeSyntheticEvent,
+  ScrollView,
+  StyleSheet,
+  View,
+} from 'react-native';
+import { Edge, SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
+import { BlurTargetView } from 'expo-blur';
 
 import { useDimension } from '@/hooks/useDimension';
 
 import Loading from './Loading';
 import Navbar from './Navbar';
 import NavbarMobile from './Navbar/NavbarMobile';
+
+const MOBILE_NAVBAR_DIVIDER_OFFSET = 1;
 
 interface PageLayoutProps {
   children: ReactNode;
@@ -91,6 +100,10 @@ export default function PageLayout({
   contentClassName = '',
 }: PageLayoutProps) {
   const { isScreenMedium, isDesktop } = useDimension();
+  const insets = useSafeAreaInsets();
+  const mobileBlurTargetRef = useRef<View>(null);
+  const [mobileNavbarOffset, setMobileNavbarOffset] = useState(0);
+  const [isMobileNavbarScrolled, setIsMobileNavbarScrolled] = useState(false);
 
   // Determine which breakpoint to use
   const isLargeScreen = useDesktopBreakpoint ? isDesktop : isScreenMedium;
@@ -98,15 +111,34 @@ export default function PageLayout({
   // Determine what to show for navbar
   const shouldShowDesktopNavbar = showNavbar && (!desktopOnly || isLargeScreen);
   const shouldShowMobileNavbar = showNavbar && !desktopOnly && !isLargeScreen;
+  const shouldOverlayMobileNavbar = shouldShowMobileNavbar && !customMobileHeader;
+  const safeAreaEdges = shouldOverlayMobileNavbar ? edges.filter(edge => edge !== 'top') : edges;
+  const mobileContentOffset = shouldOverlayMobileNavbar ? mobileNavbarOffset : 0;
+
+  const handleMobileScroll = useCallback((event: NativeSyntheticEvent<NativeScrollEvent>) => {
+    const isScrolled = event.nativeEvent.contentOffset.y > MOBILE_NAVBAR_DIVIDER_OFFSET;
+
+    setIsMobileNavbarScrolled(current => (current === isScrolled ? current : isScrolled));
+  }, []);
 
   // Render navbar/header content
-  const renderNavbar = () => {
+  const renderNavbar = (isOverlay = false) => {
     if (isLargeScreen) {
       // Desktop navbar/header
       return customDesktopHeader || (shouldShowDesktopNavbar && <Navbar />);
     }
     // Mobile navbar/header
-    return customMobileHeader || (shouldShowMobileNavbar && <NavbarMobile />);
+    return (
+      customMobileHeader ||
+      (shouldShowMobileNavbar && (
+        <NavbarMobile
+          blurTarget={isOverlay ? mobileBlurTargetRef : undefined}
+          onContentOffsetChange={isOverlay ? setMobileNavbarOffset : undefined}
+          showDivider={isOverlay && isMobileNavbarScrolled}
+          topInset={isOverlay ? insets.top : 0}
+        />
+      ))
+    );
   };
 
   // Show loading state with navbar
@@ -121,30 +153,86 @@ export default function PageLayout({
 
   // Build the main content
   if (scrollable) {
+    const scrollView = (
+      <ScrollView
+        className={`flex-1 ${contentClassName}`}
+        contentContainerStyle={
+          mobileContentOffset ? { paddingTop: mobileContentOffset } : undefined
+        }
+        contentInsetAdjustmentBehavior="automatic"
+        onScroll={shouldOverlayMobileNavbar ? handleMobileScroll : undefined}
+        scrollEventThrottle={shouldOverlayMobileNavbar ? 16 : undefined}
+        stickyHeaderIndices={stickyHeader && !isScreenMedium ? [0] : undefined}
+      >
+        {stickyHeader && <View className="z-10 bg-background">{stickyHeader}</View>}
+        {children}
+      </ScrollView>
+    );
+
     return (
-      <SafeAreaView className={`flex-1 bg-background text-foreground ${className}`} edges={edges}>
-        {renderNavbar()}
-        <ScrollView
-          className={`flex-1 ${contentClassName}`}
-          contentInsetAdjustmentBehavior="automatic"
-          stickyHeaderIndices={stickyHeader && !isScreenMedium ? [0] : undefined}
-        >
-          {stickyHeader && <View className="z-10 bg-background">{stickyHeader}</View>}
-          {children}
-        </ScrollView>
+      <SafeAreaView
+        className={`flex-1 bg-background text-foreground ${className}`}
+        edges={safeAreaEdges}
+      >
+        {shouldOverlayMobileNavbar ? (
+          <BlurTargetView ref={mobileBlurTargetRef} style={styles.mobileBlurTarget}>
+            {scrollView}
+          </BlurTargetView>
+        ) : (
+          <>
+            {renderNavbar()}
+            {scrollView}
+          </>
+        )}
+        {shouldOverlayMobileNavbar && (
+          <View style={styles.mobileNavbarOverlay}>{renderNavbar(true)}</View>
+        )}
         {additionalContent}
       </SafeAreaView>
     );
   }
 
   return (
-    <SafeAreaView className={`flex-1 bg-background text-foreground ${className}`} edges={edges}>
-      {renderNavbar()}
-      <View className={`flex-1 ${contentClassName}`}>
-        {stickyHeader}
-        {children}
-      </View>
+    <SafeAreaView
+      className={`flex-1 bg-background text-foreground ${className}`}
+      edges={safeAreaEdges}
+    >
+      {shouldOverlayMobileNavbar ? (
+        <>
+          <BlurTargetView ref={mobileBlurTargetRef} style={styles.mobileBlurTarget}>
+            <View
+              className={`flex-1 ${contentClassName}`}
+              style={mobileContentOffset ? { paddingTop: mobileContentOffset } : undefined}
+            >
+              {stickyHeader}
+              {children}
+            </View>
+          </BlurTargetView>
+          <View style={styles.mobileNavbarOverlay}>{renderNavbar(true)}</View>
+        </>
+      ) : (
+        <>
+          {renderNavbar()}
+          <View className={`flex-1 ${contentClassName}`}>
+            {stickyHeader}
+            {children}
+          </View>
+        </>
+      )}
       {additionalContent}
     </SafeAreaView>
   );
 }
+
+const styles = StyleSheet.create({
+  mobileBlurTarget: {
+    flex: 1,
+  },
+  mobileNavbarOverlay: {
+    left: 0,
+    position: 'absolute',
+    right: 0,
+    top: 0,
+    zIndex: 50,
+  },
+});


### PR DESCRIPTION
## Summary
- Add a translucent Android status bar and render the mobile navbar as an overlay that can blur underlying content.
- Animate the mobile navbar glass/divider state when content scrolls.
- Adjust mobile dashboard/home stat typography and virtual card layout with a shared home stat value style.

## Impact
- Mobile screens get a more immersive top chrome treatment while keeping content offset below the overlay.
- Home stat values share consistent sizing and weight.

## Validation
- `git diff --check` passed.
- `npx prettier --check app.config.ts app/_layout.tsx components/Dashboard/DashboardHeaderMobile.tsx components/Home/HomeCashbackCard.tsx components/Home/HomeSavingsStatCard.tsx components/Home/HomeVirtualCard.tsx components/Home/homeStatValueStyle.ts components/Navbar/NavbarMobile.tsx components/PageLayout.tsx` passed.
- Repo-wide `npx prettier --check "app/**/*.{ts,tsx}" "components/**/*.{ts,tsx}" "hooks/**/*.{ts,tsx}"` fails on 22 pre-existing files outside this PR scope.
- Repo-wide `npx tsc --noEmit --pretty false` fails on existing unrelated errors in KYC/card/bridge files; no errors were reported in the touched files.