### PR TITLE
Fix soFUSE interest display during RPC failures

### DIFF
--- a/hooks/useSavingsYield.ts
+++ b/hooks/useSavingsYield.ts
@@ -78,6 +78,23 @@ export function useSavingsYield({
 
   // Full calc only when inputs change (no animation). For TOTAL_USD use redeemable only so display matches withdraw.
   useEffect(() => {
+    // soFUSE CURRENT mode: interest comes from the backend summary (no subgraph
+    // for FUSE) and stays valid even if the on-chain balance read is momentarily
+    // 0 (slow/failed RPC poll or a vault switch). Handle it BEFORE the balance<=0
+    // guard so a transient 0 balance can't wipe the anchor and snap interest to 0.
+    if (mode === SavingMode.CURRENT && vault === 'FUSE') {
+      if (summary) {
+        const backendInterest = parseFloat(summary.interestEarnedUSD);
+        const calculatedAtUnix = Math.floor(new Date(summary.calculatedAt).getTime() / 1000);
+        if (backendInterest >= 0 && calculatedAtUnix > 0) {
+          setLiveYield(backendInterest);
+          setAnchor({ value: backendInterest, time: calculatedAtUnix });
+        }
+      }
+      // No summary yet — keep current value until backend responds
+      return;
+    }
+
     if (balance <= 0) {
       setLiveYield(0);
       setAnchor(null);
@@ -90,20 +107,6 @@ export function useSavingsYield({
     }
     if (mode === SavingMode.TOTAL_USD) {
       setLiveYield(balance * exchangeRate);
-      return;
-    }
-
-    // soFUSE CURRENT mode: use backend summary (no subgraph available for FUSE)
-    if (mode === SavingMode.CURRENT && vault === 'FUSE') {
-      if (summary) {
-        const backendInterest = parseFloat(summary.interestEarnedUSD);
-        const calculatedAtUnix = Math.floor(new Date(summary.calculatedAt).getTime() / 1000);
-        if (backendInterest >= 0 && calculatedAtUnix > 0) {
-          setLiveYield(backendInterest);
-          setAnchor({ value: backendInterest, time: calculatedAtUnix });
-        }
-      }
-      // No summary yet — keep current value until backend responds
       return;
     }
 


### PR DESCRIPTION
## Summary
Reorder the soFUSE CURRENT mode interest calculation to execute before the balance guard check. This prevents transient RPC failures or slow balance reads from clearing the interest display and snapping it to zero.

## Key Changes
- Moved the soFUSE CURRENT mode logic to the beginning of the `useEffect` hook, before the `balance <= 0` guard
- This ensures backend-sourced interest remains valid even when on-chain balance reads are momentarily unavailable or return 0
- The logic now returns early for soFUSE CURRENT mode, preventing subsequent balance-based calculations from overwriting the backend interest value

## Implementation Details
- The soFUSE CURRENT mode relies on backend summary data (no subgraph available for FUSE) which is independent of on-chain balance reads
- By executing this check first, we preserve the interest anchor and live yield values during transient RPC issues or vault switches
- Early return prevents the balance guard from resetting `liveYield` to 0 when balance is temporarily unavailable
- Maintains the existing behavior of keeping current values until the backend responds with new data

https://claude.ai/code/session_01BiZP2CH3SeESf7JKxaroEE