### PR TITLE
Use compactNumberFormat for rewards points display

### DIFF
--- a/components/Rewards/RewardsDashboard.tsx
+++ b/components/Rewards/RewardsDashboard.tsx
@@ -13,7 +13,7 @@ import { useDimension } from '@/hooks/useDimension';
 import { useTierBenefits } from '@/hooks/useRewards';
 import { getAsset } from '@/lib/assets';
 import { RewardsTier, TierBenefits } from '@/lib/types';
-import { formatNumber } from '@/lib/utils';
+import { compactNumberFormat, formatNumber } from '@/lib/utils';
 
 import RewardBenefit from './RewardBenefit';
 import RewardComingSoon from './RewardComingSoon';
@@ -150,7 +150,7 @@ const RewardsDashboard = ({
               <View>
                 <Text className="text-rewards/70 md:text-lg">Total points</Text>
                 <Text className="text-4.5xl font-semibold text-rewards">
-                  {formatNumber(totalPoints, 0, 0)}
+                  {compactNumberFormat(totalPoints)}
                 </Text>
               </View>
             </View>

--- a/components/Rewards/TierProgressBar.tsx
+++ b/components/Rewards/TierProgressBar.tsx
@@ -7,7 +7,7 @@ import { Text } from '@/components/ui/text';
 import { getTierIcon } from '@/constants/rewards';
 import { useDimension } from '@/hooks/useDimension';
 import { RewardsTier } from '@/lib/types';
-import { formatNumber, toTitleCase } from '@/lib/utils';
+import { compactNumberFormat, toTitleCase } from '@/lib/utils';
 import { useRewards } from '@/store/useRewardsStore';
 
 interface TierProgressBarProps {
@@ -51,7 +51,7 @@ const TierProgressBar = ({
         <Text className="text-base text-rewards/70">{toTitleCase(currentTier)}</Text>
         <View className="flex-row items-center gap-5">
           <View className="flex-row items-center gap-1">
-            <Text className="text-base">{formatNumber(pointsNeeded, 0, 0)} more points to</Text>
+            <Text className="text-base">{compactNumberFormat(pointsNeeded)} more points to</Text>
             <Text className="text-base text-rewards/70">{toTitleCase(nextTier)}</Text>
             <Image
               source={getTierIcon(nextTier)}


### PR DESCRIPTION
## Summary
Updated the Rewards dashboard components to use `compactNumberFormat` instead of `formatNumber` for displaying points values, providing a more compact and readable representation of large numbers.

## Key Changes
- **RewardsDashboard.tsx**: Replaced `formatNumber(totalPoints, 0, 0)` with `compactNumberFormat(totalPoints)` for the total points display
- **TierProgressBar.tsx**: Replaced `formatNumber(pointsNeeded, 0, 0)` with `compactNumberFormat(pointsNeeded)` for the tier progression points display
- Updated imports in both files to include `compactNumberFormat` from `@/lib/utils`

## Implementation Details
The change simplifies the API calls by using `compactNumberFormat` which appears to handle the formatting logic more elegantly than calling `formatNumber` with explicit zero parameters. This improves code readability and likely provides better number formatting for large point values (e.g., displaying "1.2K" instead of "1200").

https://claude.ai/code/session_01Kaennqeg2dHrZTvErwEdir