### PR TITLE
fix(gooddollar): top up gas via backend proxy and verify sufficiency

### DIFF
--- a/constants/gooddollar.ts
+++ b/constants/gooddollar.ts
@@ -28,6 +28,11 @@ export const G_DOLLAR_DECIMALS = 2;
 
 export const G_DOLLAR_SYMBOL = 'G$';
 
+// G$ logo (Voltage Finance token list) — used everywhere instead of the dark
+// CoinGecko image. Mirrors the swaptokens `logoURI` for the Fuse G$ token.
+export const G_DOLLAR_LOGO_URI =
+  'https://raw.githubusercontent.com/voltfinance/swap-default-token-list/master/logos/0x495d133B938596C9984d462F007B676bDc57eCEC/logo.png';
+
 // Fuse mainnet (production) contract addresses, mirrored from
 // `@goodsdks/citizen-sdk` chainConfigs[122].contracts.production.
 export const GOODDOLLAR_FUSE = {

--- a/constants/gooddollar.ts
+++ b/constants/gooddollar.ts
@@ -37,6 +37,10 @@ export const GOODDOLLAR_FUSE = {
   gdToken: '0x495d133B938596C9984d462F007B676bDc57eCEC',
 } as const;
 
+// Fallback minimum native FUSE (wei) the signer EOA should hold before a
+// claim/sweep, used only when on-chain gas estimation is unavailable (~0.01 FUSE).
+export const GOODDOLLAR_GAS_FLOOR_WEI = 10_000_000_000_000_000n;
+
 // Deep-link path the GoodDollar Face Verification flow redirects back to.
 export const GOODDOLLAR_REDIRECT_PATH = 'gooddollar';
 

--- a/constants/transaction.ts
+++ b/constants/transaction.ts
@@ -118,6 +118,14 @@ export const TRANSACTION_DETAILS: Record<TransactionType, TransactionDetails> = 
     sign: TransactionDirection.OUT,
     category: TransactionCategory.WALLET_TRANSFER,
   },
