### PR TITLE
Replace breakpoint-based star positioning with fluid layout measurement

### DIFF
--- a/components/Rewards/RewardsDashboard.tsx
+++ b/components/Rewards/RewardsDashboard.tsx
@@ -1,5 +1,5 @@
-import { ReactNode } from 'react';
-import { Platform, View } from 'react-native';
+import { ReactNode, useState } from 'react';
+import { LayoutChangeEvent, Platform, View } from 'react-native';
 import { Image } from 'expo-image';
 import { LinearGradient } from 'expo-linear-gradient';
 import { router } from 'expo-router';
@@ -9,7 +9,6 @@ import { Text } from '@/components/ui/text';
 import { path } from '@/constants/path';
 import { getTierDisplayName, getTierIcon } from '@/constants/rewards';
 import { useMaxAPY } from '@/hooks/useAnalytics';
-import { useDimension } from '@/hooks/useDimension';
 import { useTierBenefits } from '@/hooks/useRewards';
 import { getAsset } from '@/lib/assets';
 import { RewardsTier, TierBenefits } from '@/lib/types';
@@ -18,6 +17,18 @@ import { compactNumberFormat, formatNumber } from '@/lib/utils';
 import RewardBenefit from './RewardBenefit';
 import RewardComingSoon from './RewardComingSoon';
 import TierProgressBar from './TierProgressBar';
+
+// The rewards hero star is a single decorative image that scales fluidly with
+// the card. Sizing and positioning it from the measured card area — instead of
+// swapping between two fixed desktop/mobile layouts at the `md` breakpoint —
+// keeps it anchored to the right so it never snaps between versions or slides
+// over the tier/points content at intermediate tablet widths.
+const STAR_ASPECT_RATIO = 839 / 386; // native pixel ratio of points_large.png
+const STAR_WIDTH_RATIO = 0.66; // fraction of the card width the star image spans
+const STAR_MIN_WIDTH = 340; // keep the star visible on the narrowest screens
+const STAR_MAX_WIDTH = 760; // cap the star on very wide cards
+const STAR_RIGHT_BLEED_RATIO = 0.4; // how far the (mostly transparent) image bleeds past the right edge
+const STAR_VERTICAL_CENTER_MAX = 150; // pin the star to the upper area on tall (stacked) mobile cards
 
 // Transform API tier benefits to display items with dynamic icons
 interface DashboardBenefitItem {
@@ -76,9 +87,22 @@ const RewardsDashboard = ({
   nextTier,
   nextTierPoints,
 }: RewardsDashboardProps) => {
-  const { isScreenMedium } = useDimension();
+  const [starArea, setStarArea] = useState({ width: 0, height: 0 });
   const { data: allTierBenefits } = useTierBenefits();
   const { maxAPY } = useMaxAPY();
+
+  // Star dimensions derived from the measured card area (see constants above).
+  const starWidth = Math.min(
+    STAR_MAX_WIDTH,
+    Math.max(STAR_MIN_WIDTH, starArea.width * STAR_WIDTH_RATIO),
+  );
+  const starHeight = starWidth / STAR_ASPECT_RATIO;
+  const starCenterY = Math.min(starArea.height / 2, STAR_VERTICAL_CENTER_MAX);
+
+  const handleStarAreaLayout = (event: LayoutChangeEvent) => {
+    const { width, height } = event.nativeEvent.layout;
+    setStarArea(prev => (prev.width === width && prev.height === height ? prev : { width, height }));
+  };
 
   // Get benefits for the current tier from API data
   const currentTierBenefits = allTierBenefits?.find(tb => tb.tier === currentTier);
@@ -115,21 +139,25 @@ const RewardsDashboard = ({
           borderRadius: 20,
         }}
       />
-      {!isScreenMedium && (
-        <Image
-          source={getAsset('images/points_large.png')}
-          contentFit="contain"
-          pointerEvents="none"
-          style={{
-            position: 'absolute',
-            right: -225,
-            top: -22,
-            width: 600,
-            height: 276,
-            zIndex: 0,
-          }}
-        />
-      )}
+      <View
+        pointerEvents="none"
+        onLayout={handleStarAreaLayout}
+        style={{ position: 'absolute', top: 0, right: 0, bottom: 0, left: 0, zIndex: -1 }}
+      >
+        {starArea.width > 0 && (
+          <Image
+            source={getAsset('images/points_large.png')}
+            contentFit="contain"
+            style={{
+              position: 'absolute',
+              width: starWidth,
+              height: starHeight,
+              right: -starWidth * STAR_RIGHT_BLEED_RATIO,
+              top: starCenterY - starHeight / 2,
+            }}
+          />
+        )}
+      </View>
       <View className="relative flex-row justify-between">
         <View className="flex-1 justify-between gap-12 md:flex-[0.7]">
           <View className="justify-between gap-4 md:flex-row">
@@ -163,16 +191,6 @@ const RewardsDashboard = ({
             nextTierPoints={nextTierPoints}
           />
         </View>
-
-        {isScreenMedium && (
-          <View className="pointer-events-none absolute -right-[55%] top-[45%] flex-[0.3] -translate-x-1/2 -translate-y-1/2">
-            <Image
-              source={getAsset('images/points_large.png')}
-              contentFit="contain"
-              style={{ width: 800, height: 600 }}
-            />
-          </View>
-        )}
       </View>
       <View className="gap-6 md:gap-10">
         <View className="flex-row items-center justify-between">


### PR DESCRIPTION
## Summary
Replaced the `useDimension` hook's breakpoint-based conditional rendering with a fluid, measurement-driven approach for positioning the decorative star image in the RewardsDashboard. The star now scales and positions dynamically based on the actual card dimensions rather than snapping between fixed desktop/mobile layouts.

## Key Changes
- Removed dependency on `useDimension` hook and `md` breakpoint conditionals
- Implemented `useState` to track the star container's measured dimensions via `onLayout`
- Added constants to define star sizing ratios and constraints:
  - `STAR_ASPECT_RATIO`: Maintains native image proportions (839/386)
  - `STAR_WIDTH_RATIO`: Star spans 66% of card width
  - `STAR_MIN_WIDTH` / `STAR_MAX_WIDTH`: Constrains star between 340px and 760px
  - `STAR_RIGHT_BLEED_RATIO`: Controls transparent overflow (40% past right edge)
  - `STAR_VERTICAL_CENTER_MAX`: Pins star to upper area on tall mobile cards (150px max)
- Replaced two separate conditional render blocks (mobile and desktop) with a single, responsive implementation
- Star dimensions now calculated dynamically: `starWidth = clamp(starArea.width * 0.66, 340, 760)`

## Implementation Details
- The star container uses `onLayout` to measure the card area and trigger recalculation
- Conditional rendering (`starArea.width > 0`) prevents rendering before layout measurement completes
- Positioning uses calculated offsets (`right: -starWidth * STAR_RIGHT_BLEED_RATIO`) instead of fixed pixel values
- Vertical centering respects the `STAR_VERTICAL_CENTER_MAX` constraint to prevent overlap on stacked layouts
- This approach eliminates layout snapping at breakpoints and maintains proper proportions across all screen sizes

https://claude.ai/code/session_011WiUTbsjXMUkRtH6GzmK3S