### PR TITLE
fix: scope rewards cache by user and reset persisted points on switch

### DIFF
--- a/hooks/useRewards.ts
+++ b/hooks/useRewards.ts
@@ -10,12 +10,24 @@ import {
 } from '@/lib/api';
 import { RewardsUserData } from '@/lib/types';
 import { withRefreshToken } from '@/lib/utils';
+import { useUserStore } from '@/store/useUserStore';
 
 const REWARDS = 'rewards';
 
+// The rewards/referral endpoints return per-user data but are authenticated
+// purely by the session — the URL carries no address and getJWTToken() is null
+// on web (cookie auth). That means every account hits the exact same query key,
+// so after switching wallets React Query serves the previous wallet's cached
+// rewards/points to the new one until gcTime expires (the cross-account leak
+// seen on web). Scoping the key by the selected user id isolates each account's
+// cache, mirroring how the rest of the app keys user data by safeAddress/userId.
+const useSelectedUserId = () =>
+  useUserStore(state => state.users.find(user => user.selected)?.userId);
+
 export const useReferralSummary = () => {
+  const userId = useSelectedUserId();
   return useQuery({
-    queryKey: [REWARDS, 'referralSummary'],
+    queryKey: [REWARDS, 'referralSummary', userId],
     queryFn: async () => {
       return await withRefreshToken(() => fetchReferralSummary());
     },
@@ -25,8 +37,9 @@ export const useReferralSummary = () => {
 };
 
 export const useRewardsUserData = () => {
+  const userId = useSelectedUserId();
   return useQuery({
-    queryKey: [REWARDS, 'userData'],
+    queryKey: [REWARDS, 'userData', userId],
     queryFn: async () => {
       return await withRefreshToken(() => fetchRewardsUserData());
     },
@@ -53,10 +66,12 @@ export const useRewardsConfig = () => {
 
 export const useOptInToRewards = () => {
   const queryClient = useQueryClient();
+  const userId = useSelectedUserId();
   return useMutation({
     mutationFn: async () => await withRefreshToken(() => optInToRewards()),
     onSuccess: (data: RewardsUserData) => {
-      queryClient.setQueryData([REWARDS, 'userData'], data);
+      // Write to the user-scoped key so the rewards screen reads it back.
+      queryClient.setQueryData([REWARDS, 'userData', userId], data);
       void queryClient.invalidateQueries({ queryKey: [REWARDS] });
     },
   });

--- a/hooks/useUser.ts
+++ b/hooks/useUser.ts
@@ -209,6 +209,7 @@ const useUser = (): UseUserReturn => {
     // Start every new session from a clean query cache so this login can never
     // read data cached under user-agnostic keys (e.g. Rewards) by a prior one.
     queryClient.clear();
+    usePointsStore.getState().reset();
 
     // Get attribution context for login tracking
     const attributionStore = useAttributionStore.getState();
@@ -459,6 +460,8 @@ const useUser = (): UseUserReturn => {
     // keys, so without this the previous wallet's details would be served to
     // the next wallet on web until gcTime expires or the page is hard-refreshed.
     queryClient.clear();
+    // Points live in a persisted zustand store, outside the query cache.
+    usePointsStore.getState().reset();
     intercom?.shutdown();
     intercom?.boot();
 
@@ -496,8 +499,11 @@ const useUser = (): UseUserReturn => {
       clearKycLinkId();
       // Switching accounts: drop any queries cached by a previously active
       // session before authenticating, so the incoming user never sees stale
-      // data cached under user-agnostic keys (e.g. Rewards).
+      // data cached under user-agnostic keys (e.g. Rewards), and reset the
+      // persisted points store which would otherwise carry the previous
+      // user's totals (and skip refetching for 5 minutes).
       queryClient.clear();
+      usePointsStore.getState().reset();
 
       // Find the selected user
       const selectedUser = users.find(u => u.userId === userId);
@@ -566,6 +572,7 @@ const useUser = (): UseUserReturn => {
     clearKycLinkId(); // Clear KYC data when removing all users
     removeEvents();
     queryClient.clear(); // Drop all cached queries belonging to the forgotten users
+    usePointsStore.getState().reset();
     router.replace(path.ONBOARDING);
   }, [users, removeUsers, clearKycLinkId, removeEvents, router, queryClient]);
 
@@ -585,6 +592,7 @@ const useUser = (): UseUserReturn => {
     // Purge cached queries so a re-login (possibly as a different user) starts
     // from a clean cache instead of the expired session's data.
     queryClient.clear();
+    usePointsStore.getState().reset();
     intercom?.shutdown();
     intercom?.boot();
 
@@ -619,6 +627,7 @@ const useUser = (): UseUserReturn => {
       removeUsers();
       clearKycLinkId();
       queryClient.clear();
+      usePointsStore.getState().reset();
 
       // Navigate to onboarding (no users left after deletion)
       router.replace(path.ONBOARDING);

--- a/store/usePointsStore.ts
+++ b/store/usePointsStore.ts
@@ -16,24 +16,28 @@ interface PointsState {
   lastFetchTime: number | null;
   setPoints: (points: Points) => void;
   fetchPoints: (options?: { force?: boolean }) => Promise<void>;
+  reset: () => void;
 }
 
 // Cache duration in milliseconds (5 minutes)
 const CACHE_DURATION_MS = 5 * 60 * 1000;
 
+// Empty points, used for the initial state and when resetting on account switch.
+const INITIAL_POINTS: Points = {
+  nextRewardTime: 0,
+  pointsLast24Hours: 0,
+  userRewardsSummary: {
+    totalPoints: 0,
+    rewardsByType: [],
+  },
+  userRefferer: '',
+  leaderboardPosition: 0,
+};
+
 export const usePointsStore = create<PointsState>()(
   persist(
     (set, get) => ({
-      points: {
-        nextRewardTime: 0,
-        pointsLast24Hours: 0,
-        userRewardsSummary: {
-          totalPoints: 0,
-          rewardsByType: [],
-        },
-        userRefferer: '',
-        leaderboardPosition: 0,
-      },
+      points: INITIAL_POINTS,
       isLoading: false,
       error: null,
       lastFetchTime: null,
@@ -45,6 +49,18 @@ export const usePointsStore = create<PointsState>()(
             state.error = null;
           }),
         );
+      },
+
+      // Wipe all points state on logout / account switch so a new account never
+      // sees the previous user's points. Clearing lastFetchTime also disables
+      // the 5-minute fetch-skip so the next fetchPoints() actually runs.
+      reset: () => {
+        set({
+          points: INITIAL_POINTS,
+          isLoading: false,
+          error: null,
+          lastFetchTime: null,
+        });
       },
 
       fetchPoints: async (options?: { force?: boolean }) => {


### PR DESCRIPTION
Clearing the query cache on logout was not enough to stop the rewards page showing the previous wallet's total points after switching accounts. Two gaps remained:

- The rewards/referral queries were cached under user-agnostic keys ([rewards, 'userData']), so any repopulation or clear-timing gap let the new account read the old account's entry. The endpoints carry no address in the URL (session-cookie auth on web), so the key must carry the identity instead. Scope the keys by the selected userId, mirroring how useCardStatus/useVault/useBalances already key by userId/safeAddress. With distinct keys, one account can never read another's cached rewards regardless of when or whether the cache is cleared.

- usePointsStore persists points (userRewardsSummary.totalPoints) to storage and skips refetching for 5 minutes via lastFetchTime, and was never reset on logout — so the previous user's points survived account switches entirely outside the query cache. Add a reset() action and call it on every session transition alongside queryClient.clear().

The opt-in mutation now writes its response to the user-scoped key so the rewards screen reads it back correctly.


Claude-Session: https://claude.ai/code/session_01SZJXbQCeVfHmfwdRASivSn