### PR TITLE
feat(gooddollar): add GoodDollar UBI claim page

### DIFF
--- a/app/(protected)/(tabs)/settings/index.tsx
+++ b/app/(protected)/(tabs)/settings/index.tsx
@@ -4,7 +4,14 @@ import * as Application from 'expo-application';
 import { Image } from 'expo-image';
 import * as IntentLauncher from 'expo-intent-launcher';
 import { Href, router } from 'expo-router';
-import { Bell, ChevronRight, CircleDollarSign, Heart, Sparkles } from 'lucide-react-native';
+import {
+  Bell,
+  ChevronRight,
+  CircleDollarSign,
+  HandCoins,
+  Heart,
+  Sparkles,
+} from 'lucide-react-native';
 
 import ProfileIcon from '@/assets/images/profile';
 import Navbar from '@/components/Navbar';
@@ -138,6 +145,11 @@ const MobileSettings = () => {
         title: 'Agent wallet',
         icon: <Sparkles size={24} color="#ffffff" strokeWidth={1.8} />,
         href: path.AGENT,
+      },
+      {
+        title: 'GoodDollar',
+        icon: <HandCoins size={24} color="#ffffff" strokeWidth={1.8} />,
+        href: path.GOODDOLLAR,
       },
     ],
     [

--- a/app/(protected)/_layout.tsx
+++ b/app/(protected)/_layout.tsx
@@ -228,6 +228,12 @@ export default function ProtectedLayout() {
           headerShown: false,
         }}
       />
+      <Stack.Screen
+        name="gooddollar/index"
+        options={{
+          headerShown: false,
+        }}
+      />
     </Stack>
   );
 }

--- a/app/(protected)/gooddollar/index.tsx
+++ b/app/(protected)/gooddollar/index.tsx
@@ -1,0 +1,38 @@
+import { View } from 'react-native';
+
+import GoodDollarClaim from '@/components/GoodDollar/GoodDollarClaim';
+import Navbar from '@/components/Navbar';
+import PageLayout from '@/components/PageLayout';
+import { BackButton } from '@/components/ui/back-button';
+import { Text } from '@/components/ui/text';
+
+const mobileHeader = (
+  <View className="px-4 pb-0 pt-1">
+    <BackButton />
+  </View>
+);
+
+const desktopHeader = (
+  <>
+    <Navbar />
+    <View className="mx-auto w-full max-w-[512px] px-4 pb-8 pt-8">
+      <View className="mb-8 flex-row items-center justify-between">
+        <BackButton />
+        <Text className="text-3xl font-semibold text-white">GoodDollar</Text>
+        <View className="w-6" />
+      </View>
+    </View>
+  </>
+);
+
+export default function GoodDollarScreen() {
+  return (
+    <PageLayout
+      customMobileHeader={mobileHeader}
+      customDesktopHeader={desktopHeader}
+      useDesktopBreakpoint
+    >
+      <GoodDollarClaim />
+    </PageLayout>
+  );
+}

--- a/components/AccountCenter/AccountCenterDropdown.web.tsx
+++ b/components/AccountCenter/AccountCenterDropdown.web.tsx
@@ -12,11 +12,13 @@ import { cn } from '@/lib/utils';
 
 import {
   AccountCenterAgent,
+  AccountCenterGoodDollar,
   AccountCenterSettings,
   AccountCenterSignOut,
   AccountCenterTrigger,
   AccountCenterUsername,
   onAccountCenterAgentPress,
+  onAccountCenterGoodDollarPress,
   onAccountCenterSettingsPress,
 } from '.';
 
