### PR TITLE
[codex] mobile settings and rewards nav polish

### DIFF
--- a/app/(protected)/(tabs)/index.native.tsx
+++ b/app/(protected)/(tabs)/index.native.tsx
@@ -27,7 +27,7 @@ import { useVaultBalance } from '@/hooks/useVault';
 import { useWalletTokens } from '@/hooks/useWalletTokens';
 import { useIntercom } from '@/lib/intercom';
 import { SavingMode } from '@/lib/types';
-import { hasCard } from '@/lib/utils';
+import { formatBalanceUSD, hasCard } from '@/lib/utils';
 import { useSpinWinModalStore } from '@/store/useSpinWinModalStore';
 import { useUserStore } from '@/store/useUserStore';
 
@@ -108,10 +108,12 @@ export default function Home() {
 
   const isBalanceSectionLoading =
     isLoadingTokens || isBalanceLoading || isTotalSavingsLoading || totalSavingsUSD === undefined;
+  const headlineBalance = totalUSDExcludingVaultTokens + (totalSavingsUSD ?? 0) + cardBalance;
+  const mobileHeaderBalance = isBalanceSectionLoading ? null : formatBalanceUSD(headlineBalance);
   const showAssets = isLoadingTokens || hasTokens || !!tokenError;
 
   return (
-    <PageLayout>
+    <PageLayout mobileTitle={mobileHeaderBalance}>
       <View className="mb-5 w-full gap-8 pb-20">
         {isBalanceSectionLoading ? (
           <View className="items-center pt-6">
@@ -123,10 +125,7 @@ export default function Home() {
             </View>
           </View>
         ) : (
-          <DashboardHeaderMobile
-            balance={totalUSDExcludingVaultTokens + (totalSavingsUSD ?? 0) + cardBalance}
-            mode={SavingMode.BALANCE_ONLY}
-          />
+          <DashboardHeaderMobile balance={headlineBalance} mode={SavingMode.BALANCE_ONLY} />
         )}
 
         <View className="gap-3 px-4">

--- a/app/(protected)/(tabs)/index.tsx
+++ b/app/(protected)/(tabs)/index.tsx
@@ -30,7 +30,7 @@ import { useVaultBalance } from '@/hooks/useVault';
 import { useWalletTokens } from '@/hooks/useWalletTokens';
 import { useIntercom } from '@/lib/intercom';
 import { SavingMode } from '@/lib/types';
-import { fontSize, hasCard } from '@/lib/utils';
+import { fontSize, formatBalanceUSD, hasCard } from '@/lib/utils';
 import { useSpinWinModalStore } from '@/store/useSpinWinModalStore';
 import { useUserStore } from '@/store/useUserStore';
 
@@ -126,6 +126,7 @@ export default function Home() {
     isCardBalanceLoading ||
     totalSavingsUSD === undefined;
   const headlineBalance = totalUSDExcludingVaultTokens + (totalSavingsUSD ?? 0) + cardBalance;
+  const mobileHeaderBalance = isHeadlineLoading ? null : formatBalanceUSD(headlineBalance);
 
   if (!isInitialLoading && !balance && !isDeposited && !hasTokens) {
     return <HomeEmptyState />;
@@ -135,7 +136,7 @@ export default function Home() {
   // fallbacks from LazyWalletTabs and LazyHomeBanners to be visible immediately.
   // This improves perceived performance - users see content structure right away.
   return (
-    <PageLayout>
+    <PageLayout mobileTitle={mobileHeaderBalance}>
       <View className="mx-auto mb-5 w-full max-w-7xl gap-8 px-0 py-0 pb-20 md:gap-12 md:px-4 md:py-12">
         {isScreenMedium ? (
           <View className="flex-row items-center justify-between">

--- a/app/(protected)/(tabs)/referral.tsx
+++ b/app/(protected)/(tabs)/referral.tsx
@@ -37,7 +37,7 @@ export default function Referral() {
               Know who referred you?&nbsp;
               <Link href={path.ADD_REFERRER} className="hover:opacity-70">
                 <Text className="leading-4 web:underline">
-                  Add them so <br />
+                  Add them so{'\n'}
                   you both get credit
                 </Text>
               </Link>

--- a/app/(protected)/(tabs)/rewards/benefits.tsx
+++ b/app/(protected)/(tabs)/rewards/benefits.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react';
 import { View } from 'react-native';
 import { router } from 'expo-router';
 
@@ -9,13 +10,33 @@ import { BackButton } from '@/components/ui/back-button';
 import { Text } from '@/components/ui/text';
 import { path } from '@/constants/path';
 import { useDimension } from '@/hooks/useDimension';
-import { useTierBenefits } from '@/hooks/useRewards';
+import { useRewardsUserData, useTierBenefits } from '@/hooks/useRewards';
 
 export default function RewardsBenefits() {
   const { isScreenMedium } = useDimension();
   const { data: tierBenefits, isLoading } = useTierBenefits();
+  const {
+    data: rewardsData,
+    isLoading: isRewardsUserDataLoading,
+    isError: isRewardsUserDataError,
+  } = useRewardsUserData();
 
-  if (isLoading || !tierBenefits) {
+  const hasOptedIn = rewardsData?.hasOptedIn ?? true;
+  const rewardsLocked = Boolean(rewardsData && !hasOptedIn);
+
+  useEffect(() => {
+    if (rewardsLocked || isRewardsUserDataError) {
+      router.replace(path.REWARDS);
+    }
+  }, [isRewardsUserDataError, rewardsLocked]);
+
+  if (
+    isRewardsUserDataLoading ||
+    isRewardsUserDataError ||
+    rewardsLocked ||
+    isLoading ||
+    !tierBenefits
+  ) {
     return <PageLayout isLoading={true}>{null}</PageLayout>;
   }
 

--- a/app/(protected)/(tabs)/rewards/index.tsx
+++ b/app/(protected)/(tabs)/rewards/index.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useEffect, useMemo } from 'react';
 import { Pressable, View } from 'react-native';
 import { router } from 'expo-router';
 import { RotateCw } from 'lucide-react-native';
@@ -29,6 +29,19 @@ export default function Rewards() {
   const { mutate: joinRewards, isPending: isJoining } = useOptInToRewards();
   const welcomeDismissed = useRewardsWelcomePopupStore(state => state.dismissed);
   const setWelcomeDismissed = useRewardsWelcomePopupStore(state => state.setDismissed);
+
+  // The new rewards program requires an explicit opt-in. `hasOptedIn` defaults to
+  // true when the backend doesn't yet send it, so we never prompt prematurely.
+  const hasOptedIn = rewardsData?.hasOptedIn ?? true;
+  const rewardsLocked = Boolean(rewardsData && !hasOptedIn);
+  const legacyPoints = rewardsData?.legacyPoints ?? 0;
+  const showWelcomePopup = rewardsLocked && !welcomeDismissed;
+
+  useEffect(() => {
+    if (rewardsLocked && welcomeDismissed) {
+      router.replace(path.HOME);
+    }
+  }, [rewardsLocked, welcomeDismissed]);
 
   const bannerData = useMemo(() => {
     if (!rewardsData) return [];
@@ -67,11 +80,25 @@ export default function Rewards() {
 
   const { currentTier, totalPoints, nextTier, nextTierPoints } = rewardsData;
 
-  // The new rewards program requires an explicit opt-in. `hasOptedIn` defaults to
-  // true when the backend doesn't yet send it, so we never prompt prematurely.
-  const hasOptedIn = rewardsData.hasOptedIn ?? true;
-  const legacyPoints = rewardsData.legacyPoints ?? 0;
-  const showWelcomePopup = !hasOptedIn && !welcomeDismissed;
+  if (rewardsLocked) {
+    return (
+      <PageLayout isLoading={welcomeDismissed}>
+        <RewardsWelcomePopup
+          isOpen={showWelcomePopup}
+          variant={legacyPoints > 0 ? 'existing' : 'new'}
+          oldPoints={legacyPoints}
+          legacyCarryoverPoints={rewardsData.legacyCarryoverPoints ?? 0}
+          startingTier={rewardsData.startingTier ?? currentTier}
+          isJoining={isJoining}
+          onAgree={() => joinRewards()}
+          onClose={() => {
+            setWelcomeDismissed(true);
+            router.replace(path.HOME);
+          }}
+        />
+      </PageLayout>
+    );
+  }
 
   return (
     <PageLayout isLoading={isLoading}>
@@ -102,24 +129,6 @@ export default function Rewards() {
         <HomeBanners data={bannerData} />
         <CardBanner />
       </View>
-
-      <RewardsWelcomePopup
-        isOpen={showWelcomePopup}
-        variant={legacyPoints > 0 ? 'existing' : 'new'}
-        oldPoints={legacyPoints}
-        legacyCarryoverPoints={rewardsData.legacyCarryoverPoints ?? 0}
-        startingTier={rewardsData.startingTier ?? currentTier}
-        isJoining={isJoining}
-        onAgree={() =>
-          joinRewards(undefined, {
-            onSuccess: () => setWelcomeDismissed(true),
-          })
-        }
-        onClose={() => {
-          setWelcomeDismissed(true);
-          router.replace(path.HOME);
-        }}
-      />
     </PageLayout>
   );
 }

--- a/app/(protected)/(tabs)/settings/index.tsx
+++ b/app/(protected)/(tabs)/settings/index.tsx
@@ -1,25 +1,182 @@
-import { Linking, Platform, Pressable, Text, View } from 'react-native';
+import React from 'react';
+import { Linking, Platform, Pressable, View } from 'react-native';
 import * as Application from 'expo-application';
 import { Image } from 'expo-image';
 import * as IntentLauncher from 'expo-intent-launcher';
-import { Bell } from 'lucide-react-native';
+import { Href, router } from 'expo-router';
+import { Bell, ChevronRight, CircleDollarSign, Heart, Sparkles } from 'lucide-react-native';
 
+import ProfileIcon from '@/assets/images/profile';
 import Navbar from '@/components/Navbar';
 import PageLayout from '@/components/PageLayout';
 import { SettingsCard } from '@/components/Settings';
 import { BackButton } from '@/components/ui/back-button';
+import { Text } from '@/components/ui/text';
+import { path } from '@/constants/path';
+import { getTierDisplayName, getTierIcon } from '@/constants/rewards';
 import { useDimension } from '@/hooks/useDimension';
 import useNotificationPermissionStatus from '@/hooks/useNotificationPermissionStatus';
+import { useRewardsUserData } from '@/hooks/useRewards';
 import useUser from '@/hooks/useUser';
 import { getAsset } from '@/lib/assets';
-import { cn } from '@/lib/utils';
+import { RewardsTier } from '@/lib/types';
+import { cn, getUserDisplayName } from '@/lib/utils';
 
 const AccountDetailsIcon = getAsset('images/settings_account_details.png');
 const SecurityIcon = getAsset('images/settings_security.png');
 const HelpSupportIcon = getAsset('images/settings_help_and_support.png');
 const LogoutIcon = getAsset('images/settings_logout.png');
 
-export default function Settings() {
+type MobileSettingsRow = {
+  title: string;
+  icon: React.ReactNode;
+  href?: Href;
+  onPress?: () => void;
+  accessory?: React.ReactNode;
+};
+
+const mobileHeader = (
+  <View className="px-4 pb-0 pt-1">
+    <BackButton />
+  </View>
+);
+
+const IconImage = ({
+  source,
+  width,
+  height,
+}: {
+  source: ReturnType<typeof getAsset>;
+  width: number;
+  height: number;
+}) => <Image source={source} contentFit="contain" style={{ width, height }} />;
+
+const TierBadge = ({ tier }: { tier: RewardsTier }) => {
+  return (
+    <View className="h-[29px] flex-row items-center gap-1.5 rounded-full bg-[#FFD15126] px-3">
+      <Text className="text-base font-semibold text-[#FFD151]">{getTierDisplayName(tier)}</Text>
+      <Image source={getTierIcon(tier)} contentFit="contain" style={{ width: 19, height: 19 }} />
+    </View>
+  );
+};
+
+const SettingsRow = ({ title, icon, href, onPress, accessory }: MobileSettingsRow) => {
+  const handlePress = () => {
+    if (href) {
+      router.push(href);
+      return;
+    }
+
+    onPress?.();
+  };
+
+  return (
+    <Pressable
+      onPress={handlePress}
+      className="h-[60px] flex-row items-center justify-between px-5 active:opacity-70"
+      accessibilityRole="button"
+    >
+      <View className="flex-1 flex-row items-center gap-3">
+        <View className="w-6 items-center justify-center">{icon}</View>
+        <Text className="text-[17px] font-bold text-white">{title}</Text>
+      </View>
+      <View className="flex-row items-center gap-4">
+        {accessory}
+        <ChevronRight size={22} color="#ffffff" strokeWidth={1.8} />
+      </View>
+    </Pressable>
+  );
+};
+
+const SettingsRowGroup = ({ rows }: { rows: MobileSettingsRow[] }) => {
+  return (
+    <View className="overflow-hidden rounded-xl bg-[#1c1c1c]">
+      {rows.map((row, index) => (
+        <React.Fragment key={row.title}>
+          <SettingsRow {...row} />
+          {index < rows.length - 1 && <View className="h-px bg-[#101010]" />}
+        </React.Fragment>
+      ))}
+    </View>
+  );
+};
+
+const MobileSettings = () => {
+  const { user, handleLogout } = useUser();
+  const { data: rewardsData } = useRewardsUserData();
+  const currentTier = rewardsData?.currentTier ?? RewardsTier.CORE;
+  const displayName = getUserDisplayName(user, 18);
+
+  const rowGroups: MobileSettingsRow[][] = [
+    [
+      {
+        title: 'Rewards',
+        icon: <CircleDollarSign size={23} color="#ffffff" strokeWidth={2} />,
+        href: path.REWARDS,
+        accessory: <TierBadge tier={currentTier} />,
+      },
+      {
+        title: 'Refer & Earn',
+        icon: <Heart size={23} color="#ffffff" strokeWidth={2} />,
+        href: path.REFERRAL,
+      },
+    ],
+    [
+      {
+        title: 'Account details',
+        icon: <IconImage source={AccountDetailsIcon} width={22} height={22} />,
+        href: '/settings/account' as Href,
+      },
+      {
+        title: 'Security',
+        icon: <IconImage source={SecurityIcon} width={24} height={24} />,
+        href: '/settings/security' as Href,
+      },
+    ],
+    [
+      {
+        title: 'Agent wallet',
+        icon: <Sparkles size={24} color="#ffffff" strokeWidth={1.8} />,
+        href: path.AGENT,
+      },
+    ],
+    [
+      {
+        title: 'Help & Support',
+        icon: <IconImage source={HelpSupportIcon} width={24} height={24} />,
+        href: '/settings/help' as Href,
+      },
+    ],
+    [
+      {
+        title: 'Sign out',
+        icon: <IconImage source={LogoutIcon} width={23} height={20} />,
+        onPress: handleLogout,
+      },
+    ],
+  ];
+
+  return (
+    <PageLayout customMobileHeader={mobileHeader} useDesktopBreakpoint>
+      <View className="mx-auto w-full max-w-[512px] px-4 pb-10">
+        <View className="items-center">
+          <View className="relative h-[124px] w-[124px] items-center justify-center rounded-full bg-[#2A2A2A]">
+            <ProfileIcon width={48} height={60} />
+          </View>
+          <Text className="mt-3 text-lg font-semibold text-white">{displayName}</Text>
+        </View>
+
+        <View className="mt-9 gap-2.5">
+          {rowGroups.map((rows, index) => (
+            <SettingsRowGroup key={index} rows={rows} />
+          ))}
+        </View>
+      </View>
+    </PageLayout>
+  );
+};
+
+const DesktopSettings = () => {
   const { handleLogout } = useUser();
   const { isDesktop } = useDimension();
   const { status: notificationStatus } = useNotificationPermissionStatus();
@@ -41,13 +198,6 @@ export default function Settings() {
     }
   };
 
-  const mobileHeader = (
-    <View className="flex-row items-center justify-between px-4 py-3">
-      <BackButton />
-      <Text className="mr-10 flex-1 text-center text-xl font-bold text-white">Settings</Text>
-    </View>
-  );
-
   const desktopHeader = (
     <>
       <Navbar />
@@ -62,40 +212,33 @@ export default function Settings() {
   );
 
   return (
-    <PageLayout
-      customMobileHeader={mobileHeader}
-      customDesktopHeader={desktopHeader}
-      useDesktopBreakpoint
-    >
+    <PageLayout customDesktopHeader={desktopHeader} useDesktopBreakpoint>
       <View
         className={cn('mx-auto w-full gap-3 px-4 py-4', {
           'max-w-[512px]': isDesktop,
           'max-w-7xl': !isDesktop,
         })}
       >
-        {/* Account Details Card */}
         <View className="overflow-hidden rounded-xl bg-[#1c1c1c]">
           <SettingsCard
             title="Account details"
-            icon={<Image source={AccountDetailsIcon} style={{ width: 22, height: 22 }} />}
+            icon={<IconImage source={AccountDetailsIcon} width={22} height={22} />}
             link="/settings/account"
             isDesktop={isDesktop}
             hideIconBackground
           />
         </View>
 
-        {/* Security Card */}
         <View className="overflow-hidden rounded-xl bg-[#1c1c1c]">
           <SettingsCard
             title="Security"
-            icon={<Image source={SecurityIcon} style={{ width: 24, height: 24 }} />}
+            icon={<IconImage source={SecurityIcon} width={24} height={24} />}
             link="/settings/security"
             isDesktop={isDesktop}
             hideIconBackground
           />
         </View>
 
-        {/* Push Notifications Card */}
         {Platform.OS !== 'web' && (
           <View className="overflow-hidden rounded-xl bg-[#1c1c1c]">
             <SettingsCard
@@ -119,36 +262,32 @@ export default function Settings() {
           </View>
         )}
 
-        {/* Help & Support Card */}
         <View className="overflow-hidden rounded-xl bg-[#1c1c1c]">
           <SettingsCard
             title="Help & Support"
-            icon={<Image source={HelpSupportIcon} style={{ width: 24, height: 24 }} />}
+            icon={<IconImage source={HelpSupportIcon} width={24} height={24} />}
             link="/settings/help"
             isDesktop={isDesktop}
             hideIconBackground
           />
         </View>
 
-        {/* Logout Card */}
         <View className="overflow-hidden rounded-xl bg-[#1c1c1c]">
           <SettingsCard
             title="Logout"
-            icon={<Image source={LogoutIcon} style={{ width: 23, height: 20 }} />}
+            icon={<IconImage source={LogoutIcon} width={23} height={20} />}
             onPress={handleLogout}
             isDesktop={isDesktop}
             hideIconBackground
           />
         </View>
 
-        {/* Legal Footer Link */}
         <View className="items-center pb-4 pt-6">
           <Pressable onPress={handleLegalPress} className="active:opacity-70">
             <Text className="text-base font-medium text-[#808080]">Legal</Text>
           </Pressable>
         </View>
 
-        {/* Build Information */}
         {Platform.OS !== 'web' && (
           <View className="items-center px-4 pb-2">
             <Text className="text-xs text-muted-foreground">
@@ -161,4 +300,14 @@ export default function Settings() {
       </View>
     </PageLayout>
   );
+};
+
+export default function Settings() {
+  const { isDesktop } = useDimension();
+
+  if (isDesktop) {
+    return <DesktopSettings />;
+  }
+
+  return <MobileSettings />;
 }

--- a/components/AccountCenter/AccountCenterDropdown.native.tsx
+++ b/components/AccountCenter/AccountCenterDropdown.native.tsx
@@ -1,96 +1,18 @@
-import { useCallback, useRef } from 'react';
-import { Pressable, View } from 'react-native';
-import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import { BottomSheetBackdrop, BottomSheetModal, BottomSheetView } from '@gorhom/bottom-sheet';
+import { View } from 'react-native';
+import { router } from 'expo-router';
 
-import { InfoCenterSupport, useInfoCenterSupportPress } from '@/components/InfoCenter';
-import useUser from '@/hooks/useUser';
+import { path } from '@/constants/path';
 
-import {
-  AccountCenterAgent,
-  AccountCenterSettings,
-  AccountCenterSignOut,
-  AccountCenterTrigger,
-  AccountCenterUsername,
-  onAccountCenterAgentPress,
-  onAccountCenterSettingsPress,
-} from '.';
-
-const rowClassName = 'h-14 flex-row items-center gap-2 px-[30px]';
+import { AccountCenterTrigger } from '.';
 
 const AccountCenterDropdown = () => {
-  const insets = useSafeAreaInsets();
-  const { handleLogout } = useUser();
-  const onSupportPress = useInfoCenterSupportPress();
-  const bottomSheetModalRef = useRef<BottomSheetModal>(null);
-
-  const dismissAndRun = useCallback((action: () => void) => {
-    bottomSheetModalRef.current?.dismiss();
-    action();
-  }, []);
-
-  const handlePresentModalPress = useCallback(() => {
-    bottomSheetModalRef.current?.present();
-  }, []);
-
-  const handleSettingsPress = useCallback(
-    () => dismissAndRun(onAccountCenterSettingsPress),
-    [dismissAndRun],
-  );
-
-  const handleAgentPress = useCallback(
-    () => dismissAndRun(onAccountCenterAgentPress),
-    [dismissAndRun],
-  );
-
-  const handleSignOutPress = useCallback(
-    () => dismissAndRun(handleLogout),
-    [dismissAndRun, handleLogout],
-  );
-
-  const handleSupportPress = useCallback(
-    () => dismissAndRun(onSupportPress),
-    [dismissAndRun, onSupportPress],
-  );
-
-  const renderBackdrop = useCallback(
-    (props: any) => <BottomSheetBackdrop {...props} appearsOnIndex={0} disappearsOnIndex={-1} />,
-    [],
-  );
-
   return (
     <View>
-      <AccountCenterTrigger onPress={handlePresentModalPress} />
-      <BottomSheetModal
-        ref={bottomSheetModalRef}
-        backdropComponent={renderBackdrop}
-        backgroundStyle={{ backgroundColor: '#1c1c1c', borderRadius: 20 }}
-        handleIndicatorStyle={{
-          backgroundColor: 'rgba(255,255,255,0.2)',
-          width: 74,
-          height: 8,
-        }}
-      >
-        <BottomSheetView className="gap-2 pb-2" style={{ paddingBottom: insets.bottom }}>
-          <View className={rowClassName}>
-            <AccountCenterUsername />
-          </View>
-          <View className="mx-[30px] h-px bg-border/50" />
-          <Pressable className={rowClassName} onPress={handleAgentPress}>
-            <AccountCenterAgent />
-          </Pressable>
-          <Pressable className={rowClassName} onPress={handleSettingsPress}>
-            <AccountCenterSettings />
-          </Pressable>
-          <Pressable className={rowClassName} onPress={handleSupportPress}>
-            <InfoCenterSupport />
-          </Pressable>
-          <View className="mx-[30px] h-px bg-border/50" />
-          <Pressable className={rowClassName} onPress={handleSignOutPress}>
-            <AccountCenterSignOut />
-          </Pressable>
-        </BottomSheetView>
-      </BottomSheetModal>
+      <AccountCenterTrigger
+        accessibilityLabel="Open account center"
+        accessibilityRole="button"
+        onPress={() => router.push(path.SETTINGS)}
+      />
     </View>
   );
 };

--- a/components/CustomTabBar.tsx
+++ b/components/CustomTabBar.tsx
@@ -127,6 +127,7 @@ const VISIBLE_TAB_NAMES = ['index', 'savings', 'card', 'activity'];
 
 export function CustomTabBar({ state, descriptors, navigation }: BottomTabBarProps) {
   const insets = useSafeAreaInsets();
+  const currentRouteName = state.routes[state.index]?.name;
 
   // Lift the tab bar above the system navigation bar / home indicator using the
   // real bottom inset (plus a little extra on Android, see constant), never
@@ -140,6 +141,10 @@ export function CustomTabBar({ state, descriptors, navigation }: BottomTabBarPro
 
   // Filter to only show the main visible tabs
   const visibleRoutes = state.routes.filter(route => VISIBLE_TAB_NAMES.includes(route.name));
+
+  if (currentRouteName === 'settings') {
+    return null;
+  }
 
   return (
     <View

--- a/components/Dashboard/HomeBanners.tsx
+++ b/components/Dashboard/HomeBanners.tsx
@@ -133,7 +133,7 @@ const HomeBannersContent = ({ data: propData }: HomeBannersContentProps) => {
   const GAP = isScreenMedium ? 30 : 8;
   const ITEM_WIDTH = isScreenMedium ? containerWidth / 2 : containerWidth;
   const VIEW_COUNT = isScreenMedium ? 2 : 1;
-  const BANNER_HEIGHT = isScreenMedium ? 220 : 170;
+  const BANNER_HEIGHT = isScreenMedium ? 220 : propData ? 200 : 170;
   const HAS_MULTIPLE_VIEWS = VIEW_COUNT > 1;
 
   const defaultData = useMemo(() => {
@@ -319,7 +319,7 @@ const styles = StyleSheet.create({
   },
   paginationContainer: {
     gap: 4,
-    marginTop: 0,
+    marginTop: 8,
   },
   dotStyle: {
     backgroundColor: '#616161',

--- a/components/Navbar/NavbarMobile.tsx
+++ b/components/Navbar/NavbarMobile.tsx
@@ -1,5 +1,5 @@
 import { type RefObject, useCallback, useEffect } from 'react';
-import { LayoutChangeEvent, StyleSheet, View } from 'react-native';
+import { LayoutChangeEvent, Platform, StyleSheet, View } from 'react-native';
 import Animated, {
   Easing,
   useAnimatedStyle,
@@ -10,6 +10,7 @@ import { BlurView } from 'expo-blur';
 import { Image } from 'expo-image';
 
 import AccountCenterDropdown from '@/components/AccountCenter/AccountCenterDropdown.native';
+import { Text } from '@/components/ui/text';
 import useUser from '@/hooks/useUser';
 import { getAsset } from '@/lib/assets';
 
@@ -21,10 +22,17 @@ const GLASS_TRANSITION = {
   easing: Easing.out(Easing.cubic),
 };
 
+const TITLE_TRANSITION = {
+  duration: 240,
+  easing: Easing.out(Easing.cubic),
+};
+
 type NavbarMobileProps = {
   blurTarget?: RefObject<View | null>;
   onContentOffsetChange?: (height: number) => void;
   showDivider?: boolean;
+  showTitle?: boolean;
+  title?: string;
   topInset?: number;
 };
 
@@ -32,22 +40,45 @@ const NavbarMobile = ({
   blurTarget,
   onContentOffsetChange,
   showDivider,
+  showTitle,
+  title,
   topInset = 0,
 }: NavbarMobileProps) => {
   const { user } = useUser();
   const hasBlurTarget = !!blurTarget;
   const isGlassVisible = hasBlurTarget && !!showDivider;
+  const isTitleVisible = !!title && !!showTitle;
+  const blurViewProps =
+    Platform.OS === 'android'
+      ? {
+          blurMethod: 'dimezisBlurView' as const,
+          blurReductionFactor: 2.4,
+          blurTarget,
+        }
+      : {};
   const glassProgress = useSharedValue(isGlassVisible ? 1 : 0);
+  const titleProgress = useSharedValue(isTitleVisible ? 1 : 0);
 
   useEffect(() => {
     glassProgress.value = withTiming(isGlassVisible ? 1 : 0, GLASS_TRANSITION);
   }, [glassProgress, isGlassVisible]);
+
+  useEffect(() => {
+    titleProgress.value = withTiming(isTitleVisible ? 1 : 0, TITLE_TRANSITION);
+  }, [isTitleVisible, titleProgress]);
 
   const glassAnimatedStyle = useAnimatedStyle(() => ({
     opacity: glassProgress.value,
   }));
   const dividerAnimatedStyle = useAnimatedStyle(() => ({
     opacity: glassProgress.value,
+  }));
+  const titleAnimatedStyle = useAnimatedStyle(() => ({
+    opacity: titleProgress.value,
+    transform: [
+      { translateY: (1 - titleProgress.value) * 6 },
+      { scale: 0.96 + titleProgress.value * 0.04 },
+    ],
   }));
 
   const handleLayout = useCallback(
@@ -59,16 +90,14 @@ const NavbarMobile = ({
 
   return (
     <View
-      className="overflow-hidden bg-background"
+      className={hasBlurTarget ? 'overflow-hidden' : 'overflow-hidden bg-background'}
       onLayout={handleLayout}
       style={topInset ? { paddingTop: topInset } : undefined}
     >
       {hasBlurTarget && (
         <Animated.View pointerEvents="none" style={[styles.overlay, glassAnimatedStyle]}>
           <BlurView
-            blurMethod="dimezisBlurView"
-            blurReductionFactor={2.4}
-            blurTarget={blurTarget}
+            {...blurViewProps}
             intensity={56}
             pointerEvents="none"
             style={StyleSheet.absoluteFill}
@@ -84,6 +113,18 @@ const NavbarMobile = ({
           style={{ width: 30, height: 30 }}
           contentFit="contain"
         />
+        {!!title && (
+          <Animated.View
+            accessibilityElementsHidden={!isTitleVisible}
+            importantForAccessibility={isTitleVisible ? 'auto' : 'no-hide-descendants'}
+            pointerEvents="none"
+            style={[styles.title, titleAnimatedStyle]}
+          >
+            <Text className="text-xl font-semibold text-white" numberOfLines={1}>
+              {title}
+            </Text>
+          </Animated.View>
+        )}
         {user ? (
           <View className="flex-row items-center gap-2">
             <WhatsNewButton />
@@ -107,6 +148,15 @@ const styles = StyleSheet.create({
   },
   glassOverlay: {
     backgroundColor: 'rgba(18, 18, 18, 0.66)',
+  },
+  title: {
+    alignItems: 'center',
+    bottom: 0,
+    justifyContent: 'center',
+    left: 72,
+    position: 'absolute',
+    right: 72,
+    top: 0,
   },
   divider: {
     backgroundColor: 'rgba(102, 99, 101, 0.28)',

--- a/components/PageLayout.tsx
+++ b/components/PageLayout.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, useCallback, useRef, useState } from 'react';
+import { ReactNode, useCallback, useMemo, useRef, useState } from 'react';
 import {
   NativeScrollEvent,
   NativeSyntheticEvent,
@@ -8,6 +8,7 @@ import {
 } from 'react-native';
 import { Edge, SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
 import { BlurTargetView } from 'expo-blur';
+import { usePathname } from 'expo-router';
 
 import { useDimension } from '@/hooks/useDimension';
 
@@ -16,6 +17,33 @@ import Navbar from './Navbar';
 import NavbarMobile from './Navbar/NavbarMobile';
 
 const MOBILE_NAVBAR_DIVIDER_OFFSET = 1;
+const MOBILE_NAVBAR_TITLE_REVEAL_OFFSET = 28;
+
+const MOBILE_NAVBAR_TITLES: Record<string, string> = {
+  '/': 'Home',
+  '/activity': 'Activity',
+  '/agent': 'Agent',
+  '/bank-transfer': 'Bank Transfer',
+  '/card': 'Card',
+  '/card-onboard': 'Card',
+  '/card/details': 'Card',
+  '/card/details/transactions': 'Transactions',
+  '/overview': 'Overview',
+  '/points': 'Points',
+  '/points/leaderboard': 'Leaderboard',
+  '/rewards': 'Rewards',
+  '/rewards/benefits': 'Rewards benefits',
+  '/savings': 'Savings',
+  '/savings-old': 'Savings',
+};
+
+const MOBILE_NAVBAR_TITLE_PREFIXES: [string, string][] = [
+  ['/activity/', 'Activity'],
+  ['/card-onboard/', 'Card'],
+  ['/card/', 'Card'],
+  ['/points/', 'Points'],
+  ['/rewards/', 'Rewards'],
+];
 
 interface PageLayoutProps {
   children: ReactNode;
@@ -27,6 +55,7 @@ interface PageLayoutProps {
   showNavbar?: boolean;
   desktopOnly?: boolean; // Only show navbar on desktop (isScreenMedium)
   useDesktopBreakpoint?: boolean; // Use isDesktop instead of isScreenMedium
+  mobileTitle?: string | null; // Overrides the route-derived mobile navbar title. Use null to hide it.
 
   // Custom headers
   customMobileHeader?: ReactNode; // Custom header for mobile (replaces NavbarMobile)
@@ -46,6 +75,29 @@ interface PageLayoutProps {
   className?: string;
   contentClassName?: string;
 }
+
+const toTitleCase = (value: string) =>
+  value
+    .replace(/[-_]+/g, ' ')
+    .replace(/\b\w/g, character => character.toUpperCase())
+    .trim();
+
+const getDefaultMobileNavbarTitle = (pathname: string) => {
+  const normalizedPathname = pathname.replace(/\/+$/, '') || '/';
+  const configuredTitle = MOBILE_NAVBAR_TITLES[normalizedPathname];
+
+  if (configuredTitle) return configuredTitle;
+
+  const prefixTitle = MOBILE_NAVBAR_TITLE_PREFIXES.find(([prefix]) =>
+    normalizedPathname.startsWith(prefix),
+  )?.[1];
+
+  if (prefixTitle) return prefixTitle;
+
+  const lastSegment = normalizedPathname.split('/').filter(Boolean).at(-1);
+
+  return lastSegment ? toTitleCase(lastSegment) : undefined;
+};
 
 /**
  * PageLayout - Flexible wrapper component for all pages
@@ -90,6 +142,7 @@ export default function PageLayout({
   showNavbar = true,
   desktopOnly = false,
   useDesktopBreakpoint = false,
+  mobileTitle,
   customMobileHeader,
   customDesktopHeader,
   scrollable = true,
@@ -100,10 +153,15 @@ export default function PageLayout({
   contentClassName = '',
 }: PageLayoutProps) {
   const { isScreenMedium, isDesktop } = useDimension();
+  const pathname = usePathname();
   const insets = useSafeAreaInsets();
   const mobileBlurTargetRef = useRef<View>(null);
   const [mobileNavbarOffset, setMobileNavbarOffset] = useState(0);
   const [isMobileNavbarScrolled, setIsMobileNavbarScrolled] = useState(false);
+  const [isMobileTitleVisible, setIsMobileTitleVisible] = useState(false);
+  const defaultMobileTitle = useMemo(() => getDefaultMobileNavbarTitle(pathname), [pathname]);
+  const resolvedMobileTitle =
+    mobileTitle === undefined ? defaultMobileTitle : mobileTitle || undefined;
 
   // Determine which breakpoint to use
   const isLargeScreen = useDesktopBreakpoint ? isDesktop : isScreenMedium;
@@ -115,11 +173,18 @@ export default function PageLayout({
   const safeAreaEdges = shouldOverlayMobileNavbar ? edges.filter(edge => edge !== 'top') : edges;
   const mobileContentOffset = shouldOverlayMobileNavbar ? mobileNavbarOffset : 0;
 
-  const handleMobileScroll = useCallback((event: NativeSyntheticEvent<NativeScrollEvent>) => {
-    const isScrolled = event.nativeEvent.contentOffset.y > MOBILE_NAVBAR_DIVIDER_OFFSET;
+  const handleMobileScroll = useCallback(
+    (event: NativeSyntheticEvent<NativeScrollEvent>) => {
+      const scrollOffsetY = event.nativeEvent.contentOffset.y;
+      const isScrolled = scrollOffsetY > MOBILE_NAVBAR_DIVIDER_OFFSET;
+      const isTitleVisible =
+        !!resolvedMobileTitle && scrollOffsetY > MOBILE_NAVBAR_TITLE_REVEAL_OFFSET;
 
-    setIsMobileNavbarScrolled(current => (current === isScrolled ? current : isScrolled));
-  }, []);
+      setIsMobileNavbarScrolled(current => (current === isScrolled ? current : isScrolled));
+      setIsMobileTitleVisible(current => (current === isTitleVisible ? current : isTitleVisible));
+    },
+    [resolvedMobileTitle],
+  );
 
   // Render navbar/header content
   const renderNavbar = (isOverlay = false) => {
@@ -135,6 +200,8 @@ export default function PageLayout({
           blurTarget={isOverlay ? mobileBlurTargetRef : undefined}
           onContentOffsetChange={isOverlay ? setMobileNavbarOffset : undefined}
           showDivider={isOverlay && isMobileNavbarScrolled}
+          showTitle={isOverlay && isMobileTitleVisible}
+          title={resolvedMobileTitle}
           topInset={isOverlay ? insets.top : 0}
         />
       ))
@@ -159,7 +226,7 @@ export default function PageLayout({
         contentContainerStyle={
           mobileContentOffset ? { paddingTop: mobileContentOffset } : undefined
         }
-        contentInsetAdjustmentBehavior="automatic"
+        contentInsetAdjustmentBehavior={shouldOverlayMobileNavbar ? 'never' : 'automatic'}
         onScroll={shouldOverlayMobileNavbar ? handleMobileScroll : undefined}
         scrollEventThrottle={shouldOverlayMobileNavbar ? 16 : undefined}
         stickyHeaderIndices={stickyHeader && !isScreenMedium ? [0] : undefined}

--- a/components/Rewards/CashbackCard.tsx
+++ b/components/Rewards/CashbackCard.tsx
@@ -27,7 +27,7 @@ const CashbackCard = ({
   const remainingSpend = cashbackRate > 0 ? (remainingCashback * 100) / cashbackRate : 0;
 
   return (
-    <View className="flex-1 justify-between overflow-hidden rounded-twice bg-card p-6">
+    <View className="flex-1 justify-between overflow-hidden rounded-twice bg-card px-6 pb-10 pt-6 md:p-6">
       <View className="relative flex-row items-center justify-between">
         <View className="flex-1 gap-1">
           <Text className="text-lg font-medium text-brand/70">Cashback</Text>

--- a/components/Rewards/RewardsDashboard.tsx
+++ b/components/Rewards/RewardsDashboard.tsx
@@ -1,4 +1,4 @@
-import { ImageBackground, Platform, View } from 'react-native';
+import { Platform, View } from 'react-native';
 import { Image } from 'expo-image';
 import { LinearGradient } from 'expo-linear-gradient';
 import { router } from 'expo-router';
@@ -92,7 +92,7 @@ const RewardsDashboard = ({
 
   return (
     <View
-      className="relative gap-20 rounded-twice p-6 md:px-10 md:py-8"
+      className="relative gap-10 rounded-twice p-6 md:gap-20 md:px-10 md:py-8"
       style={Platform.OS === 'web' ? {} : { borderRadius: 20 }}
     >
       <LinearGradient
@@ -112,24 +112,17 @@ const RewardsDashboard = ({
         }}
       />
       {!isScreenMedium && (
-        <ImageBackground
+        <Image
           source={getAsset('images/points_large.png')}
-          resizeMode="contain"
+          contentFit="contain"
+          pointerEvents="none"
           style={{
             position: 'absolute',
-            left: 0,
-            right: 0,
-            top: 0,
-            bottom: 0,
+            right: -225,
+            top: -22,
+            width: 600,
+            height: 276,
             zIndex: 0,
-            pointerEvents: 'none',
-          }}
-          imageStyle={{
-            width: 800,
-            height: 600,
-            marginTop: isScreenMedium ? -120 : -180,
-            marginRight: isScreenMedium ? -120 : -300,
-            marginLeft: 'auto',
           }}
         />
       )}

--- a/components/Rewards/TierBenefitsCard.tsx
+++ b/components/Rewards/TierBenefitsCard.tsx
@@ -15,7 +15,7 @@ const TierBenefitsCard = ({ label, icon, onPress }: TierBenefitsCardProps) => {
   const { isScreenMedium } = useDimension();
   return (
     <Pressable
-      className="flex-1 rounded-twice bg-card p-5 hover:opacity-90 md:px-8 md:py-6"
+      className="w-full rounded-twice bg-card p-5 hover:opacity-90 md:flex-1 md:px-8 md:py-6"
       onPress={onPress}
     >
       <View className="flex-row items-center justify-between">

--- a/components/Rewards/TierModalProvider.tsx
+++ b/components/Rewards/TierModalProvider.tsx
@@ -129,7 +129,7 @@ const TierModalProvider = () => {
               <ActivityIndicator />
             </View>
           ) : (
-            <View className="flex-row flex-wrap justify-between gap-6 md:pr-10">
+            <View className="gap-5 md:flex-row md:flex-wrap md:justify-between md:gap-6 md:pr-10">
               {tierBenefitItems.map((benefit, index) => (
                 <RewardBenefit
                   key={index}
@@ -153,7 +153,7 @@ const TierModalProvider = () => {
 
         <Button
           variant="secondary"
-          className="mt-auto h-12 rounded-xl border-0 bg-card web:hover:bg-card-hover md:mt-20"
+          className="h-12 rounded-xl border-0 bg-card web:hover:bg-card-hover md:mt-20"
           onPress={() => {
             setSelectedTierModalId(null);
             router.push(path.REWARDS_BENEFITS);

--- a/components/Rewards/TierProgressBar.tsx
+++ b/components/Rewards/TierProgressBar.tsx
@@ -25,7 +25,7 @@ const TierProgressBar = ({
 }: TierProgressBarProps) => {
   const { setSelectedTierModalId } = useRewards();
   const { isScreenMedium } = useDimension();
-  const progress = nextTier ? Math.min((currentPoints / nextTierPoints) * 100, 100) : 100;
+  const progress = nextTier ? Math.min((currentPoints / nextTierPoints) * 100, 100) : 0;
 
   const animatedProgress = useAnimatedStyle(
     () => ({
@@ -34,7 +34,11 @@ const TierProgressBar = ({
     [progress],
   );
 
-  const pointsNeeded = nextTier ? Math.max(0, nextTierPoints - currentPoints) : 0;
+  if (!nextTier) {
+    return null;
+  }
+
+  const pointsNeeded = Math.max(0, nextTierPoints - currentPoints);
 
   return (
     <View className="flex-1 gap-2">
@@ -43,32 +47,30 @@ const TierProgressBar = ({
           style={[{ backgroundColor: '#FFD151', height: '100%' }, animatedProgress]}
         ></Animated.View>
       </View>
-      {nextTier && (
-        <View className="flex-row items-center justify-between">
-          <Text className="text-base text-rewards/70">{toTitleCase(currentTier)}</Text>
-          <View className="flex-row items-center gap-5">
-            <View className="flex-row items-center gap-1">
-              <Text className="text-base">{formatNumber(pointsNeeded, 0, 0)} more points to</Text>
-              <Text className="text-base text-rewards/70">{toTitleCase(nextTier)}</Text>
-              <Image
-                source={getTierIcon(nextTier)}
-                contentFit="contain"
-                style={{ width: 16, height: 16 }}
-              />
-            </View>
-
-            {isScreenMedium && (
-              <Pressable
-                onPress={() => setSelectedTierModalId(currentTier)}
-                className="flex-row items-center hover:opacity-70"
-              >
-                <Text className="text-base">View benefits</Text>
-                <ChevronRightIcon size={16} color="white" />
-              </Pressable>
-            )}
+      <View className="flex-row items-center justify-between">
+        <Text className="text-base text-rewards/70">{toTitleCase(currentTier)}</Text>
+        <View className="flex-row items-center gap-5">
+          <View className="flex-row items-center gap-1">
+            <Text className="text-base">{formatNumber(pointsNeeded, 0, 0)} more points to</Text>
+            <Text className="text-base text-rewards/70">{toTitleCase(nextTier)}</Text>
+            <Image
+              source={getTierIcon(nextTier)}
+              contentFit="contain"
+              style={{ width: 16, height: 16 }}
+            />
           </View>
+
+          {isScreenMedium && (
+            <Pressable
+              onPress={() => setSelectedTierModalId(currentTier)}
+              className="flex-row items-center hover:opacity-70"
+            >
+              <Text className="text-base">View benefits</Text>
+              <ChevronRightIcon size={16} color="white" />
+            </Pressable>
+          )}
         </View>
-      )}
+      </View>
     </View>
   );
 };


### PR DESCRIPTION
## What changed

- Added scroll-revealed mobile navbar titles, including route-derived defaults and balance titles on home.
- Reworked mobile settings into a profile-centered menu with rewards, referral, account, security, agent wallet, support, and sign-out actions.
- Routed the native account center trigger to settings and hid the bottom tab bar on settings.
- Tightened rewards opt-in flow behavior and adjusted mobile rewards layout spacing, banners, tier cards, and progress behavior.

## Why

This consolidates the mobile account/settings entry point, improves mobile navigation feedback while scrolling, and keeps rewards pages from exposing locked/opt-in-only content before the user joins.

## Impact

Mobile users get a cleaner settings hub and better contextual navbar titles. Rewards users who have not opted in stay in the welcome/locked flow, while opted-in users continue to the normal rewards dashboard.

## Validation

- `git diff --check` passed.
- Targeted Prettier check on changed files passed: `git diff --name-only -z | xargs -0 npx prettier --check`.
- Full `npm run format:check` still fails on pre-existing formatting issues in unrelated files.
- Full `npx tsc --noEmit --pretty false` still fails on pre-existing unrelated errors in KYC, CardBanner, path typing, bridge hooks, and withdrawal collateral files.
