### PR TITLE
Add referral program banner for internal test users

### DIFF
--- a/app/(protected)/(tabs)/points/index.tsx
+++ b/app/(protected)/(tabs)/points/index.tsx
@@ -5,6 +5,7 @@ import { router } from 'expo-router';
 
 import PageLayout from '@/components/PageLayout';
 import PointsTitle from '@/components/Points/PointsTitle';
+import ReferralProgramBanner from '@/components/Points/ReferralProgramBanner';
 import RewardReferBanner from '@/components/Points/RewardReferBanner';
 import { Button, buttonVariants } from '@/components/ui/button';
 import { Text } from '@/components/ui/text';
@@ -12,6 +13,7 @@ import { path } from '@/constants/path';
 import { useCountdownTimer } from '@/hooks/useCountdownTimer';
 import { useDimension } from '@/hooks/useDimension';
 import { useHoldingFundsPointsMultiplier } from '@/hooks/useHoldingFundsPointsMultiplier';
+import { useIsTestUser } from '@/hooks/useIsTestUser';
 import { usePoints } from '@/hooks/usePoints';
 import { getAsset } from '@/lib/assets';
 import { RewardsType } from '@/lib/types';
@@ -21,6 +23,7 @@ export default function Points() {
   const { points, isLoading: isPointsLoading } = usePoints();
   const { multiplier } = useHoldingFundsPointsMultiplier();
   const { isScreenMedium } = useDimension();
+  const isTestUser = useIsTestUser();
   const countdownTime = useCountdownTimer(points.nextRewardTime);
 
   const referrer = points.userRefferer;
@@ -177,7 +180,9 @@ export default function Points() {
               </View>
             </Button>
           </View>
-          <RewardReferBanner />
+          {/* Internal whitelist team members get the new `/referral-program`
+              banner; public users keep the existing `/referral` banner. */}
+          {isTestUser ? <ReferralProgramBanner /> : <RewardReferBanner />}
         </View>
       </View>
     </PageLayout>

--- a/app/(protected)/(tabs)/rewards/index.tsx
+++ b/app/(protected)/(tabs)/rewards/index.tsx
@@ -5,6 +5,7 @@ import { RotateCw } from 'lucide-react-native';
 
 import { HomeBanners } from '@/components/Dashboard/HomeBanners';
 import PageLayout from '@/components/PageLayout';
+import ReferralProgramBanner from '@/components/Points/ReferralProgramBanner';
 import RewardReferBanner from '@/components/Points/RewardReferBanner';
 import CashbackCard from '@/components/Rewards/CashbackCard';
 import GetCardRewardsBanner from '@/components/Rewards/GetCardRewardsBanner';
@@ -16,6 +17,7 @@ import { path } from '@/constants/path';
 import { TRACKING_EVENTS } from '@/constants/tracking-events';
 import { useCardStatus } from '@/hooks/useCardStatus';
 import { useDimension } from '@/hooks/useDimension';
+import { useIsTestUser } from '@/hooks/useIsTestUser';
 import { useOptInToRewards, useRewardsUserData } from '@/hooks/useRewards';
 import { track } from '@/lib/analytics';
 import { hasCard } from '@/lib/utils';
@@ -24,6 +26,7 @@ import { useRewardsWelcomePopupStore } from '@/store/useRewardsWelcomePopupStore
 
 export default function Rewards() {
   const { isScreenMedium } = useDimension();
+  const isTestUser = useIsTestUser();
   const { data: rewardsData, isLoading, isError, refetch } = useRewardsUserData();
   const { setSelectedTierModalId } = useRewards();
   const { mutate: joinRewards, isPending: isJoining } = useOptInToRewards();
@@ -53,9 +56,15 @@ export default function Rewards() {
         cashbackRate={cashbackRate}
         maxCashbackMonthly={maxCashbackMonthly}
       />,
-      <RewardReferBanner key="refer" title="Refer a Friend" buttonText="Start earning" />,
+      // Internal whitelist team members get the new `/referral-program` banner;
+      // public users keep the existing `/referral` banner.
+      isTestUser ? (
+        <ReferralProgramBanner key="refer" />
+      ) : (
+        <RewardReferBanner key="refer" title="Refer a Friend" buttonText="Start earning" />
+      ),
     ];
-  }, [rewardsData]);
+  }, [rewardsData, isTestUser]);
 
   if (isError && !isLoading) {
     return (

--- a/components/Points/ReferralProgramBanner.tsx
+++ b/components/Points/ReferralProgramBanner.tsx
@@ -1,0 +1,49 @@
+import { View } from 'react-native';
+import { Image } from 'expo-image';
+import { router } from 'expo-router';
+
+import SwipeableBanner from '@/components/Dashboard/SwipeableBanner';
+import { Button } from '@/components/ui/button';
+import { Text } from '@/components/ui/text';
+import { path } from '@/constants/path';
+import { useDimension } from '@/hooks/useDimension';
+import { getAsset } from '@/lib/assets';
+
+/**
+ * Internal-only referral banner pointing to the new `/referral-program` page.
+ * Rendered in place of {@link RewardReferBanner} for whitelisted team members
+ * (see `useIsTestUser`); public users keep the existing `/referral` banner.
+ */
+const ReferralProgramBanner = () => {
+  const { isScreenMedium } = useDimension();
+
+  return (
+    <SwipeableBanner onPress={() => router.push(path.REFERRAL_PROGRAM)}>
+      <View className="flex-1 flex-row items-center justify-between bg-card pl-5 md:px-10">
+        <View className="max-w-64 items-start justify-between gap-2 py-5 md:py-7">
+          <Text className="text-lg font-medium leading-5 text-brand/70">Invite friends</Text>
+          <Text className="text-3xl font-semibold">Refer & Earn</Text>
+          <Text className="text-base font-semibold opacity-70">
+            Earn $15 for you and $10 for friends for using the card
+          </Text>
+          <Button
+            variant="secondary"
+            className="h-12 rounded-xl border-0 px-6"
+            onPress={() => router.push(path.REFERRAL_PROGRAM)}
+          >
+            <Text className="text-base font-bold text-primary">Refer friends</Text>
+          </Button>
+        </View>
+        <View className="pointer-events-none -ml-6 md:ml-0">
+          <Image
+            source={getAsset('images/referral-3d.png')}
+            contentFit="contain"
+            style={{ width: isScreenMedium ? 160 : 110, height: isScreenMedium ? 160 : 110 }}
+          />
+        </View>
+      </View>
+    </SwipeableBanner>
+  );
+};
+
+export default ReferralProgramBanner;


### PR DESCRIPTION
## Summary
Introduces a new `ReferralProgramBanner` component that points to the `/referral-program` page and conditionally displays it to whitelisted internal team members, while public users continue to see the existing `/referral` banner.

## Key Changes
- **New Component**: Created `ReferralProgramBanner.tsx` with a swipeable banner featuring referral messaging, CTA button, and 3D imagery
- **Conditional Rendering**: Updated both the Rewards and Points pages to use `useIsTestUser()` hook to determine which banner to display
  - Test users (internal team): See new `ReferralProgramBanner` pointing to `/referral-program`
  - Public users: Continue using existing `RewardReferBanner` pointing to `/referral`
- **Updated Pages**:
  - `app/(protected)/(tabs)/rewards/index.tsx`: Added conditional banner logic with updated dependency array
  - `app/(protected)/(tabs)/points/index.tsx`: Added conditional banner logic with explanatory comments

## Implementation Details
- The new banner uses the existing `SwipeableBanner` wrapper component for consistency
- Responsive design with different image sizes for medium and smaller screens
- Clear inline comments document the whitelist behavior for future maintainers
- No changes to the existing `RewardReferBanner` component, ensuring backward compatibility

https://claude.ai/code/session_01FxDV3BC9hC4RxNLY5YuzYY