@@ -56,6 +58,12 @@ const AccountCenterDropdown = () => {
           onPress={onAccountCenterAgentPress}
         >
           <AccountCenterAgent />
+        </DropdownMenuItem>
+        <DropdownMenuItem
+          className={cn(dropdownMenuItemClassName)}
+          onPress={onAccountCenterGoodDollarPress}
+        >
+          <AccountCenterGoodDollar />
         </DropdownMenuItem>
         <DropdownMenuItem
           className={cn(dropdownMenuItemClassName)}

--- a/components/AccountCenter/index.tsx
+++ b/components/AccountCenter/index.tsx
@@ -1,6 +1,6 @@
 import { Pressable, View } from 'react-native';
 import { router } from 'expo-router';
-import { ChevronDown, Sparkles } from 'lucide-react-native';
+import { ChevronDown, HandCoins, Sparkles } from 'lucide-react-native';
 
 import ProfileIcon from '@/assets/images/profile';
 import SettingsIcon from '@/assets/images/settings';
@@ -71,6 +71,19 @@ const onAccountCenterAgentPress = () => {
   router.push(path.AGENT);
 };
 
+const AccountCenterGoodDollar = () => {
+  return (
+    <>
+      <HandCoins size={20} color="#fff" />
+      <Text className="text-base font-semibold">GoodDollar</Text>
+    </>
+  );
+};
+
+const onAccountCenterGoodDollarPress = () => {
+  router.push(path.GOODDOLLAR);
+};
+
 const AccountCenterSignOut = () => {
   return (
     <>
@@ -82,10 +95,12 @@ const AccountCenterSignOut = () => {
 
 export {
   AccountCenterAgent,
+  AccountCenterGoodDollar,
   AccountCenterSettings,
   AccountCenterSignOut,
   AccountCenterTrigger,
   AccountCenterUsername,
   onAccountCenterAgentPress,
+  onAccountCenterGoodDollarPress,
   onAccountCenterSettingsPress,
 };

--- a/components/GoodDollar/GoodDollarClaim.tsx
+++ b/components/GoodDollar/GoodDollarClaim.tsx
@@ -1,0 +1,160 @@
+import { ReactNode } from 'react';
+import { ActivityIndicator, View } from 'react-native';
+import { formatDistanceToNowStrict } from 'date-fns';
+import { HandCoins } from 'lucide-react-native';
+
+import { Button } from '@/components/ui/button';
+import { Text } from '@/components/ui/text';
+import useGoodDollarClaim from '@/hooks/useGoodDollarClaim';
+
+const formatGDollar = (value: string) => {
+  const amount = Number(value);
+  if (!Number.isFinite(amount)) return value;
+  try {
+    return amount.toLocaleString('en-US', { maximumFractionDigits: 2 });
+  } catch {
+    return value;
+  }
+};
+
+const Card = ({ children }: { children: ReactNode }) => (
+  <View className="gap-3 rounded-2xl bg-card p-5">{children}</View>
+);
+
+export default function GoodDollarClaim() {
+  const {
+    isLoading,
+    isWhitelisted,
+    canClaim,
+    canSweep,
+    isVerifying,
+    isClaiming,
+    isSweeping,
+    claimMessage,
+    nextClaimTime,
+    error,
+    formattedBalance,
+    formattedEntitlement,
+    verify,
+    claim,
+    sweep,
+    refresh,
+  } = useGoodDollarClaim();
+
+  const renderAction = () => {
+    if (error && !isLoading) {
+      return (
+        <Card>
+          <Text className="text-lg font-semibold text-white">Something went wrong</Text>
+          <Text className="text-sm text-muted-foreground">{error}</Text>
+          <Button variant="secondary" onPress={() => void refresh()}>
+            <Text>Try again</Text>
+          </Button>
+        </Card>
+      );
+    }
+
+    if (isLoading) {
+      return (
+        <Card>
+          <View className="items-center py-6">
+            <ActivityIndicator color="#ffffff" />
+          </View>
+        </Card>
+      );
+    }
+
+    if (!isWhitelisted) {
+      return (
+        <Card>
+          <Text className="text-lg font-semibold text-white">Verify to start claiming</Text>
+          <Text className="text-sm text-muted-foreground">
+            GoodDollar requires a quick, one-time face verification (a liveness check only — no
+            documents) to make sure each person claims once. It takes about a minute.
+          </Text>
+          <Button onPress={() => void verify()} disabled={isVerifying}>
+            <Text>{isVerifying ? 'Opening verification…' : 'Verify with GoodDollar'}</Text>
+          </Button>
+        </Card>
+      );
+    }
+
+    if (canClaim) {
+      return (
+        <Card>
+          <Text className="text-sm text-muted-foreground">Available to claim</Text>
+          <Text className="text-3xl font-semibold text-white">
+            {formatGDollar(formattedEntitlement)} G$
+          </Text>
+          <Button onPress={() => void claim()} disabled={isClaiming}>
+            {isClaiming ? (
+              <>
+                <ActivityIndicator color="#ffffff" size="small" />
+                <Text>{claimMessage ?? 'Claiming…'}</Text>
+              </>
+            ) : (
+              <Text>Claim G$</Text>
+            )}
+          </Button>
+        </Card>
+      );
+    }
+
+    return (
+      <Card>
+        <Text className="text-lg font-semibold text-white">You&apos;re all caught up</Text>
+        <Text className="text-sm text-muted-foreground">
+          {nextClaimTime
+            ? `Come back ${formatDistanceToNowStrict(nextClaimTime, {
+                addSuffix: true,
+              })} for your next claim.`
+            : 'Your next GoodDollar UBI will be available soon.'}
+        </Text>
+        <Button variant="secondary" onPress={() => void refresh()}>
+          <Text>Refresh</Text>
+        </Button>
+      </Card>
+    );
+  };
+
+  return (
+    <View className="mx-auto w-full max-w-[512px] gap-4 px-4 py-4">
+      <View className="gap-3">
+        <View className="h-12 w-12 items-center justify-center rounded-full bg-card">
+          <HandCoins size={24} color="#ffffff" strokeWidth={1.8} />
+        </View>
+        <Text className="text-2xl font-semibold text-white">GoodDollar UBI</Text>
+        <Text className="text-base text-muted-foreground">
+          Claim your daily GoodDollar (G$) basic income on Fuse.
+        </Text>
+      </View>
+
+      <View className="gap-3 rounded-2xl bg-card p-5">
+        <View className="gap-2">
+          <Text className="text-sm text-muted-foreground">Your G$ balance</Text>
+          <Text className="text-3xl font-semibold text-white">
+            {formatGDollar(formattedBalance)} G$
+          </Text>
+          <Text className="text-xs text-muted-foreground">
+            Claimed G$ is sent to your signer wallet on Fuse. Move it to your Solid wallet to use it
+            for swaps and sends.
+          </Text>
+        </View>
+        {canSweep && (
+          <Button variant="secondary" onPress={() => void sweep()} disabled={isSweeping}>
+            {isSweeping ? (
+              <>
+                <ActivityIndicator color="#ffffff" size="small" />
+                <Text>Moving to your wallet…</Text>
+              </>
+            ) : (
+              <Text>Move to Solid wallet</Text>
+            )}
+          </Button>
+        )}
+      </View>
+
+      {renderAction()}
+    </View>
+  );
+}

--- a/constants/gooddollar.ts
+++ b/constants/gooddollar.ts
@@ -1,0 +1,43 @@
+import { fuse } from 'wagmi/chains';
+
+/**
+ * GoodDollar UBI configuration.
+ *
+ * We integrate GoodDollar via the viem-based `@goodsdks/citizen-sdk` (the
+ * `<claim-button>` web component is a Lit/DOM custom element and cannot render
+ * in React Native).
+ *
+ * Identity (Face Verification) and claiming are EOA-only in GoodDollar: the FV
+ * link is signed with `personal_sign` and verified server-side via `ecrecover`,
+ * and the whitelisted address is the one that calls `claim()`. Our on-chain
+ * account is a Safe smart account, which cannot satisfy that, so we drive the
+ * flow with the user's Turnkey signer EOA (`user.walletAddress`). Claimed G$
+ * therefore lands in that EOA on Fuse.
+ *
+ * Only Fuse is supported for now; Celo is planned for a future release.
+ */
+
+// GoodDollar SDK environment. "production" targets the live mainnet contracts
+// on Fuse (and Celo), independent of Solid's own EXPO_PUBLIC_ENVIRONMENT.
+export const GOODDOLLAR_ENV = 'production' as const;
+
+export const GOODDOLLAR_CHAIN_ID = fuse.id; // 122
+
+// G$ has 2 decimals on Fuse (18 on Celo).
+export const G_DOLLAR_DECIMALS = 2;
+
+export const G_DOLLAR_SYMBOL = 'G$';
+
+// Fuse mainnet (production) contract addresses, mirrored from
+// `@goodsdks/citizen-sdk` chainConfigs[122].contracts.production.
+export const GOODDOLLAR_FUSE = {
+  identity: '0x2F9C28de9e6d44b71B91b8BA337A5D82e308E7BE',
+  ubiScheme: '0xd253A5203817225e9768C05E5996d642fb96bA86',
+  faucet: '0x01ab5966C1d742Ae0CFF7f14cC0F4D85156e83d9',
+  gdToken: '0x495d133B938596C9984d462F007B676bDc57eCEC',
+} as const;
+
+// Deep-link path the GoodDollar Face Verification flow redirects back to.
+export const GOODDOLLAR_REDIRECT_PATH = 'gooddollar';
+
+export const getGoodDollarExplorerTxUrl = (hash: string) => `https://explorer.fuse.io/tx/${hash}`;

--- a/constants/path.ts
+++ b/constants/path.ts
@@ -48,6 +48,7 @@ type Path = {
   QR_SCANNER: Route;
   RESCUE_TOKEN: Href;
   AGENT: Href;
+  GOODDOLLAR: Href;
   STOCKS: Href;
 };
 
@@ -102,5 +103,6 @@ export const path: Path = {
   QR_SCANNER: '/qr-scanner' as Route,
   RESCUE_TOKEN: '/rescue-token' as Href,
   AGENT: '/agent' as Href,
+  GOODDOLLAR: '/gooddollar' as Href,
   STOCKS: '/stocks' as Href,
 };

--- a/hooks/useGoodDollarClaim.ts
+++ b/hooks/useGoodDollarClaim.ts
@@ -1,0 +1,485 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import Toast from 'react-native-toast-message';
+import * as Linking from 'expo-linking';
+import * as WebBrowser from 'expo-web-browser';
+import { ClaimSDK, IdentitySDK, SupportedChains } from '@goodsdks/citizen-sdk';
+import * as Sentry from '@sentry/react-native';
+import { StamperType, useTurnkey } from '@turnkey/react-native-wallet-kit';
+import { createAccount } from '@turnkey/viem';
+import {
+  Address,
+  createWalletClient,
+  erc20Abi,
+  formatUnits,
+  hashTypedData,
+  http,
+  PublicClient,
+  WalletClient,
+} from 'viem';
+import { fuse } from 'wagmi/chains';
+
+import {
+  G_DOLLAR_DECIMALS,
+  G_DOLLAR_SYMBOL,
+  GOODDOLLAR_CHAIN_ID,
+  GOODDOLLAR_ENV,
+  GOODDOLLAR_FUSE,
+  GOODDOLLAR_REDIRECT_PATH,
+  getGoodDollarExplorerTxUrl,
+} from '@/constants/gooddollar';
+import { useActivityActions } from '@/hooks/useActivityActions';
+import useUser from '@/hooks/useUser';
+import { TransactionStatus, TransactionType } from '@/lib/types';
+import { publicClient, rpcUrls } from '@/lib/wagmi';
+
+type GoodDollarSdks = {
+  account: Address;
+  readClient: PublicClient;
+  walletClient: WalletClient;
+  identitySDK: IdentitySDK;
+  claimSDK: ClaimSDK;
+};
+
+export type GoodDollarClaimState = {
+  isLoading: boolean;
+  isWhitelisted: boolean;
+  /** Amount claimable in this period (base units, G$ has 2 decimals on Fuse). */
+  entitlement: bigint;
+  /** When the next claim becomes available (null if claimable now). */
+  nextClaimTime: Date | null;
+  /** G$ balance of the signer EOA on Fuse. */
+  balance: bigint;
+  error: string | null;
+};
+
+const INITIAL_STATE: GoodDollarClaimState = {
+  isLoading: true,
+  isWhitelisted: false,
+  entitlement: 0n,
+  nextClaimTime: null,
+  balance: 0n,
+  error: null,
+};
+
+const isUserCancelled = (error: unknown): boolean => {
+  const message = (error instanceof Error ? error.message : String(error ?? '')).toLowerCase();
+  return (
+    message.includes('cancel') ||
+    message.includes('denied') ||
+    message.includes('rejected') ||
+    message.includes('not allowed')
+  );
+};
+
+const getErrorMessage = (error: unknown, fallback: string): string =>
+  error instanceof Error && error.message ? error.message : fallback;
+
+const extractTxHash = (receipt: any): string | undefined =>
+  receipt?.transactionHash ?? receipt?.receipt?.transactionHash ?? undefined;
+
+const getRedirectUrl = () => Linking.createURL(GOODDOLLAR_REDIRECT_PATH);
+
+/**
+ * Drives the GoodDollar UBI flow on Fuse: identity (Face Verification),
+ * eligibility, and daily claiming. The SDK is EOA-only, so everything runs
+ * through the user's Turnkey signer EOA (`user.walletAddress`) rather than the
+ * Safe smart account. See `constants/gooddollar.ts`.
+ */
+const useGoodDollarClaim = () => {
+  const { user } = useUser();
+  const { createHttpClient } = useTurnkey();
+  const { createActivity, updateActivity } = useActivityActions();
+
+  const sdksRef = useRef<Promise<GoodDollarSdks> | null>(null);
+  const [state, setState] = useState<GoodDollarClaimState>(INITIAL_STATE);
+  const [isVerifying, setIsVerifying] = useState(false);
+  const [isClaiming, setIsClaiming] = useState(false);
+  const [isSweeping, setIsSweeping] = useState(false);
+  const [claimMessage, setClaimMessage] = useState<string | null>(null);
+
+  // Lazily build (and cache) the viem wallet client + GoodDollar SDKs backed by
+  // the Turnkey signer EOA. Creating the account does not prompt for a passkey
+  // — only signing (verify/claim) does — so this is safe to call for read-only
+  // status too.
+  const getSdks = useCallback((): Promise<GoodDollarSdks> => {
+    if (!user?.walletAddress || !user?.suborgId) {
+      return Promise.reject(new Error('Wallet is not ready yet'));
+    }
+
+    if (!sdksRef.current) {
+      sdksRef.current = (async () => {
+        const passkeyClient = createHttpClient({ defaultStamperType: StamperType.Passkey });
+
+        const turnkeyAccount = await createAccount({
+          client: passkeyClient,
+          organizationId: user.suborgId,
+          signWith: user.walletAddress as string,
+        });
+
+        // Same workaround as useUser.safeAA / useRescueToken: the Turnkey viem
+        // adapter mis-sends typed data, so route it through the raw sign.
+        if (turnkeyAccount.sign) {
+          const originalSign = turnkeyAccount.sign.bind(turnkeyAccount);
+          turnkeyAccount.signTypedData = async (typedData: any) =>
+            originalSign({ hash: hashTypedData(typedData) });
+        }
+
+        const walletClient = createWalletClient({
+          account: turnkeyAccount,
+          chain: fuse,
+          transport: http(rpcUrls[GOODDOLLAR_CHAIN_ID]),
+        });
+
+        const readClient = publicClient(GOODDOLLAR_CHAIN_ID) as PublicClient;
+
+        const identitySDK = await IdentitySDK.init({
+          publicClient: readClient,
+          walletClient,
+          env: GOODDOLLAR_ENV,
+        });
+
+        const claimSDK = await ClaimSDK.init({
+          publicClient: readClient,
+          walletClient,
+          identitySDK,
+          env: GOODDOLLAR_ENV,
+          rdu: getRedirectUrl(),
+        });
+
+        return {
+          account: turnkeyAccount.address as Address,
+          readClient,
+          walletClient: walletClient as WalletClient,
+          identitySDK,
+          claimSDK,
+        };
+      })().catch(error => {
+        // Don't cache a failed build — allow retry on the next call.
+        sdksRef.current = null;
+        throw error;
+      });
+    }
+
+    return sdksRef.current;
+  }, [createHttpClient, user?.suborgId, user?.walletAddress]);
+
+  const refresh = useCallback(async () => {
+    if (!user?.walletAddress) return;
+
+    setState(prev => ({ ...prev, isLoading: true, error: null }));
+
+    try {
+      const { identitySDK, claimSDK, account, readClient } = await getSdks();
+
+      const [{ isWhitelisted }, balance] = await Promise.all([
+        identitySDK.getWhitelistedRoot(account),
+        readClient.readContract({
+          address: GOODDOLLAR_FUSE.gdToken,
+          abi: erc20Abi,
+          functionName: 'balanceOf',
+          args: [account],
+        }) as Promise<bigint>,
+      ]);
+
+      let entitlement = 0n;
+      let nextClaimTime: Date | null = null;
+
+      if (isWhitelisted) {
+        try {
+          const result = await claimSDK.checkEntitlement();
+          entitlement = result?.amount ?? 0n;
+        } catch (error) {
+          Sentry.addBreadcrumb({
+            category: 'gooddollar',
+            level: 'warning',
+            message: 'checkEntitlement failed',
+            data: { error: getErrorMessage(error, 'unknown') },
+          });
+        }
+
+        if (entitlement === 0n) {
+          try {
+            const next = await claimSDK.nextClaimTime();
+            nextClaimTime = next && next.getTime() > Date.now() ? next : null;
+          } catch {
+            nextClaimTime = null;
+          }
+        }
+      }
+
+      setState({
+        isLoading: false,
+        isWhitelisted,
+        entitlement,
+        nextClaimTime,
+        balance,
+        error: null,
+      });
+    } catch (error) {
+      setState(prev => ({
+        ...prev,
+        isLoading: false,
+        error: getErrorMessage(error, 'Failed to load GoodDollar status'),
+      }));
+    }
+  }, [getSdks, user?.walletAddress]);
+
+  useEffect(() => {
+    if (user?.walletAddress) {
+      void refresh();
+    }
+  }, [refresh, user?.walletAddress]);
+
+  // Opens GoodDollar's hosted Face Verification (FaceTec liveness) flow in an
+  // in-app browser and re-checks whitelist status on-chain when it returns.
+  const verify = useCallback(async () => {
+    setIsVerifying(true);
+    try {
+      const { identitySDK } = await getSdks();
+      const redirectUrl = getRedirectUrl();
+
+      // Signs the FV identifier message with the EOA (triggers a passkey prompt)
+      // and builds the hosted verification URL. popupMode=false → redirect mode
+      // with a deep-link callback, which is GoodDollar's recommended mobile flow.
+      const link = await identitySDK.generateFVLink(false, redirectUrl, SupportedChains.FUSE);
+
+      await WebBrowser.openAuthSessionAsync(link, redirectUrl);
+
+      // Trust the chain, not the redirect params: re-read whitelist status.
+      await refresh();
+    } catch (error) {
+      if (!isUserCancelled(error)) {
+        Sentry.captureException(error, { tags: { type: 'gooddollar_verify_error' } });
+      }
+      Toast.show({
+        type: 'error',
+        text1: 'Verification failed',
+        text2: isUserCancelled(error)
+          ? 'Verification was cancelled'
+          : getErrorMessage(error, 'Please try again'),
+        props: { badgeText: 'Error' },
+      });
+    } finally {
+      setIsVerifying(false);
+    }
+  }, [getSdks, refresh]);
+
+  const claim = useCallback(async () => {
+    let clientTxId: string | null = null;
+    setIsClaiming(true);
+    setClaimMessage('Preparing your claim…');
+
+    try {
+      const { claimSDK, account } = await getSdks();
+
+      const entitlement = await claimSDK.checkEntitlement();
+      if (!entitlement?.amount || entitlement.amount === 0n) {
+        // Already claimed this period (or nothing available) — just resync the UI.
+        await refresh();
+        return;
+      }
+
+      const amount = formatUnits(entitlement.amount, G_DOLLAR_DECIMALS);
+
+      clientTxId = await createActivity({
+        type: TransactionType.GOODDOLLAR_CLAIM,
+        title: `Claimed ${amount} G$`,
+        shortTitle: 'G$ Claim',
+        amount,
+        symbol: G_DOLLAR_SYMBOL,
+        chainId: GOODDOLLAR_CHAIN_ID,
+        toAddress: account,
+        status: TransactionStatus.PENDING,
+        metadata: {
+          source: 'gooddollar',
+          description: 'GoodDollar UBI daily claim',
+          tokenAddress: GOODDOLLAR_FUSE.gdToken,
+        },
+      });
+
+      // claim() tops up gas via GoodDollar's Fuse faucet if needed, then calls
+      // claim() on the UBI scheme. Both may prompt the passkey signer.
+      const receipt = await claimSDK.claim((message: string) => setClaimMessage(message));
+      const hash = extractTxHash(receipt);
+
+      await updateActivity(clientTxId, {
+        status: TransactionStatus.SUCCESS,
+        hash,
+        url: hash ? getGoodDollarExplorerTxUrl(hash) : undefined,
+      });
+
+      Toast.show({
+        type: 'success',
+        text1: `Claimed ${amount} G$`,
+        text2: 'Your GoodDollar UBI is on the way.',
+        props: { badgeText: 'Success' },
+      });
+
+      await refresh();
+    } catch (error) {
+      if (clientTxId) {
+        void updateActivity(clientTxId, {
+          status: TransactionStatus.FAILED,
+          metadata: { error: getErrorMessage(error, 'Claim failed') },
+        });
+      }
+      if (!isUserCancelled(error)) {
+        Sentry.captureException(error, { tags: { type: 'gooddollar_claim_error' } });
+      }
+      Toast.show({
+        type: 'error',
+        text1: 'Claim failed',
+        text2: isUserCancelled(error)
+          ? 'Passkey prompt was cancelled'
+          : getErrorMessage(error, 'Please try again'),
+        props: { badgeText: 'Error' },
+      });
+    } finally {
+      setIsClaiming(false);
+      setClaimMessage(null);
+    }
+  }, [createActivity, getSdks, refresh, updateActivity]);
+
+  // Moves the claimed G$ from the signer EOA to the user's Solid Safe so it can
+  // be used across the app (swap, send). Ensures the EOA has gas via GoodDollar's
+  // Fuse faucet, then transfers the full G$ balance.
+  const sweep = useCallback(async () => {
+    if (!user?.safeAddress) {
+      Toast.show({
+        type: 'error',
+        text1: 'Move failed',
+        text2: 'Solid wallet not found',
+        props: { badgeText: 'Error' },
+      });
+      return;
+    }
+
+    let clientTxId: string | null = null;
+    setIsSweeping(true);
+
+    try {
+      const { claimSDK, walletClient, readClient, account } = await getSdks();
+      const safeAddress = user.safeAddress as Address;
+
+      const balanceWei = (await readClient.readContract({
+        address: GOODDOLLAR_FUSE.gdToken,
+        abi: erc20Abi,
+        functionName: 'balanceOf',
+        args: [account],
+      })) as bigint;
+
+      if (balanceWei === 0n) {
+        await refresh();
+        return;
+      }
+
+      const amount = formatUnits(balanceWei, G_DOLLAR_DECIMALS);
+
+      // Ensure the EOA has enough native FUSE to pay for the transfer (tops up
+      // via GoodDollar's faucet if needed). Best effort — a gas error on the
+      // transfer itself is surfaced below.
+      try {
+        await claimSDK.checkBalanceWithRetry();
+      } catch {
+        // ignore — proceed to the transfer
+      }
+
+      clientTxId = await createActivity({
+        type: TransactionType.GOODDOLLAR_SWEEP,
+        title: `Moved ${amount} G$ to wallet`,
+        shortTitle: 'G$ to wallet',
+        amount,
+        symbol: G_DOLLAR_SYMBOL,
+        chainId: GOODDOLLAR_CHAIN_ID,
+        fromAddress: account,
+        toAddress: safeAddress,
+        status: TransactionStatus.PENDING,
+        metadata: {
+          source: 'gooddollar',
+          description: 'Moved GoodDollar UBI to Solid wallet',
+          tokenAddress: GOODDOLLAR_FUSE.gdToken,
+        },
+      });
+
+      const txHash = await walletClient.writeContract({
+        address: GOODDOLLAR_FUSE.gdToken,
+        abi: erc20Abi,
+        functionName: 'transfer',
+        args: [safeAddress, balanceWei],
+        account: walletClient.account ?? account,
+        chain: fuse,
+      });
+
+      await updateActivity(clientTxId, {
+        status: TransactionStatus.PROCESSING,
+        hash: txHash,
+        url: getGoodDollarExplorerTxUrl(txHash),
+      });
+
+      const receipt = await readClient.waitForTransactionReceipt({ hash: txHash });
+
+      if (receipt.status !== 'success') {
+        await updateActivity(clientTxId, {
+          status: TransactionStatus.FAILED,
+          hash: txHash,
+          url: getGoodDollarExplorerTxUrl(txHash),
+          metadata: { error: 'Transfer reverted on-chain' },
+        });
+        throw new Error('Sweep transaction reverted on-chain');
+      }
+
+      await updateActivity(clientTxId, {
+        status: TransactionStatus.SUCCESS,
+        hash: txHash,
+        url: getGoodDollarExplorerTxUrl(txHash),
+      });
+
+      Toast.show({
+        type: 'success',
+        text1: `Moved ${amount} G$ to your wallet`,
+        text2: 'It’s now available across Solid.',
+        props: { badgeText: 'Success' },
+      });
+
+      await refresh();
+    } catch (error) {
+      if (clientTxId) {
+        void updateActivity(clientTxId, {
+          status: TransactionStatus.FAILED,
+          metadata: { error: getErrorMessage(error, 'Sweep failed') },
+        });
+      }
+      if (!isUserCancelled(error)) {
+        Sentry.captureException(error, { tags: { type: 'gooddollar_sweep_error' } });
+      }
+      Toast.show({
+        type: 'error',
+        text1: 'Move failed',
+        text2: isUserCancelled(error)
+          ? 'Passkey prompt was cancelled'
+          : getErrorMessage(error, 'Please try again'),
+        props: { badgeText: 'Error' },
+      });
+    } finally {
+      setIsSweeping(false);
+    }
+  }, [createActivity, getSdks, refresh, updateActivity, user?.safeAddress]);
+
+  return {
+    ...state,
+    isVerifying,
+    isClaiming,
+    isSweeping,
+    claimMessage,
+    canClaim: state.isWhitelisted && state.entitlement > 0n,
+    canSweep: state.balance > 0n && !!user?.safeAddress,
+    formattedBalance: formatUnits(state.balance, G_DOLLAR_DECIMALS),
+    formattedEntitlement: formatUnits(state.entitlement, G_DOLLAR_DECIMALS),
+    verify,
+    claim,
+    sweep,
+    refresh,
+  };
+};
+
+export default useGoodDollarClaim;

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -737,6 +737,8 @@ export enum TransactionType {
   RESCUE_TOKEN = 'rescue_token',
   AGENT_X402_PAYMENT = 'agent_x402_payment',
   AGENT_WALLET_DEPOSIT = 'agent_wallet_deposit',
+  GOODDOLLAR_CLAIM = 'gooddollar_claim',
+  GOODDOLLAR_SWEEP = 'gooddollar_sweep',
 }
 
 export enum TransactionDirection {

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@didit-protocol/sdk-web": "^0.1.8",
         "@expo-google-fonts/mona-sans": "^0.4.1",
         "@expo/vector-icons": "^15.1.1",
+        "@goodsdks/citizen-sdk": "^1.2.5",
         "@gorhom/bottom-sheet": "^5.2.8",
         "@hookform/resolvers": "^5.2.2",
         "@intercom/intercom-react-native": "^9.8.0",
@@ -3518,7 +3519,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3535,7 +3535,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3552,7 +3551,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3569,7 +3567,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3586,7 +3583,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3603,7 +3599,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3620,7 +3615,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3637,7 +3631,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3654,7 +3647,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3671,7 +3663,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3688,7 +3679,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3705,7 +3695,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3722,7 +3711,6 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3739,7 +3727,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3756,7 +3743,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3773,7 +3759,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3790,7 +3775,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3807,7 +3791,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3824,7 +3807,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3841,7 +3823,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3858,7 +3839,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3875,7 +3855,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3892,7 +3871,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3909,7 +3887,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3926,7 +3903,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3943,7 +3919,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6059,6 +6034,20 @@
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
       "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
       "license": "MIT"
+    },
+    "node_modules/@goodsdks/citizen-sdk": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@goodsdks/citizen-sdk/-/citizen-sdk-1.2.5.tgz",
+      "integrity": "sha512-jIXr3KoiWJO+CXJ830nqCyowg4Ys3q7CTp6NdaF25CYvNnNpk6eTpyKZOyNG6iSTAbuoYQm/PyatAm4loF0LdA==",
+      "license": "ISC",
+      "dependencies": {
+        "lz-string": "^1.5.0",
+        "tsup": "^8.4.0"
+      },
+      "peerDependencies": {
+        "viem": "*",
+        "wagmi": "*"
+      }
     },
     "node_modules/@gorhom/bottom-sheet": {
       "version": "5.2.8",
@@ -12673,6 +12662,331 @@
         }
       }
     },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.2.tgz",
+      "integrity": "sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.2.tgz",
+      "integrity": "sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.2.tgz",
+      "integrity": "sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.2.tgz",
+      "integrity": "sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.2.tgz",
+      "integrity": "sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.2.tgz",
+      "integrity": "sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.2.tgz",
+      "integrity": "sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.2.tgz",
+      "integrity": "sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.2.tgz",
+      "integrity": "sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.2.tgz",
+      "integrity": "sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.2.tgz",
+      "integrity": "sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.2.tgz",
+      "integrity": "sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.2.tgz",
+      "integrity": "sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.2.tgz",
+      "integrity": "sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.2.tgz",
+      "integrity": "sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.2.tgz",
+      "integrity": "sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.2.tgz",
+      "integrity": "sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.2.tgz",
+      "integrity": "sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.2.tgz",
+      "integrity": "sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.2.tgz",
+      "integrity": "sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.2.tgz",
+      "integrity": "sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.2.tgz",
+      "integrity": "sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.2.tgz",
+      "integrity": "sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -15357,9 +15671,9 @@
       "license": "MIT"
     },
     "node_modules/@types/estree": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "license": "MIT"
     },
     "node_modules/@types/graceful-fs": {
@@ -19122,7 +19436,6 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/bundle-require/-/bundle-require-5.1.0.tgz",
       "integrity": "sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "load-tsconfig": "^0.2.3"
@@ -19226,7 +19539,6 @@
       "version": "6.7.14",
       "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
       "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -19908,7 +20220,6 @@
       "resolved": "https://registry.npmjs.org/consola/-/consola-3.4.2.tgz",
       "integrity": "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^14.18.0 || >=16.10.0"
       }
