### PR TITLE
Mark subscription discounts as coming soon in tier comparison

### DIFF
--- a/components/Rewards/CompareTiersTable.tsx
+++ b/components/Rewards/CompareTiersTable.tsx
@@ -29,6 +29,8 @@ const CompareTiersTable = ({ tierBenefits }: CompareTiersTableProps) => {
       label: 'Subscription discounts',
       subtitle: 'On eligible subscription categories',
       values: sortedTiers.map(tier => tier.subscriptionDiscount),
+      isComingSoon: true,
+      isSubtitleHidden: true,
     },
   ];
 


### PR DESCRIPTION
## Summary
Updated the subscription discounts row in the tier comparison table to indicate it's a coming soon feature and hide its subtitle from display.

## Key Changes
- Added `isComingSoon: true` flag to the subscription discounts benefit row to mark this feature as unavailable
- Added `isSubtitleHidden: true` flag to hide the "On eligible subscription categories" subtitle from rendering

## Implementation Details
These flags will be used by the CompareTiersTable component to visually distinguish the subscription discounts feature as coming soon and prevent the subtitle from being displayed to users, likely showing a "Coming Soon" badge or similar indicator instead.

https://claude.ai/code/session_01PHeLCsyRyBp5tbYyWhjYQ5