### PR TITLE
Remove production environment check from navigation menu

### DIFF
--- a/hooks/useNav.ts
+++ b/hooks/useNav.ts
@@ -2,7 +2,6 @@ import { Href } from 'expo-router';
 
 import { path } from '@/constants/path';
 import { useIsTestUser } from '@/hooks/useIsTestUser';
-import { isProduction } from '@/lib/config';
 
 type MenuItem = {
   label: string;
@@ -36,9 +35,9 @@ const stocks: MenuItem = {
 
 const useNav = () => {
   const isTestUser = useIsTestUser();
-  const points: MenuItem = {
-    label: isProduction ? 'Points' : 'Rewards',
-    href: isProduction ? path.POINTS : path.REWARDS,
+  const rewards: MenuItem = {
+    label: 'Rewards',
+    href: path.REWARDS,
   };
   // Agent lives in the account-center menu, not the navbar.
   const menuItems: MenuItem[] = [
@@ -46,7 +45,7 @@ const useNav = () => {
     savings,
     card,
     ...(isTestUser ? [stocks] : []),
-    points,
+    rewards,
     activity,
   ];
   return { menuItems };


### PR DESCRIPTION
## Summary
Simplified the navigation menu by removing the production environment conditional logic that toggled between "Points" and "Rewards" labels. The menu now consistently uses "Rewards" for all environments.

## Key Changes
- Removed `isProduction` import from `@/lib/config`
- Renamed `points` menu item variable to `rewards` for clarity
- Replaced conditional label and href assignment with static "Rewards" label and `path.REWARDS` href
- Removed environment-based branching logic that previously showed "Points" in production and "Rewards" in non-production environments

## Implementation Details
The menu item now unconditionally uses the rewards configuration, eliminating the need for runtime environment checks. This simplifies the codebase and ensures consistent UX across all deployment environments.

https://claude.ai/code/session_0116bgFRXGUUpEF9gP6FdE47