@@ -21345,7 +21656,6 @@
       "version": "0.25.12",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
       "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -23979,6 +24289,17 @@
         "@firebase/storage": "0.14.1",
         "@firebase/storage-compat": "0.4.1",
         "@firebase/util": "1.14.0"
+      }
+    },
+    "node_modules/fix-dts-default-cjs-exports": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fix-dts-default-cjs-exports/-/fix-dts-default-cjs-exports-1.0.1.tgz",
+      "integrity": "sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg==",
+      "license": "MIT",
+      "dependencies": {
+        "magic-string": "^0.30.17",
+        "mlly": "^1.7.4",
+        "rollup": "^4.34.8"
       }
     },
     "node_modules/flat-cache": {
@@ -26947,6 +27268,15 @@
         "url": "https://github.com/sponsors/panva"
       }
     },
+    "node_modules/joycon": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
+      "integrity": "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/js-base64": {
       "version": "3.7.8",
       "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.8.tgz",
@@ -27713,7 +28043,6 @@
       "version": "0.2.5",
       "resolved": "https://registry.npmjs.org/load-tsconfig/-/load-tsconfig-0.2.5.tgz",
       "integrity": "sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
@@ -28009,6 +28338,15 @@
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-native": "*",
         "react-native-svg": "^12.0.0 || ^13.0.0 || ^14.0.0 || ^15.0.0"
+      }
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "license": "MIT",
+      "bin": {
+        "lz-string": "bin/bin.js"
       }
     },
     "node_modules/magic-string": {
@@ -28785,6 +29123,41 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/mlly": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.2.tgz",
+      "integrity": "sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==",
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "pathe": "^2.0.3",
+        "pkg-types": "^1.3.1",
+        "ufo": "^1.6.3"
+      }
+    },
+    "node_modules/mlly/node_modules/confbox": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
+      "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
+      "license": "MIT"
+    },
+    "node_modules/mlly/node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "license": "MIT"
+    },
+    "node_modules/mlly/node_modules/pkg-types": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
+      "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "confbox": "^0.1.8",
+        "mlly": "^1.7.4",
+        "pathe": "^2.0.1"
       }
     },
     "node_modules/morgan": {
@@ -32634,7 +33007,6 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
       "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 14.18.0"
@@ -33023,6 +33395,50 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.2.tgz",
+      "integrity": "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.62.2",
+        "@rollup/rollup-android-arm64": "4.62.2",
+        "@rollup/rollup-darwin-arm64": "4.62.2",
+        "@rollup/rollup-darwin-x64": "4.62.2",
+        "@rollup/rollup-freebsd-arm64": "4.62.2",
+        "@rollup/rollup-freebsd-x64": "4.62.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.2",
+        "@rollup/rollup-linux-arm64-musl": "4.62.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.2",
+        "@rollup/rollup-linux-loong64-musl": "4.62.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-musl": "4.62.2",
+        "@rollup/rollup-openbsd-x64": "4.62.2",
+        "@rollup/rollup-openharmony-arm64": "4.62.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.2",
+        "@rollup/rollup-win32-x64-gnu": "4.62.2",
+        "@rollup/rollup-win32-x64-msvc": "4.62.2",
+        "fsevents": "~2.3.2"
       }
     },
     "node_modules/run-applescript": {
@@ -35982,6 +36398,15 @@
         "node": ">=12"
       }
     },
