### PR TITLE
Migrate cashback calculations from FUSE to soUSD

### DIFF
--- a/app/(protected)/(tabs)/card/details.tsx
+++ b/app/(protected)/(tabs)/card/details.tsx
@@ -444,9 +444,9 @@ function DesktopHeader({
 interface SpendingBalanceCardProps {
   amount: string;
   cashback?: {
-    monthlyFuseAmount: number;
+    monthlySoUsdAmount: number;
     monthlyUsdValue: number;
-    totalFuseAmount: number;
+    totalSoUsdAmount: number;
     totalUsdValue: number;
     percentage: number;
   };
@@ -951,9 +951,9 @@ function CardActions({
 
 interface CashbackDisplayProps {
   cashback?: {
-    monthlyFuseAmount: number;
+    monthlySoUsdAmount: number;
     monthlyUsdValue: number;
-    totalFuseAmount: number;
+    totalSoUsdAmount: number;
     totalUsdValue: number;
     percentage: number;
   };

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -409,9 +409,9 @@ export interface CardResponse {
 }
 
 export interface CashbackData {
-  monthlyFuseAmount: number;
+  monthlySoUsdAmount: number;
   monthlyUsdValue: number;
-  totalFuseAmount: number;
+  totalSoUsdAmount: number;
   totalUsdValue: number;
   percentage: number;
 }
@@ -993,6 +993,10 @@ export interface Cashback {
   _id: string;
   transactionId: string;
   status: CashbackStatus;
+  /** soUSD payout amount (6dp) and the soUSD/USD rate used at payout. */
+  soUsdAmount?: string;
+  soUsdRate?: string;
+  /** @deprecated legacy FUSE fields for cashbacks paid before the soUSD migration */
   fuseAmount?: string;
   fuseUsdPrice?: string;
   fiatAmount?: string;

--- a/lib/utils/cardHelpers.ts
+++ b/lib/utils/cardHelpers.ts
@@ -119,8 +119,13 @@ export const getCashbackAmount = (
   const isPending = PENDING_CASHBACK_STATUSES.includes(cashback.status);
   const isEscrowed = cashback.status === CashbackStatus.Escrowed;
 
-  // For pending cashbacks without fuseAmount yet, show pending indicator without amount
-  if (!cashback.fuseAmount) {
+  // For pending cashbacks without a payout amount yet, show pending indicator
+  // without an amount. New cashbacks carry soUsdAmount; pre-migration ones
+  // carry the legacy fuseAmount.
+  const soUsdAmount = cashback.soUsdAmount;
+  const legacyFuseAmount = cashback.fuseAmount;
+
+  if (!soUsdAmount && !legacyFuseAmount) {
     return {
       amount: 'Pending',
       isPending: true,
@@ -129,9 +134,11 @@ export const getCashbackAmount = (
     };
   }
 
-  const fuseAmountAsNum = parseFloat(cashback.fuseAmount);
-  const fuseUsdPriceAsNum = parseFloat(cashback.fuseUsdPrice || '0');
-  const amount = fuseAmountAsNum * fuseUsdPriceAsNum;
+  // USD value = token amount × its USD rate. soUSD uses soUsdRate (USD per
+  // share); legacy FUSE cashbacks use fuseUsdPrice.
+  const tokenAmount = soUsdAmount ?? legacyFuseAmount ?? '0';
+  const usdRate = soUsdAmount ? cashback.soUsdRate : cashback.fuseUsdPrice;
+  const amount = parseFloat(tokenAmount) * parseFloat(usdRate || '0');
 
   if (isNaN(amount) || amount <= 0) {
     return null;


### PR DESCRIPTION
## Summary
This PR updates the cashback system to support the new soUSD token while maintaining backward compatibility with legacy FUSE cashbacks. The changes ensure that cashback amounts are calculated correctly using the appropriate token and exchange rate for each cashback record.

## Key Changes
- **Updated `getCashbackAmount()` helper**: Modified to handle both new soUSD cashbacks (`soUsdAmount`/`soUsdRate`) and legacy FUSE cashbacks (`fuseAmount`/`fuseUsdPrice`). The function now checks for either amount type and uses the corresponding exchange rate for USD value calculation.
- **Updated type definitions**: 
  - Added `soUsdAmount` and `soUsdRate` fields to the `Cashback` interface with JSDoc comments
  - Marked `fuseAmount` and `fuseUsdPrice` as deprecated legacy fields
  - Renamed `CashbackData` interface fields from `monthlyFuseAmount`/`totalFuseAmount` to `monthlySoUsdAmount`/`totalSoUsdAmount`
- **Updated component interfaces**: Synchronized `SpendingBalanceCardProps` and `CashbackDisplayProps` to use the renamed `CashbackData` fields

## Implementation Details
- The calculation logic now uses: `USD value = token amount × its USD rate`
- For soUSD cashbacks: uses `soUsdAmount` × `soUsdRate`
- For legacy FUSE cashbacks: uses `fuseAmount` × `fuseUsdPrice`
- Pending cashbacks without either amount type still display "Pending" without a numeric value
- All changes maintain backward compatibility with existing FUSE cashback records

https://claude.ai/code/session_01P266C31gFrB7HeonqJUssf