### PR TITLE
Fix country availability detection for newly eligible regions

### DIFF
--- a/app/(protected)/(tabs)/card-onboard/country_selection.tsx
+++ b/app/(protected)/(tabs)/card-onboard/country_selection.tsx
@@ -197,6 +197,14 @@ export default function CountrySelection() {
         }
       } else {
         setCheckingWaitlist(false);
+        if (countryInfo.isAvailable) {
+          // Country is available (e.g. just became eligible). Make sure a stale
+          // "not available" state can't strand the user on the notify
+          // confirmation screen — show the selector so they can proceed to
+          // activate their card.
+          setNotifyClicked(false);
+          setShowCountrySelector(true);
+        }
       }
     };
 

--- a/store/useCountryStore.ts
+++ b/store/useCountryStore.ts
@@ -120,7 +120,24 @@ export const useCountryStore = create<CountryState>()(
     }),
     {
       name: COUNTRY_STORAGE_KEY,
+      version: 1,
       storage: createJSONStorage(() => mmkvStorage(COUNTRY_STORAGE_KEY)),
+      // v1: drop any cached country availability so clients re-detect against
+      // the current allowed-countries config. Unsticks users who were cached as
+      // "country not available" before their country became eligible for the
+      // Rain card (e.g. Argentina) and were stranded on the notify screen.
+      migrate: (persistedState, version) => {
+        if (version < 1) {
+          return {
+            ...(persistedState as Partial<CountryState>),
+            countryInfo: null,
+            ipCountryCache: {},
+            cachedIp: null,
+            countryDetectionFailed: false,
+          } as CountryState;
+        }
+        return persistedState as CountryState;
+      },
     },
   ),
 );


### PR DESCRIPTION
## Summary
This PR fixes an issue where users in countries that became newly eligible for the Rain card (e.g., Argentina) were stranded on the notify confirmation screen due to stale cached "country not available" state.

## Key Changes
- **Store migration (v1)**: Added a migration to the country store that clears cached country availability data (`countryInfo`, `ipCountryCache`, `cachedIp`, `countryDetectionFailed`) when upgrading to v1. This forces clients to re-detect their country against the current allowed-countries configuration.
- **Country selection logic**: Updated the country selection flow to check if a country is newly available after waitlist check completes. If available, the notify confirmation state is reset and the country selector is shown, allowing users to proceed to card activation instead of being stuck on the notify screen.

## Implementation Details
- The migration runs automatically for persisted state with version < 1, ensuring all existing cached states are cleared on app update
- The country selector visibility is now properly restored when a country transitions from unavailable to available, preventing users from being stranded in a stale UI state

https://claude.ai/code/session_01QjTVArHYKTGosb5qi81Jms