+  [TransactionType.GOODDOLLAR_CLAIM]: {
+    sign: TransactionDirection.IN,
+    category: TransactionCategory.GOODDOLLAR_UBI,
+  },
+  [TransactionType.GOODDOLLAR_SWEEP]: {
+    sign: TransactionDirection.IN,
+    category: TransactionCategory.GOODDOLLAR_UBI,
+  },
 };
 
 /**

--- a/hooks/useBalances.ts
+++ b/hooks/useBalances.ts
@@ -226,7 +226,9 @@ const fetchTokenBalances = async (safeAddress: string) => {
       contractAddress: address,
       balance: item.value,
       quoteRate,
-      logoUrl: isSoUSD ? undefined : item.token.icon_url,
+      // Prefer the curated swaptokens logo (e.g. Voltage's G$ logo) over
+      // Blockscout's CoinGecko icon, which can be dark/low-quality.
+      logoUrl: isSoUSD ? undefined : (tokenFromList?.logoURI ?? item.token.icon_url),
       contractDecimals: parseInt(item.token.decimals),
       type: item.token.type as TokenType,
       verified: true,
@@ -410,8 +412,7 @@ const fetchTokenBalances = async (safeAddress: string) => {
   }
 
   if (bscBalance.status === PromiseStatus.FULFILLED && Number(bscBalance.value)) {
-    const bscPriceValue =
-      bscPrice.status === PromiseStatus.FULFILLED ? Number(bscPrice.value) : 0;
+    const bscPriceValue = bscPrice.status === PromiseStatus.FULFILLED ? Number(bscPrice.value) : 0;
     const bscBnbTokenFromList = tokenListData.find(
       token => token.chainId === BSC_CHAIN_ID && token.symbol === 'BNB',
     );

--- a/hooks/useGoodDollarClaim.ts
+++ b/hooks/useGoodDollarClaim.ts
@@ -308,7 +308,10 @@ const useGoodDollarClaim = () => {
 
       await WebBrowser.openAuthSessionAsync(link, redirectUrl);
 
-      // Trust the chain, not the redirect params: poll whitelist status.
+      // The browser has closed — drop the "Opening…" state so the whitelist
+      // poll below shows the normal loading UI instead of a stuck button.
+      // On-chain status is the source of truth, not the redirect params.
+      setIsVerifying(false);
       await pollForWhitelist();
     } catch (error) {
       if (!isUserCancelled(error)) {

--- a/hooks/useGoodDollarClaim.ts
+++ b/hooks/useGoodDollarClaim.ts
@@ -306,11 +306,22 @@ const useGoodDollarClaim = () => {
         return;
       }
 
-      await WebBrowser.openAuthSessionAsync(link, redirectUrl);
+      // Open the hosted Face Verification (FaceTec) flow in an in-app browser.
+      // Use openBrowserAsync (same call the app's KYC flow uses) rather than
+      // openAuthSessionAsync: the latter needs an ASWebAuthenticationSession
+      // callback scheme and was failing to launch the browser on native. If
+      // GoodDollar redirects to the solid:// deep link it dismisses the browser
+      // and foregrounds the app; otherwise the user closes it manually. Either
+      // way the promise resolves when the browser is dismissed.
+      await WebBrowser.openBrowserAsync(link, {
+        presentationStyle: WebBrowser.WebBrowserPresentationStyle.FULL_SCREEN,
+        controlsColor: '#94F27F',
+        showTitle: true,
+        enableBarCollapsing: true,
+      });
 
-      // The browser has closed — drop the "Opening…" state so the whitelist
-      // poll below shows the normal loading UI instead of a stuck button.
-      // On-chain status is the source of truth, not the redirect params.
+      // Browser dismissed — drop the "Opening…" state so the whitelist poll
+      // shows the normal loading UI. On-chain status is the source of truth.
       setIsVerifying(false);
       await pollForWhitelist();
     } catch (error) {

--- a/hooks/useGoodDollarClaim.ts
+++ b/hooks/useGoodDollarClaim.ts
@@ -29,15 +29,18 @@ import { fuse } from 'wagmi/chains';
 import {
   G_DOLLAR_DECIMALS,
   G_DOLLAR_SYMBOL,
+  getGoodDollarExplorerTxUrl,
   GOODDOLLAR_CHAIN_ID,
   GOODDOLLAR_ENV,
   GOODDOLLAR_FUSE,
+  GOODDOLLAR_GAS_FLOOR_WEI,
   GOODDOLLAR_REDIRECT_PATH,
-  getGoodDollarExplorerTxUrl,
 } from '@/constants/gooddollar';
 import { useActivityActions } from '@/hooks/useActivityActions';
 import useUser from '@/hooks/useUser';
+import { topUpGoodDollarGas } from '@/lib/api';
 import { TransactionStatus, TransactionType } from '@/lib/types';
+import { withRefreshToken } from '@/lib/utils';
 import { publicClient, rpcUrls } from '@/lib/wagmi';
 
 type GoodDollarSdks = {
@@ -324,6 +327,41 @@ const useGoodDollarClaim = () => {
     }
   }, [getSdks, pollForWhitelist]);
 
+  // Make sure the signer EOA holds enough native FUSE for a transaction. Tops up
+  // via GoodDollar's faucet (proxied by our backend — the faucet API is
+  // CORS-blocked in the browser) and waits for the top-up to land. Best effort:
+  // if it can't, the transaction below surfaces an insufficient-funds error.
+  const ensureGas = useCallback(
+    async (
+      readClient: PublicClient,
+      account: Address,
+      needed: bigint,
+      setMessage?: (message: string) => void,
+    ) => {
+      let balance = await readClient.getBalance({ address: account });
+      if (balance >= needed) return;
+
+      setMessage?.('Topping up gas…');
+      try {
+        await withRefreshToken(() => topUpGoodDollarGas(account, GOODDOLLAR_CHAIN_ID));
+      } catch (error) {
+        Sentry.addBreadcrumb({
+          category: 'gooddollar',
+          level: 'warning',
+          message: 'gas top-up request failed',
+          data: { error: getErrorMessage(error, 'unknown') },
+        });
+      }
+
+      for (let attempt = 0; attempt < 12; attempt++) {
+        await new Promise(resolve => setTimeout(resolve, 3000));
+        balance = await readClient.getBalance({ address: account });
+        if (balance >= needed) return;
+      }
+    },
+    [],
+  );
+
   const claim = useCallback(async () => {
     let clientTxId: string | null = null;
     setIsClaiming(true);
@@ -357,19 +395,22 @@ const useGoodDollarClaim = () => {
         },
       });
 
-      // Ensure the EOA has gas (GoodDollar faucet, with a gasless API fallback),
-      // then wait for the top-up to land before claiming.
+      // Ensure the EOA has enough native FUSE for the claim (top up via backend).
       setClaimMessage('Preparing your wallet…');
+      let neededGas = GOODDOLLAR_GAS_FLOOR_WEI;
       try {
-        await claimSDK.checkBalanceWithRetry((message: string) => setClaimMessage(message));
+        const gasUnits = await readClient.estimateContractGas({
+          address: GOODDOLLAR_FUSE.ubiScheme,
+          abi: ubiSchemeV2ABI,
+          functionName: 'claim',
+          account,
+        });
+        const gasPrice = await readClient.getGasPrice();
+        neededGas = (gasUnits * gasPrice * 13n) / 10n; // +30% headroom
       } catch {
-        // best effort — the claim below surfaces a gas error if the top-up failed
+        // estimation unavailable (e.g. zero balance) — fall back to the floor
       }
-      for (let attempt = 0; attempt < 6; attempt++) {
-        const gasBalance = await readClient.getBalance({ address: account });
-        if (gasBalance > 0n) break;
-        await new Promise(resolve => setTimeout(resolve, 3000));
-      }
+      await ensureGas(readClient, account, neededGas, setClaimMessage);
 
       // Submit the claim via viem writeContract so the transaction is fully
       // prepared (nonce, gas) and signed locally by the Turnkey account. The
@@ -437,7 +478,7 @@ const useGoodDollarClaim = () => {
       setIsClaiming(false);
       setClaimMessage(null);
     }
-  }, [createActivity, getSdks, refresh, updateActivity]);
+  }, [createActivity, ensureGas, getSdks, refresh, updateActivity]);
 
   // Moves the claimed G$ from the signer EOA to the user's Solid Safe so it can
   // be used across the app (swap, send). Ensures the EOA has gas via GoodDollar's
@@ -457,7 +498,7 @@ const useGoodDollarClaim = () => {
     setIsSweeping(true);
 
     try {
-      const { claimSDK, walletClient, readClient, account } = await getSdks();
+      const { walletClient, readClient, account } = await getSdks();
       const safeAddress = user.safeAddress as Address;
 
       const balanceWei = (await readClient.readContract({
@@ -474,14 +515,23 @@ const useGoodDollarClaim = () => {
 
       const amount = formatUnits(balanceWei, G_DOLLAR_DECIMALS);
 
-      // Ensure the EOA has enough native FUSE to pay for the transfer (tops up
-      // via GoodDollar's faucet if needed). Best effort — a gas error on the
-      // transfer itself is surfaced below.
+      // Ensure the EOA has enough native FUSE to pay for the transfer (top up
+      // via backend). Best effort — a gas error is surfaced by the transfer below.
+      let neededGas = GOODDOLLAR_GAS_FLOOR_WEI;
       try {
-        await claimSDK.checkBalanceWithRetry();
+        const gasUnits = await readClient.estimateContractGas({
+          address: GOODDOLLAR_FUSE.gdToken,
+          abi: erc20Abi,
+          functionName: 'transfer',
+          args: [safeAddress, balanceWei],
+          account,
+        });
+        const gasPrice = await readClient.getGasPrice();
+        neededGas = (gasUnits * gasPrice * 13n) / 10n; // +30% headroom
       } catch {
-        // ignore — proceed to the transfer
+        // estimation unavailable — fall back to the floor
       }
+      await ensureGas(readClient, account, neededGas);
 
       clientTxId = await createActivity({
         type: TransactionType.GOODDOLLAR_SWEEP,
@@ -562,7 +612,7 @@ const useGoodDollarClaim = () => {
     } finally {
       setIsSweeping(false);
     }
-  }, [createActivity, getSdks, refresh, updateActivity, user?.safeAddress]);
+  }, [createActivity, ensureGas, getSdks, refresh, updateActivity, user?.safeAddress]);
 
   return {
     ...state,

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -604,11 +604,36 @@ export const createDiditSession = async (
     } catch {
       // non-JSON error body — keep the generic fallback
     }
-    throw new ApiError(
-      response.status,
-      message ?? 'Failed to create verification session',
-      code,
-    );
+    throw new ApiError(response.status, message ?? 'Failed to create verification session', code);
+  }
+  return response.json();
+};
+
+/**
+ * Ask the backend to proxy GoodDollar's gasless faucet top-up for the caller's
+ * signer EOA. GoodDollar's faucet API sends no CORS headers, so it can't be
+ * called from the browser directly — the backend relays it server-side.
+ */
+export const topUpGoodDollarGas = async (
+  account: string,
+  chainId: number,
+): Promise<{ success: boolean }> => {
+  const jwt = getJWTToken();
+  const response = await fetch(
+    `${EXPO_PUBLIC_FLASH_API_BASE_URL}/accounts/v1/gooddollar/top-wallet`,
+    {
+      method: 'POST',
+      credentials: 'include',
+      headers: {
+        'Content-Type': 'application/json',
+        ...getPlatformHeaders(),
+        ...(jwt ? { Authorization: `Bearer ${jwt}` } : {}),
+      },
+      body: JSON.stringify({ account, chainId }),
+    },
+  );
+  if (!response.ok) {
+    throw new ApiError(response.status, 'Failed to request gas top-up');
   }
   return response.json();
 };

