### PR TITLE
fix(gooddollar): sign FV and claim locally via custodial SDK

### DIFF
--- a/hooks/useGoodDollarClaim.ts
+++ b/hooks/useGoodDollarClaim.ts
@@ -2,7 +2,13 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import Toast from 'react-native-toast-message';
 import * as Linking from 'expo-linking';
 import * as WebBrowser from 'expo-web-browser';
-import { ClaimSDK, IdentitySDK, SupportedChains } from '@goodsdks/citizen-sdk';
+import {
+  ClaimCustodialSDK,
+  ClaimSDK,
+  IdentityCustodialSDK,
+  IdentitySDK,
+  SupportedChains,
+} from '@goodsdks/citizen-sdk';
 import * as Sentry from '@sentry/react-native';
 import { StamperType, useTurnkey } from '@turnkey/react-native-wallet-kit';
 import { createAccount } from '@turnkey/viem';
@@ -132,13 +138,19 @@ const useGoodDollarClaim = () => {
 
         const readClient = publicClient(GOODDOLLAR_CHAIN_ID) as PublicClient;
 
-        const identitySDK = await IdentitySDK.init({
+        // Use the *custodial* SDK variants: they sign the FV message and claim
+        // transactions locally via the Turnkey account (account.signMessage /
+        // account.signTransaction) instead of dispatching personal_sign /
+        // eth_sendTransaction to the Fuse RPC, which rejects them. Constructed
+        // directly (not via .init(), which hardcodes the non-custodial class).
+        const identitySDK: IdentitySDK = new IdentityCustodialSDK({
+          account: turnkeyAccount.address as Address,
           publicClient: readClient,
           walletClient,
           env: GOODDOLLAR_ENV,
         });
 
-        const claimSDK = await ClaimSDK.init({
+        const claimSDK: ClaimSDK = new ClaimCustodialSDK({
           publicClient: readClient,
           walletClient,
           identitySDK,


### PR DESCRIPTION
The base IdentitySDK/ClaimSDK sign by passing the account *address string* to the wallet client, which makes viem dispatch personal_sign / eth_sendTransaction over the Fuse RPC — which disables the Personal namespace and rejects them, so "Verify" failed with "JSON is not a valid request object".

Switch to GoodDollar's custodial variants (IdentityCustodialSDK / ClaimCustodialSDK), which sign the FV message and claim transactions locally with the Turnkey account (account.signMessage / account.signTransaction + sendRawTransaction). They must be constructed directly — .init() hardcodes the non-custodial class. Cold-EOA gas is still covered by the faucet's no-signing API fallback.


Claude-Session: https://claude.ai/code/session_0194XbUCRmRApP76ux5uSzZC