### PR TITLE
fix(home): solid setup CTA + stop polling card details every 5s

### DIFF
--- a/components/Home/FinishSetupModal.tsx
+++ b/components/Home/FinishSetupModal.tsx
@@ -87,7 +87,8 @@ const FinishSetupModal = ({ isOpen, onClose, steps, firstIncomplete }: FinishSet
         <View className="gap-5" style={{ paddingBottom: bottomPadding }}>
           {firstIncomplete && (
             <Button
-              className="h-14 rounded-2xl border-0 bg-button-earning web:hover:bg-button-earning web:hover:brightness-110"
+              variant="brand"
+              className="h-14 rounded-2xl"
               onPress={handleCta}
               style={{ paddingVertical: 0 }}
             >

--- a/hooks/cardDetailsQueryOptions.ts
+++ b/hooks/cardDetailsQueryOptions.ts
@@ -6,6 +6,9 @@ const CARD_DETAILS = 'cardDetails';
 export const cardDetailsQueryOptions = () => ({
   queryKey: [CARD_DETAILS],
   queryFn: () => withRefreshToken(() => getCardDetails()),
-  staleTime: 5_000,
-  refetchInterval: 5_000,
+  // Card details (cashback totals, percentage, card metadata) change rarely, so we
+  // don't poll them. The live card balance is fetched separately in useCardDetails
+  // (the `cardBalance` query, polled every 5s). Polling details every 5s was causing
+  // the home cashback card to repeatedly fall back to its loading skeleton.
+  staleTime: 60_000,
 });


### PR DESCRIPTION
Promotes the home fixes from **qa** (#2176) to `master`.

These came from three reported issues on the native home screen:
1. Cashback stat card changed height while its amount loaded.
2. Cashback card re-showed its loading skeleton every few seconds.
3. The "Finish setting up" CTA looked disabled.

On `master`, the stat cards have **already** been refactored (the home redesign uses `minHeight` + a shared `HOME_STAT_VALUE_TEXT_STYLE` and a `showSkeleton = isLoading && !cardDetails` guard), so the **card-height jump (#1) is already handled there**. This promotion therefore carries only the two fixes `master` still needs:

### `cardDetailsQueryOptions.ts` — issue #2
Drop the 5s `refetchInterval` and raise `staleTime` to 60s. Card details (cashback totals / percentage / card metadata) change rarely, and the live card balance is polled separately (`cardBalance`, every 5s). The interval was needlessly making the cashback card fall back to its loading skeleton "every few seconds."

### `FinishSetupModal.tsx` — issue #3
Use the standard solid `variant="brand"` button instead of the 20%-opacity `bg-button-earning` fill, which renders as a muted, disabled-looking green on the dark modal background. Master's text-fitting tweaks (`numberOfLines` / `adjustsFontSizeToFit` / padding) are preserved.

Cherry-picked from `a74c14d3` (qa); the two stat-card files resolved to master's version since the redesign already covers that fix.

## Test plan
- [ ] Home: "Finish setting up" CTA reads as an enabled green button.
- [ ] Home: cashback card does not repeatedly flash its skeleton.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011pAKfpRFjbH5TJSfNimjJy)_