### PR TITLE
Add CTA button support to WhatsNewModal

### DIFF
--- a/components/WhatsNewModal.tsx
+++ b/components/WhatsNewModal.tsx
@@ -1,13 +1,20 @@
 import React, { useState } from 'react';
-import { useWindowDimensions, View } from 'react-native';
+import { Linking, useWindowDimensions, View } from 'react-native';
+import { Pressable } from 'react-native-gesture-handler';
 import Carousel from 'react-native-reanimated-carousel';
 import { Image } from 'expo-image';
+import { router } from 'expo-router';
+import { ChevronRight } from 'lucide-react-native';
 
 import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent } from '@/components/ui/dialog';
 import { Text } from '@/components/ui/text';
 import { WhatsNew, WhatsNewStep } from '@/lib/types';
 import { cn } from '@/lib/utils';
+
+// Mirrors the `--brand` design token (see global.css). lucide icons need a
+// concrete color value, so it can't be applied via the `text-brand` class.
+const BRAND_COLOR = 'hsl(109.04, 81.56%, 72.35%)';
 
 interface WhatsNewModalProps {
   whatsNew: WhatsNew;
@@ -21,21 +28,49 @@ const WhatsNewModal = ({ whatsNew, isOpen, onClose }: WhatsNewModalProps) => {
   const { width: screenWidth } = useWindowDimensions();
   const modalWidth = Math.min(screenWidth * 0.9, 560);
 
-  const renderItem = ({ item }: { item: WhatsNewStep }) => (
-    <View className="flex-1">
-      <View className="h-64 w-full bg-muted">
-        <Image
-          source={{ uri: item.imageUrl }}
-          style={{ width: '100%', height: '100%' }}
-          contentFit="cover"
-        />
+  const handleButtonPress = (link?: string) => {
+    const target = link?.trim();
+    if (!target) return;
+
+    // Close the modal first so the user lands on the destination screen.
+    onClose();
+
+    if (target.startsWith('http://') || target.startsWith('https://')) {
+      void Linking.openURL(target);
+    } else {
+      router.push(target as any);
+    }
+  };
+
+  const renderItem = ({ item }: { item: WhatsNewStep }) => {
+    const hasCta = Boolean(item.buttonLabel?.trim() && item.buttonLink?.trim());
+
+    return (
+      <View className="flex-1">
+        <View className="h-64 w-full bg-muted">
+          <Image
+            source={{ uri: item.imageUrl }}
+            style={{ width: '100%', height: '100%' }}
+            contentFit="cover"
+          />
+        </View>
+        <View className="px-6 pt-6">
+          <Text className="mb-4 text-2xl font-semibold text-white">{item.title}</Text>
+          <Text className="text-base font-medium text-white/70">{item.text}</Text>
+          {hasCta && (
+            <Pressable
+              onPress={() => handleButtonPress(item.buttonLink)}
+              accessibilityRole="button"
+              className="mt-4 flex-row items-center gap-0.5 self-start py-1 active:opacity-70 web:hover:opacity-80"
+            >
+              <Text className="text-base font-bold text-brand">{item.buttonLabel}</Text>
+              <ChevronRight size={20} color={BRAND_COLOR} strokeWidth={2.5} />
+            </Pressable>
+          )}
+        </View>
       </View>
-      <View className="px-6 pt-6">
-        <Text className="mb-4 text-2xl font-semibold text-white">{item.title}</Text>
-        <Text className="text-base font-medium text-white/70">{item.text}</Text>
-      </View>
-    </View>
-  );
+    );
+  };
 
   const isLastStep = activeIndex === whatsNew.steps.length - 1;
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1673,6 +1673,8 @@ export interface WhatsNewStep {
   imageUrl: string;
   title: string;
   text: string;
+  buttonLabel?: string;
+  buttonLink?: string;
 }
 
 export interface WhatsNew {


### PR DESCRIPTION
## Summary
Enhanced the WhatsNewModal component to support optional call-to-action (CTA) buttons on each step, allowing users to navigate to internal routes or external URLs directly from the modal.

## Key Changes
- **Extended WhatsNewStep type** with optional `buttonLabel` and `buttonLink` fields to support CTA configuration
- **Added CTA button rendering** in WhatsNewModal with conditional display based on button label and link availability
- **Implemented navigation handler** (`handleButtonPress`) that:
  - Closes the modal before navigation to ensure proper UX flow
  - Supports both external URLs (http/https) via `Linking.openURL`
  - Supports internal routes via `expo-router`
- **Added visual styling** for the CTA button with:
  - Brand-colored text and chevron icon
  - Active/hover state feedback
  - Proper spacing and alignment

## Implementation Details
- Introduced `BRAND_COLOR` constant to provide a concrete hex value for the lucide ChevronRight icon, since design tokens cannot be applied directly to icon components
- CTA button only renders when both `buttonLabel` and `buttonLink` are provided and non-empty
- Used `Pressable` component from react-native-gesture-handler for better touch handling
- Maintained existing modal styling and layout while adding the new interactive element

https://claude.ai/code/session_017xj8hzqJWpN58wyfnoCv74