### PR TITLE
Handle verification unavailable state in KYC flow

### DIFF
--- a/app/(protected)/(tabs)/kyc.native.tsx
+++ b/app/(protected)/(tabs)/kyc.native.tsx
@@ -7,6 +7,7 @@ import {
   KycError,
   KycLoading,
   KycNativeWaiting,
+  KycUnavailable,
   useDiditSession,
 } from '@/components/kyc';
 
@@ -83,6 +84,9 @@ export default function KycNative() {
     <View style={styles.container}>
       {session.phase === 'loading' && <KycLoading />}
       {session.phase === 'error' && <KycError message={session.message} onRetry={initSession} />}
+      {session.phase === 'unavailable' && (
+        <KycUnavailable message={session.message} onRetry={initSession} />
+      )}
       {(session.phase === 'ready' || session.phase === 'started') && <KycNativeWaiting />}
       {session.phase === 'completed' && <KycCompleted />}
     </View>

--- a/app/(protected)/(tabs)/kyc.tsx
+++ b/app/(protected)/(tabs)/kyc.tsx
@@ -160,7 +160,7 @@ export default function KycWeb() {
         {session.phase === 'error' && <KycError message={session.message} onRetry={initSession} />}
 
         {session.phase === 'unavailable' && (
-          <KycUnavailable message={session.message} onRetry={initSession} />
+          <KycUnavailable message={session.message} onRetry={initSession} showBackButton={false} />
         )}
 
         {(session.phase === 'ready' || session.phase === 'started') && (

--- a/app/(protected)/(tabs)/kyc.tsx
+++ b/app/(protected)/(tabs)/kyc.tsx
@@ -2,7 +2,13 @@ import React, { useEffect, useRef } from 'react';
 import { View } from 'react-native';
 import { DiditSdk } from '@didit-protocol/sdk-web';
 
-import { KycCompleted, KycError, KycLoading, useDiditSession } from '@/components/kyc';
+import {
+  KycCompleted,
+  KycError,
+  KycLoading,
+  KycUnavailable,
+  useDiditSession,
+} from '@/components/kyc';
 import PageLayout from '@/components/PageLayout';
 import { BackButton } from '@/components/ui/back-button';
 import { Text } from '@/components/ui/text';
@@ -152,6 +158,10 @@ export default function KycWeb() {
         {session.phase === 'loading' && <KycLoading />}
 
         {session.phase === 'error' && <KycError message={session.message} onRetry={initSession} />}
+
+        {session.phase === 'unavailable' && (
+          <KycUnavailable message={session.message} onRetry={initSession} />
+        )}
 
         {(session.phase === 'ready' || session.phase === 'started') && (
           <View

--- a/components/kyc/KycStatusViews.tsx
+++ b/components/kyc/KycStatusViews.tsx
@@ -24,6 +24,32 @@ export function KycError({ message, onRetry }: { message: string; onRetry: () =>
   );
 }
 
+/**
+ * Shown when session creation fails because identity verification is
+ * temporarily unavailable (backend VERIFICATION_UNAVAILABLE — depleted Didit
+ * credit). Distinct from KycError: this is a transient, not-your-fault state,
+ * so it reads calmer (no red) and nudges the user to retry later.
+ */
+export function KycUnavailable({ message, onRetry }: { message?: string; onRetry: () => void }) {
+  const body =
+    message ??
+    'We can’t start identity verification right now. Please try again in a little while.';
+  return (
+    <View className="flex-1 items-center justify-center gap-4 px-8 py-20">
+      <Text className="text-center text-lg font-semibold text-white">
+        Verification temporarily unavailable
+      </Text>
+      <Text className="text-center text-[#ACACAC]">{body}</Text>
+      <Button variant="brand" onPress={onRetry} className="h-12 rounded-xl px-8">
+        <Text className="font-semibold text-primary-foreground">Try again</Text>
+      </Button>
+      <Text className="text-center text-xs text-[#6B6B6B]">
+        If this keeps happening, contact support.
+      </Text>
+    </View>
+  );
+}
+
 export function KycCompleted() {
   return (
     <View className="flex-1 items-center justify-center py-20">

--- a/components/kyc/KycStatusViews.tsx
+++ b/components/kyc/KycStatusViews.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { ActivityIndicator, View } from 'react-native';
 
+import { BackButton } from '@/components/ui/back-button';
 import { Button } from '@/components/ui/button';
 import { Text } from '@/components/ui/text';
 
@@ -30,22 +31,38 @@ export function KycError({ message, onRetry }: { message: string; onRetry: () =>
  * credit). Distinct from KycError: this is a transient, not-your-fault state,
  * so it reads calmer (no red) and nudges the user to retry later.
  */
-export function KycUnavailable({ message, onRetry }: { message?: string; onRetry: () => void }) {
+export function KycUnavailable({
+  message,
+  onRetry,
+  showBackButton = true,
+}: {
+  message?: string;
+  onRetry: () => void;
+  /** Render a back button at the top-left. Off on web, where the page header already has one. */
+  showBackButton?: boolean;
+}) {
   const body =
     message ??
     'We can’t start identity verification right now. Please try again in a little while.';
   return (
-    <View className="flex-1 items-center justify-center gap-4 px-8 py-20">
-      <Text className="text-center text-lg font-semibold text-white">
-        Verification temporarily unavailable
-      </Text>
-      <Text className="text-center text-[#ACACAC]">{body}</Text>
-      <Button variant="brand" onPress={onRetry} className="h-12 rounded-xl px-8">
-        <Text className="font-semibold text-primary-foreground">Try again</Text>
-      </Button>
-      <Text className="text-center text-xs text-[#6B6B6B]">
-        If this keeps happening, contact support.
-      </Text>
+    <View className="flex-1">
+      {showBackButton && (
+        <View className="px-4 pt-2">
+          <BackButton />
+        </View>
+      )}
+      <View className="flex-1 items-center justify-center gap-4 px-8 pb-20">
+        <Text className="text-center text-lg font-semibold text-white">
+          Verification temporarily unavailable
+        </Text>
+        <Text className="text-center text-[#ACACAC]">{body}</Text>
+        <Button variant="brand" onPress={onRetry} className="h-12 rounded-xl px-8">
+          <Text className="font-semibold text-primary-foreground">Try again</Text>
+        </Button>
+        <Text className="text-center text-xs text-[#6B6B6B]">
+          If this keeps happening, contact support.
+        </Text>
+      </View>
     </View>
   );
 }

--- a/components/kyc/index.ts
+++ b/components/kyc/index.ts
@@ -1,3 +1,9 @@
-export { KycCompleted, KycError, KycLoading, KycNativeWaiting } from './KycStatusViews';
+export {
+  KycCompleted,
+  KycError,
+  KycLoading,
+  KycNativeWaiting,
+  KycUnavailable,
+} from './KycStatusViews';
 export type { SessionState } from './useDiditSession';
 export { useDiditSession } from './useDiditSession';

--- a/components/kyc/useDiditSession.ts
+++ b/components/kyc/useDiditSession.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import Toast from 'react-native-toast-message';
-import { useRouter } from 'expo-router';
+import { useLocalSearchParams, useRouter } from 'expo-router';
 import { useQueryClient } from '@tanstack/react-query';
 
 import { path } from '@/constants/path';
@@ -26,10 +26,35 @@ export function useDiditSession() {
   const router = useRouter();
   const queryClient = useQueryClient();
   const kycFlow = useKycStore(state => state.kycFlow);
+  // Debug deep-link: /kyc?state=<phase> previews a static screen (see switch in
+  // initSession). Read once here so initSession can branch on it.
+  const debugState = useLocalSearchParams<{ state?: string }>().state;
   const [session, setSession] = useState<SessionState>({ phase: 'loading' });
   const sdkInitializedRef = useRef(false);
 
   const initSession = useCallback(async () => {
+    // Debug deep-link: /kyc?state=<phase> renders a static screen without
+    // creating a real Didit session — handy for previewing these states
+    // directly (e.g. /kyc?state=unavailable). Dynamic phases (ready/started)
+    // need a live session and are intentionally not deep-linkable.
+    switch (debugState) {
+      case 'unavailable':
+        setSession({
+          phase: 'unavailable',
+          message: 'Identity verification is temporarily unavailable. Please try again shortly.',
+        });
+        return;
+      case 'error':
+        setSession({ phase: 'error', message: 'Failed to create verification session' });
+        return;
+      case 'loading':
+        setSession({ phase: 'loading' });
+        return;
+      case 'completed':
+        setSession({ phase: 'completed' });
+        return;
+    }
+
     setSession({ phase: 'loading' });
     sdkInitializedRef.current = false;
 
@@ -76,7 +101,7 @@ export function useDiditSession() {
       setSession({ phase: 'error', message });
       Toast.show({ type: 'error', text1: 'Error', text2: message, props: { badgeText: '' } });
     }
-  }, []);
+  }, [debugState]);
 
   const markStarted = useCallback(() => {
     setSession({ phase: 'started' });

--- a/components/kyc/useDiditSession.ts
+++ b/components/kyc/useDiditSession.ts
@@ -15,6 +15,7 @@ import { useKycStore } from '@/store/useKycStore';
 export type SessionState =
   | { phase: 'loading' }
   | { phase: 'error'; message: string }
+  | { phase: 'unavailable'; message: string }
   | { phase: 'ready'; verificationUrl: string; sessionToken: string }
   | { phase: 'started' }
   | { phase: 'completed' };
@@ -56,6 +57,21 @@ export function useDiditSession() {
         sessionToken: res.session_token,
       });
     } catch (e: any) {
+      // VERIFICATION_UNAVAILABLE (503): the org-wide Didit credit balance is
+      // depleted, so no session can be created for anyone. Surface a calm,
+      // branded "temporarily unavailable" page rather than the red hard-error
+      // state + toast — it's transient and not the user's fault.
+      const isUnavailable =
+        e?.code === 'VERIFICATION_UNAVAILABLE' || e?.status === 503 || e?.statusCode === 503;
+      if (isUnavailable) {
+        setSession({
+          phase: 'unavailable',
+          message:
+            e?.message ||
+            'Identity verification is temporarily unavailable. Please try again shortly.',
+        });
+        return;
+      }
       const message = e?.message || 'Failed to create verification session';
       setSession({ phase: 'error', message });
       Toast.show({ type: 'error', text1: 'Error', text2: message, props: { badgeText: '' } });

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -553,6 +553,25 @@ export const submitRainKyc = async (formData: FormData): Promise<RainKycSubmitRe
 
 // --- Didit identity verification ---
 
+/**
+ * Error thrown by createDiditSession on a non-2xx response. Carries `status`
+ * (so withRefreshToken's 401 detection keeps working) and the backend's stable
+ * `code` (e.g. VERIFICATION_UNAVAILABLE) so the UI can branch on it.
+ */
+export class ApiError extends Error {
+  readonly status: number;
+  readonly statusCode: number;
+  readonly code?: string;
+
+  constructor(status: number, message: string, code?: string) {
+    super(message);
+    this.name = 'ApiError';
+    this.status = status;
+    this.statusCode = status;
+    this.code = code;
+  }
+}
+
 /** Create a Didit verification session. Backend creates the session and returns session_id, session_token, verification_url. */
 export const createDiditSession = async (
   callback?: string,
@@ -568,7 +587,28 @@ export const createDiditSession = async (
     },
     body: JSON.stringify(callback ? { callback } : {}),
   });
-  if (!response.ok) throw response;
+  if (!response.ok) {
+    // Parse the backend error envelope ({ code, message }) so callers can branch
+    // on a stable code instead of the previous opaque throw. Falls back to a
+    // generic message when the body isn't JSON.
+    let code: string | undefined;
+    let message: string | undefined;
+    try {
+      const body = await response.json();
+      if (body && typeof body === 'object') {
+        if (typeof body.code === 'string') code = body.code;
+        if (typeof body.message === 'string') message = body.message;
+        else if (Array.isArray(body.message)) message = body.message.join(', ');
+      }
+    } catch {
+      // non-JSON error body — keep the generic fallback
+    }
+    throw new ApiError(
+      response.status,
+      message ?? 'Failed to create verification session',
+      code,
+    );
+  }
   return response.json();
 };
 


### PR DESCRIPTION
## Summary
This PR adds graceful handling for when identity verification is temporarily unavailable due to depleted Didit credit. Instead of showing a generic error state, users now see a calm, branded "temporarily unavailable" message that encourages them to retry later.

## Key Changes
- **New `ApiError` class** in `lib/api.ts`: Custom error class that carries HTTP status and backend error codes, allowing callers to branch on stable error codes rather than opaque responses
- **Enhanced error handling in `createDiditSession`**: Parses backend error envelopes (`{ code, message }`) and throws `ApiError` with structured information
- **New `KycUnavailable` component**: Distinct UI state for transient verification unavailability—uses calm styling (no red) and friendly messaging vs. the hard-error `KycError` state
- **Extended `SessionState` type**: Added `unavailable` phase to the session state machine
- **Smart error detection in `useDiditSession`**: Detects `VERIFICATION_UNAVAILABLE` code or 503 status and routes to the new unavailable state instead of generic error handling
- **Updated KYC screens**: Both web (`kyc.tsx`) and native (`kyc.native.tsx`) now render the new `KycUnavailable` component when appropriate

## Implementation Details
- The `ApiError` class maintains backward compatibility by exposing both `status` and `statusCode` properties (for `withRefreshToken` 401 detection)
- Error body parsing is defensive: falls back to generic messages if the response isn't valid JSON
- The unavailable state is treated as transient and not-the-user's-fault, so it doesn't trigger error toasts and uses softer UI language
- Retry functionality is preserved—users can attempt session creation again without leaving the flow

https://claude.ai/code/session_01HZGTYZHdDdzV1zSJVYQiSe