### PR TITLE
Refactor subscription discount system to use categories

### DIFF
--- a/components/Rewards/CompareTiersTable.tsx
+++ b/components/Rewards/CompareTiersTable.tsx
@@ -27,9 +27,8 @@ const CompareTiersTable = ({ tierBenefits }: CompareTiersTableProps) => {
     },
     {
       label: 'Subscription discounts',
-      subtitle: 'For select monthly services',
+      subtitle: 'On eligible subscription categories',
       values: sortedTiers.map(tier => tier.subscriptionDiscount),
-      isComingSoon: true,
     },
   ];
 

--- a/components/Rewards/TierFeesTable.tsx
+++ b/components/Rewards/TierFeesTable.tsx
@@ -22,7 +22,7 @@ const TierFeesTable = ({ tierBenefits }: TierFeesTableProps) => {
     },
     {
       label: 'Subscription discounts',
-      subtitle: 'For select monthly services',
+      subtitle: 'One subscription per category, per month',
       values: sortedTiers.map(tier => tier.subscriptionDiscountCap),
     },
     {

--- a/constants/rewards.ts
+++ b/constants/rewards.ts
@@ -68,14 +68,14 @@ export const MOCK_TIER_BENEFITS: TierBenefits[] = [
       title: '3%',
     },
     subscriptionDiscount: {
-      title: '25% Discount',
+      title: '25% back on 2 categories',
       image: 'images/spotify-openai-netflix.png',
     },
     cardCashbackCap: {
       title: 'Up to 20$\nmonthly',
     },
     subscriptionDiscountCap: {
-      title: '$70 per service\nper month',
+      title: 'Up to $50 per service\nper month',
     },
     cardFees: {
       title: 'No fees',
@@ -100,14 +100,14 @@ export const MOCK_TIER_BENEFITS: TierBenefits[] = [
       title: '5%',
     },
     subscriptionDiscount: {
-      title: '50% Discount',
+      title: '50% back on 4 categories',
       image: 'images/spotify-openai-netflix.png',
     },
     cardCashbackCap: {
       title: 'Unlimited',
     },
     subscriptionDiscountCap: {
-      title: '$70 per service\nper month',
+      title: 'Up to $50 per service\nper month',
     },
     cardFees: {
       title: 'No fees',

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1160,7 +1160,16 @@ export interface TierCashbackConfig {
 
 export interface TierSubscriptionDiscountConfig {
   percentage: number;
+  /** @deprecated Superseded by categoryLimit. */
   serviceLimit: number;
+  /** Number of subscription categories this tier can earn a discount on per month. */
+  categoryLimit: number;
+}
+
+export interface SubscriptionDiscountCategory {
+  key: string;
+  label: string;
+  merchants: string[];
 }
 
 export interface CashbackConfig {
@@ -1173,7 +1182,11 @@ export interface CashbackConfig {
 
 export interface SubscriptionDiscountConfig {
   enabled: boolean;
+  /** @deprecated Legacy flat service list; detection uses categories. */
   eligibleServices: string[];
+  categories: SubscriptionDiscountCategory[];
+  /** First N dollars of an eligible charge that earn the discount. */
+  eligibleAmountCap: number;
   tier1: TierSubscriptionDiscountConfig;
   tier2: TierSubscriptionDiscountConfig;
   tier3: TierSubscriptionDiscountConfig;
@@ -1201,6 +1214,8 @@ export interface PointsEarningConfig {
 }
 
 export interface FullRewardsConfig {
+  /** Master switch: when false, all users are treated as Core for benefits. */
+  tierSystemLive?: boolean;
   tiers: TierThresholds;
   points: PointsEarningConfig;
   cashback: CashbackConfig;


### PR DESCRIPTION
## Summary
This PR refactors the subscription discount system from a flat service-based model to a category-based approach, improving flexibility and clarity around discount eligibility and caps.

## Key Changes

- **Type definitions** (`lib/types.ts`):
  - Added new `SubscriptionDiscountCategory` interface to represent discount categories with key, label, and associated merchants
  - Updated `TierSubscriptionDiscountConfig` to replace `serviceLimit` with `categoryLimit` (marked old field as deprecated)
  - Enhanced `SubscriptionDiscountConfig` with:
    - New `categories` field for category-based discount eligibility
    - New `eligibleAmountCap` field to specify the dollar cap per service
    - Marked `eligibleServices` as deprecated in favor of category-based detection
  - Added `tierSystemLive` optional flag to `FullRewardsConfig` as a master switch for the tier system

- **Mock data** (`constants/rewards.ts`):
  - Updated tier benefit descriptions to reflect category-based discounts:
    - Tier 1: "25% back on 2 categories" (was "25% Discount")
    - Tier 2: "50% back on 4 categories" (was "50% Discount")
  - Updated subscription discount caps from "$70 per service per month" to "Up to $50 per service per month"

- **UI components**:
  - `CompareTiersTable.tsx`: Updated subtitle to "On eligible subscription categories" and removed "coming soon" indicator
  - `TierFeesTable.tsx`: Updated subtitle to "One subscription per category, per month" for clarity

## Implementation Details
The changes maintain backward compatibility by deprecating old fields rather than removing them, allowing for a gradual migration path. The new category-based system provides better organization and clearer communication of discount eligibility to users.

https://claude.ai/code/session_01H2LH2ERZsBwn5TWpRQzCP5