+    "node_modules/tree-kill": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+      "license": "MIT",
+      "bin": {
+        "tree-kill": "cli.js"
+      }
+    },
     "node_modules/ts-api-utils": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
@@ -36049,6 +36474,545 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/tsup": {
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/tsup/-/tsup-8.5.1.tgz",
+      "integrity": "sha512-xtgkqwdhpKWr3tKPmCkvYmS9xnQK3m3XgxZHwSUjvfTjp7YfXe5tT3GgWi0F2N+ZSMsOeWeZFh7ZZFg5iPhing==",
+      "license": "MIT",
+      "dependencies": {
+        "bundle-require": "^5.1.0",
+        "cac": "^6.7.14",
+        "chokidar": "^4.0.3",
+        "consola": "^3.4.0",
+        "debug": "^4.4.0",
+        "esbuild": "^0.27.0",
+        "fix-dts-default-cjs-exports": "^1.0.0",
+        "joycon": "^3.1.1",
+        "picocolors": "^1.1.1",
+        "postcss-load-config": "^6.0.1",
+        "resolve-from": "^5.0.0",
+        "rollup": "^4.34.8",
+        "source-map": "^0.7.6",
+        "sucrase": "^3.35.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.11",
+        "tree-kill": "^1.2.2"
+      },
+      "bin": {
+        "tsup": "dist/cli-default.js",
+        "tsup-node": "dist/cli-node.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@microsoft/api-extractor": "^7.36.0",
+        "@swc/core": "^1",
+        "postcss": "^8.4.12",
+        "typescript": ">=4.5.0"
+      },
+      "peerDependenciesMeta": {
+        "@microsoft/api-extractor": {
+          "optional": true
+        },
+        "@swc/core": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsup/node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/tsup/node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "node_modules/tsup/node_modules/source-map": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
+      "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/tsup/node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "license": "MIT"
     },
     "node_modules/tsx": {
       "version": "4.21.0",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@didit-protocol/sdk-web": "^0.1.8",
     "@expo-google-fonts/mona-sans": "^0.4.1",
     "@expo/vector-icons": "^15.1.1",
+    "@goodsdks/citizen-sdk": "^1.2.5",
     "@gorhom/bottom-sheet": "^5.2.8",
     "@hookform/resolvers": "^5.2.2",
     "@intercom/intercom-react-native": "^9.8.0",


### PR DESCRIPTION
Add a GoodDollar page (linked from the account center next to "Agent wallet" on both the web dropdown and the native Settings screen) that lets users:
- verify their identity via GoodDollar's hosted FaceTec liveness check (opened in an in-app browser with a solid:// deep-link callback),
- claim their daily G$ UBI on Fuse, and
- sweep the claimed G$ from their Turnkey signer EOA to their Solid Safe so it can be used across the app (swap, send).

GoodDollar identity and claiming are EOA-only (personal_sign + ecrecover, no ERC-1271), so the flow runs through the user's Turnkey signer EOA rather than the Safe smart account, via the viem-based @goodsdks/citizen-sdk. Gas for the claim and sweep is covered by GoodDollar's Fuse faucet (mainnet gas top-up). Only Fuse is supported for now; Celo is planned for a future release.

A claim records a GOODDOLLAR_CLAIM activity and a sweep records a GOODDOLLAR_SWEEP activity, mirroring the existing useRescueToken pattern.


Claude-Session: https://claude.ai/code/session_0194XbUCRmRApP76ux5uSzZC