--- a/lib/getTokenIcon.tsx
+++ b/lib/getTokenIcon.tsx
@@ -1,4 +1,5 @@
 import DefaultTokenIcon from '@/components/DefaultTokenIcon';
+import { G_DOLLAR_LOGO_URI } from '@/constants/gooddollar';
 
 import { getAsset } from './assets';
 import { TokenIcon } from './types';
@@ -56,6 +57,11 @@ const getTokenIcon = ({ logoUrl, tokenSymbol, size = 24 }: GetTokenIconProps): T
       return {
         type: 'image',
         source: getAsset('images/eth.png'),
+      };
+    case 'G$':
+      return {
+        type: 'image',
+        source: { uri: G_DOLLAR_LOGO_URI },
       };
     default:
       return {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -764,6 +764,7 @@ export enum TransactionCategory {
   MERKL_CLAIM = 'Merkl claim',
   CARD_WELCOME_BONUS = 'Card welcome bonus',
   DEPOSIT_BONUS = 'Deposit bonus',
+  GOODDOLLAR_UBI = 'GoodDollar UBI',
   RECEIVE = 'Receive',
 }
 


### PR DESCRIPTION
The GoodDollar faucet API is CORS-blocked from the browser, so a claim on web left the signer EOA underfunded (InsufficientFunds). Route the gas top-up through our backend proxy (POST /accounts/v1/gooddollar/top-wallet), estimate the actual gas the claim/sweep needs, and wait until the EOA balance covers it before submitting — instead of the SDK's browser faucet call and a naive balance>0 check.


Claude-Session: https://claude.ai/code/session_0194XbUCRmRApP76ux5uSzZC