### PR TITLE
Update rewards tier comparison table labels for yield boost

### DIFF
--- a/components/Rewards/CompareTiersTable.tsx
+++ b/components/Rewards/CompareTiersTable.tsx
@@ -19,8 +19,8 @@ const CompareTiersTable = ({ tierBenefits }: CompareTiersTableProps) => {
       values: sortedTiers.map(tier => tier.cardCashback),
     },
     {
-      label: 'Deposit boosts',
-      subtitle: 'Campaign-based\ndeposit boosts',
+      label: 'Yield boost',
+      subtitle: 'Campaign-based\nyield boosts',
       values: sortedTiers.map(tier => tier.depositBoost),
       isComingSoon: true,
       isSubtitleHidden: true,


### PR DESCRIPTION
## Summary
Updated the rewards tier comparison table to use more accurate terminology for the deposit incentive feature.

## Changes
- Changed the "Deposit boosts" label to "Yield boost" in the CompareTiersTable component
- Updated the corresponding subtitle from "Campaign-based\ndeposit boosts" to "Campaign-based\nyield boosts"

## Details
This change improves the clarity of the rewards tier comparison by using "yield boost" terminology, which better reflects the nature of the campaign-based incentive feature being displayed to users.

https://claude.ai/code/session_01Dgdz4WvNFSwSsPuLuXHEor