### PR TITLE
ci: stop overriding SENTRY_AUTH_TOKEN with a literal in eas.json

### DIFF
--- a/eas.json
+++ b/eas.json
@@ -20,7 +20,6 @@
         "disabled": true
       },
       "env": {
-        "SENTRY_AUTH_TOKEN": "$SENTRY_AUTH_TOKEN",
         "SENTRY_ALLOW_FAILURE": "true"
       }
     }


### PR DESCRIPTION
eas.json build-profile `env` values are static strings — they are not shell-expanded — so "SENTRY_AUTH_TOKEN": "$SENTRY_AUTH_TOKEN" passed the literal string "$SENTRY_AUTH_TOKEN" to sentry-cli, which Sentry rejects as an invalid token (HTTP 401). Because a build-profile env value also takes precedence over the EAS-hosted environment variable of the same name, this override silently shadowed the real (rotated) production token, so source-map upload 401'd on both Android and iOS regardless of rotation.

Remove the key so the EAS-hosted `production` SENTRY_AUTH_TOKEN is used directly. SENTRY_ALLOW_FAILURE=true stays as a safety net.


Claude-Session: https://claude.ai/code/session_017LWh8sKPgZWEF7JNvFxq3g