### PR TITLE
[codex] Polish card rewards UI

### DIFF
--- a/components/CardWaitlist/CardFeesModal.tsx
+++ b/components/CardWaitlist/CardFeesModal.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { View } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { Image } from 'expo-image';
 import { LinearGradient } from 'expo-linear-gradient';
 
@@ -8,6 +9,7 @@ import GetCardButton from '@/components/CardWaitlist/GetCardButton';
 import SolidCardSummary from '@/components/CardWaitlist/SolidCardSummary';
 import ResponsiveModal, { ModalState } from '@/components/ResponsiveModal';
 import { Text } from '@/components/ui/text';
+import { useDimension } from '@/hooks/useDimension';
 import { getAsset } from '@/lib/assets';
 
 const MODAL_STATE: ModalState = { name: 'card-fees', number: 1 };
@@ -39,6 +41,20 @@ const DetailItem = ({ icon, title, description }: DetailItemProps) => (
 );
 
 const CardFeesModal = ({ isOpen, onOpenChange }: CardFeesModalProps) => {
+  const { isScreenMedium } = useDimension();
+  const insets = useSafeAreaInsets();
+  const [heroWidth, setHeroWidth] = React.useState(0);
+  const measuredHeroWidth = heroWidth || (isScreenMedium ? 448 : 340);
+  const artworkWidth = isScreenMedium
+    ? Math.min(Math.max(measuredHeroWidth * 0.7, 260), 340)
+    : Math.min(Math.max(measuredHeroWidth * 0.9, 300), 340);
+  const artworkRight = isScreenMedium ? -measuredHeroWidth * 0.42 : -measuredHeroWidth * 0.5 + 10;
+  const artworkTop = isScreenMedium ? 0 : 10;
+  const summaryMaxWidth = isScreenMedium
+    ? undefined
+    : Math.min(Math.max(measuredHeroWidth * 0.52, 178), 205);
+  const bottomScrollPadding = isScreenMedium ? 0 : Math.max(insets.bottom, 24) + 56;
+
   return (
     <ResponsiveModal
       currentModal={MODAL_STATE}
@@ -52,26 +68,30 @@ const CardFeesModal = ({ isOpen, onOpenChange }: CardFeesModalProps) => {
       contentClassName="md:max-w-md"
       shouldAnimate={false}
     >
-      <View className="gap-10">
+      <View className="gap-10" style={{ paddingBottom: bottomScrollPadding }}>
         <LinearGradient
           colors={['rgba(148, 242, 127, 0.25)', 'rgba(148, 242, 127, 0)']}
           start={{ x: 0, y: 0 }}
           end={{ x: 1, y: 1 }}
           className="overflow-hidden"
           style={{ borderRadius: 20, overflow: 'hidden' }}
+          onLayout={event => setHeroWidth(event.nativeEvent.layout.width)}
         >
           <View className="relative p-5">
-            <View className="absolute top-0" style={{ right: '-42%' }}>
+            <View
+              pointerEvents="none"
+              className="absolute"
+              style={{ right: artworkRight, top: artworkTop, zIndex: 0 }}
+            >
               <Image
                 source={getAsset('images/cards.png')}
-                style={{ width: 340, height: 340 }}
+                style={{ width: artworkWidth, height: artworkWidth }}
                 contentFit="contain"
               />
             </View>
-            <SolidCardSummary
-              compact
-              topUpLabel={'Zero top-up fee,\nzero monthly fee'}
-            />
+            <View style={{ zIndex: 1, maxWidth: summaryMaxWidth }}>
+              <SolidCardSummary compact topUpLabel={'Zero top-up fee,\nzero monthly fee'} />
+            </View>
           </View>
         </LinearGradient>
 

--- a/components/CardWaitlist/SolidCardSummary.tsx
+++ b/components/CardWaitlist/SolidCardSummary.tsx
@@ -33,6 +33,8 @@ const SolidCardSummary = ({
   compact = false,
   className,
 }: SolidCardSummaryProps) => {
+  const compactFeatureText = compact ? 'flex-shrink text-lg leading-6' : undefined;
+
   return (
     <View className={cn('gap-5', className)}>
       <View className="gap-2">
@@ -45,13 +47,21 @@ const SolidCardSummary = ({
       </View>
       <Text className="text-lg font-semibold text-brand">Free</Text>
       <View className={cn(compact ? 'gap-3' : 'flex-row flex-wrap gap-x-8 gap-y-3')}>
-        <FeatureItem icon={<CreditCard size={22} color="#94F27F" />} label="Virtual card" />
-        <FeatureItem icon={<CashbackBadge />} label="3% Cashback" />
+        <FeatureItem
+          icon={<CreditCard size={22} color="#94F27F" />}
+          label="Virtual card"
+          classNames={{ text: compactFeatureText }}
+        />
+        <FeatureItem
+          icon={<CashbackBadge />}
+          label="3% Cashback"
+          classNames={{ text: compactFeatureText }}
+        />
         {compact && (
           <FeatureItem
             icon={<Tag size={20} color="#94F27F" />}
             label={topUpLabel}
-            classNames={{ container: 'items-start' }}
+            classNames={{ container: 'items-start', text: compactFeatureText }}
           />
         )}
       </View>

--- a/components/Home/FinishSetupModal.tsx
+++ b/components/Home/FinishSetupModal.tsx
@@ -88,12 +88,12 @@ const FinishSetupModal = ({ isOpen, onClose, steps, firstIncomplete }: FinishSet
           {firstIncomplete && (
             <Button
               variant="brand"
-              className="h-14 rounded-2xl"
+              className="h-14 rounded-2xl border-0"
               onPress={handleCta}
               style={{ paddingVertical: 0 }}
             >
               <Text
-                className="w-full flex-shrink text-center text-base font-bold text-primary-foreground"
+                className="w-full flex-shrink text-center text-base font-bold text-brand-foreground"
                 style={{ lineHeight: 22 }}
                 numberOfLines={1}
                 adjustsFontSizeToFit

--- a/components/Home/HomeCashbackCard.tsx
+++ b/components/Home/HomeCashbackCard.tsx
@@ -9,7 +9,7 @@ import { Text } from '@/components/ui/text';
 import { path } from '@/constants/path';
 import { useCardDetails } from '@/hooks/useCardDetails';
 import { getAsset } from '@/lib/assets';
-import { cn } from '@/lib/utils';
+import { cn, formatNumber } from '@/lib/utils';
 
 interface HomeCashbackCardProps {
   className?: string;
@@ -24,12 +24,15 @@ const HomeCashbackCard = ({ className }: HomeCashbackCardProps) => {
   const { data: cardDetails, isLoading } = useCardDetails();
 
   const cashbackUsd = cardDetails?.cashback?.totalUsdValue ?? 0;
-  const percentage = cardDetails?.cashback?.percentage ?? 3;
+  const rawPercentage = cardDetails?.cashback?.percentage;
+  const percentage =
+    rawPercentage == null ? 3 : rawPercentage <= 1 ? rawPercentage * 100 : rawPercentage;
+  const formattedPercentage = formatNumber(percentage, 2, 0);
   const showSkeleton = isLoading && !cardDetails;
 
   return (
     <Pressable onPress={() => router.push(path.POINTS)} className={cn('flex-1', className)}>
-      <View className="gap-3 rounded-twice bg-card p-5" style={{ minHeight: 188 }}>
+      <View className="gap-3 overflow-hidden rounded-twice bg-card p-5" style={{ minHeight: 188 }}>
         <Image
           source={getAsset('images/green-diamond-background.png')}
           alt="Cashback"
@@ -38,28 +41,42 @@ const HomeCashbackCard = ({ className }: HomeCashbackCardProps) => {
         />
         <View className="gap-1">
           <Text className="text-base font-medium text-muted-foreground">Cashback</Text>
-          <View className="flex-row items-end gap-2">
+          <View
+            className="flex-row items-end justify-between gap-1"
+            style={{ minHeight: HOME_STAT_VALUE_TEXT_STYLE.lineHeight }}
+          >
             {showSkeleton ? (
-              <Skeleton className="h-8 w-16 rounded-xl" />
+              <>
+                <Skeleton className="h-8 w-14 rounded-xl" />
+                <View className="mb-1 ml-auto w-16 items-end gap-1 pr-1">
+                  <Skeleton className="h-3 w-10 rounded" />
+                  <Skeleton className="h-3 w-14 rounded" />
+                </View>
+              </>
             ) : (
-              <CountUp
-                prefix="$"
-                count={cashbackUsd}
-                isTrailingZero={false}
-                decimalPlaces={cashbackUsd > 0 ? 2 : 0}
-                classNames={{
-                  wrapper: 'text-foreground',
-                }}
-                styles={{
-                  wholeText: HOME_STAT_VALUE_TEXT_STYLE,
-                  decimalText: HOME_STAT_VALUE_TEXT_STYLE,
-                  decimalSeparator: HOME_STAT_VALUE_TEXT_STYLE,
-                }}
-              />
+              <>
+                <CountUp
+                  prefix="$"
+                  count={cashbackUsd}
+                  isTrailingZero={false}
+                  decimalPlaces={cashbackUsd > 0 ? 2 : 0}
+                  classNames={{
+                    wrapper: 'shrink-0 text-foreground',
+                  }}
+                  styles={{
+                    wholeText: HOME_STAT_VALUE_TEXT_STYLE,
+                    decimalText: HOME_STAT_VALUE_TEXT_STYLE,
+                    decimalSeparator: HOME_STAT_VALUE_TEXT_STYLE,
+                  }}
+                />
+                <Text
+                  className="mb-1 ml-auto min-w-0 max-w-[4.75rem] shrink text-right text-xs leading-tight text-muted-foreground"
+                  numberOfLines={2}
+                >
+                  Up to {formattedPercentage}% Cashback
+                </Text>
+              </>
             )}
-            <Text className="mb-1 max-w-[5.5rem] text-xs leading-tight text-muted-foreground">
-              Up to {percentage}% Cashback
-            </Text>
           </View>
         </View>
       </View>

--- a/components/Rewards/RewardBenefit.tsx
+++ b/components/Rewards/RewardBenefit.tsx
@@ -29,7 +29,12 @@ const RewardBenefit = ({
 }: RewardBenefitProps) => {
   const renderDescription = () => {
     if (descriptionNode) {
-      return descriptionNode;
+      return (
+        <View className="flex-row flex-wrap items-center gap-2">
+          <Text className="text-base opacity-70">{description}</Text>
+          {descriptionNode}
+        </View>
+      );
     }
 
     if (tooltip) {

--- a/components/Rewards/RewardsDashboard.tsx
+++ b/components/Rewards/RewardsDashboard.tsx
@@ -1,3 +1,4 @@
+import { ReactNode } from 'react';
 import { Platform, View } from 'react-native';
 import { Image } from 'expo-image';
 import { LinearGradient } from 'expo-linear-gradient';
@@ -15,6 +16,7 @@ import { RewardsTier, TierBenefits } from '@/lib/types';
 import { formatNumber } from '@/lib/utils';
 
 import RewardBenefit from './RewardBenefit';
+import RewardComingSoon from './RewardComingSoon';
 import TierProgressBar from './TierProgressBar';
 
 // Transform API tier benefits to display items with dynamic icons
@@ -23,6 +25,7 @@ interface DashboardBenefitItem {
   iconText?: string;
   title: string;
   description: string;
+  descriptionNode?: ReactNode;
 }
 
 const transformTierBenefitsForDashboard = (
@@ -44,6 +47,7 @@ const transformTierBenefitsForDashboard = (
       icon: 'images/dollar-yellow.png',
       title: depositTitle,
       description: 'On your savings',
+      descriptionNode: currentTier !== RewardsTier.CORE ? <RewardComingSoon /> : undefined,
     },
     {
       iconText: tierBenefits.cardCashback.title, // e.g., "2%", "3%", "5%"
@@ -182,6 +186,7 @@ const RewardsDashboard = ({
               iconText={benefit.iconText}
               title={benefit.title}
               description={benefit.description}
+              descriptionNode={benefit.descriptionNode}
             />
           ))}
 


### PR DESCRIPTION
## Summary
- Improve the card fees hero layout with responsive artwork sizing and mobile bottom padding.
- Tighten compact card summary feature text and cashback card layout/percentage formatting.
- Align finish setup CTA colors with the brand button variant and show coming-soon labeling for future reward deposit benefits.

## Impact
This polishes the mobile card and rewards surfaces so labels fit better, cashback percentage display handles fractional API values, and reward benefit states are clearer.

## Validation
- `git diff --cached --check`
- `npx --no-install prettier --check components/CardWaitlist/CardFeesModal.tsx components/CardWaitlist/SolidCardSummary.tsx components/Home/FinishSetupModal.tsx components/Home/HomeCashbackCard.tsx components/Rewards/RewardBenefit.tsx components/Rewards/RewardsDashboard.tsx`
- `npx --no-install tsc --noEmit` *(fails on pre-existing unrelated TypeScript errors in `app/(protected)/(tabs)/bridge-kyc.tsx`, `components/BankTransfer/KycModalContent.tsx`, `components/Dashboard/CardBanner.tsx`, `components/SpinAndWin/prepareLottieSource.ts`, `constants/path.ts`, `hooks/useBridgeToMainnet.ts`, `hooks/useBridgeToMainnetSoEth.ts`, and `hooks/useWithdrawRainCollateral.ts`.)*
