### PR TITLE
ci: make Sentry source-map upload non-blocking for production builds

### DIFF
--- a/eas.json
+++ b/eas.json
@@ -20,7 +20,8 @@
         "disabled": true
       },
       "env": {
-        "SENTRY_AUTH_TOKEN": "$SENTRY_AUTH_TOKEN"
+        "SENTRY_AUTH_TOKEN": "$SENTRY_AUTH_TOKEN",
+        "SENTRY_ALLOW_FAILURE": "true"
       }
     }
   },


### PR DESCRIPTION
The EAS production build fails at the @sentry/react-native source-map upload step when SENTRY_AUTH_TOKEN is rejected (HTTP 401), even though the JS bundle and native build complete successfully. Set SENTRY_ALLOW_FAILURE=true so a failed upload is non-fatal: source maps still upload when the token is valid, but a token problem no longer blocks the release. Applies to both iOS and Android, which share the same upload step.


Claude-Session: https://claude.ai/code/session_017LWh8sKPgZWEF7JNvFxq3g