### PR TITLE
fix(home): native deposit crash + new-home polish (card, tab bar, hea…

### DIFF
--- a/app/(protected)/(tabs)/_layout.tsx
+++ b/app/(protected)/(tabs)/_layout.tsx
@@ -176,7 +176,10 @@ export default function TabLayout() {
           title: 'Rewards',
           headerShown: false,
           // Placeholder icon: no rewards/star Lottie exists in assets/tabs-icons.
-          tabBarIcon: ({ color, size }) => <Star size={size ?? 28} color={color} />,
+          // Reduced 30% so the lucide glyph visually matches the Lottie tab icons.
+          tabBarIcon: ({ color, size }) => (
+            <Star size={Math.round((size ?? 28) * 0.7)} color={color} />
+          ),
           // Only surface the Rewards tab (and its route) for whitelisted users;
           // the whitelisted NewCustomTabBar renders Wallet/Savings/Rewards.
           href: isTestUser ? path.REWARDS : null,

--- a/components/ConnectedWalletDropdown.tsx
+++ b/components/ConnectedWalletDropdown.tsx
@@ -7,7 +7,6 @@ import Animated, {
   withTiming,
 } from 'react-native-reanimated';
 import { ChevronDown, Unlink, WalletMinimal } from 'lucide-react-native';
-import { useActiveAccount, useActiveWallet, useDisconnect } from 'thirdweb/react';
 
 import { BRIDGE_TOKENS } from '@/constants/bridge';
 import { TRACKING_EVENTS } from '@/constants/tracking-events';
@@ -22,9 +21,14 @@ type ConnectedWalletDropdownProps = {
 };
 
 const ConnectedWalletDropdown = ({ chainId }: ConnectedWalletDropdownProps = {}) => {
-  const wallet = useActiveWallet();
-  const activeAccount = useActiveAccount();
-  const { disconnect } = useDisconnect();
+  // Connected external wallet is mirrored into the store by the desktop-only
+  // ThirdwebConnectionBridge (thirdweb is desktop-only). Reading from the store
+  // instead of calling thirdweb hooks keeps this component safe on mobile, where
+  // it can still render transiently (e.g. while the savings deposit modal closes
+  // and depositFromSolid flips back to false).
+  const wallet = useDepositStore(state => state.externalWallet.wallet);
+  const activeAccount = useDepositStore(state => state.externalWallet.account);
+  const disconnect = useDepositStore(state => state.externalWallet.disconnect);
   const [isOpen, setIsOpen] = useState(false);
   const srcChainId = useDepositStore(state => state.srcChainId);
   const address = activeAccount?.address;
@@ -95,7 +99,7 @@ const ConnectedWalletDropdown = ({ chainId }: ConnectedWalletDropdownProps = {})
                 network: networkName,
                 wallet_type: wallet.id,
               });
-              disconnect(wallet);
+              disconnect?.(wallet);
             }
           }}
           onLayout={event => {

--- a/components/Home/NewHome/HomeScreenNew.tsx
+++ b/components/Home/NewHome/HomeScreenNew.tsx
@@ -3,7 +3,7 @@ import { TouchableOpacity, View } from 'react-native';
 import { useQueryClient } from '@tanstack/react-query';
 import { Address } from 'viem';
 
-import HomeCardSetup from '@/components/Home/HomeCardSetup';
+import HomeVerificationCard from '@/components/Home/NewHome/HomeVerificationCard';
 import HomeWalletCard from '@/components/Home/NewHome/HomeWalletCard';
 import OtherBalancesDropdown from '@/components/Home/NewHome/OtherBalancesDropdown/OtherBalancesDropdown';
 import WalletActions from '@/components/Home/NewHome/WalletActions';
@@ -135,8 +135,9 @@ export default function HomeScreenNew() {
           </View>
         )}
 
-        <View className="px-4">
-          {userHasCard ? <HomeWalletCard /> : <HomeCardSetup depositCompleted={depositCompleted} />}
+        <View className="gap-3 px-4">
+          <HomeWalletCard hasCard={userHasCard} />
+          {!userHasCard && <HomeVerificationCard depositCompleted={depositCompleted} />}
         </View>
 
         {showAssets && (

--- a/components/Home/NewHome/HomeVerificationCard.tsx
+++ b/components/Home/NewHome/HomeVerificationCard.tsx
@@ -1,0 +1,59 @@
+import { useState } from 'react';
+import { View } from 'react-native';
+
+import CircularProgress from '@/components/Home/CircularProgress';
+import FinishSetupModal from '@/components/Home/FinishSetupModal';
+import { Button } from '@/components/ui/button';
+import { Text } from '@/components/ui/text';
+import { useHomeSetupSteps } from '@/hooks/useHomeSetupSteps';
+
+interface HomeVerificationCardProps {
+  /** Whether the user has already funded their account (deposit step). */
+  depositCompleted: boolean;
+  className?: string;
+}
+
+/**
+ * "Finish verification" card for the redesigned home screen. Reuses the shared
+ * setup-steps flow (useHomeSetupSteps + FinishSetupModal + CircularProgress) with
+ * the redesigned copy and a brand "Get verified" CTA. Separate from the legacy
+ * HomeCardSetup so the public/legacy home is unaffected.
+ */
+const HomeVerificationCard = ({ depositCompleted, className }: HomeVerificationCardProps) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const { steps, completedCount, total, firstIncomplete } = useHomeSetupSteps(depositCompleted);
+
+  return (
+    <>
+      <View className={className}>
+        <View className="rounded-twice bg-card p-5">
+          <View className="flex-row items-center justify-between">
+            <View className="flex-1 gap-1 pr-4">
+              <Text className="text-2xl font-semibold text-foreground">Finish verification</Text>
+              <Text className="text-sm leading-tight text-muted-foreground">
+                You&apos;re a few steps from setting up your card.
+              </Text>
+              <Button
+                variant="brand"
+                className="mt-4 h-10 self-start rounded-full px-5"
+                onPress={() => setIsOpen(true)}
+              >
+                <Text className="text-sm font-bold text-primary-foreground">Get verified</Text>
+              </Button>
+            </View>
+            <CircularProgress completed={completedCount} total={total} />
+          </View>
+        </View>
+      </View>
+
+      <FinishSetupModal
+        isOpen={isOpen}
+        onClose={() => setIsOpen(false)}
+        steps={steps}
+        firstIncomplete={firstIncomplete}
+      />
+    </>
+  );
+};
+
+export default HomeVerificationCard;

--- a/components/Home/NewHome/HomeWalletCard.tsx
+++ b/components/Home/NewHome/HomeWalletCard.tsx
@@ -9,25 +9,34 @@ import { getAsset } from '@/lib/assets';
 // drop shadow), used to render the artwork full-width without distortion.
 const CARD_ASPECT_RATIO = 838 / 555;
 
+interface HomeWalletCardProps {
+  /** When true the card links to card details; otherwise it's shown but inert. */
+  hasCard: boolean;
+}
+
 /**
- * The merged green VISA Platinum "glass" card shown on the wallet page. Tapping
- * it opens the full card management page (/card/details). The card artwork —
- * including the "•••" menu glyph and the "VISA Platinum" wordmark — is baked
- * into the image (assets/images/visa-platinum-card.png).
+ * The merged green VISA Platinum "glass" card shown on the wallet page. Always
+ * displayed; only navigates to the card management page (/card/details) once the
+ * user actually has a card. The card artwork — including the "•••" menu glyph and
+ * the "VISA Platinum" wordmark — is baked into the image.
  */
-const HomeWalletCard = () => {
+const HomeWalletCard = ({ hasCard }: HomeWalletCardProps) => {
   const router = useRouter();
 
-  return (
-    <Pressable onPress={() => router.push(path.CARD_DETAILS)}>
-      <Image
-        source={getAsset('images/visa-platinum-card.png')}
-        alt="Solid VISA Platinum card"
-        style={{ width: '100%', aspectRatio: CARD_ASPECT_RATIO }}
-        contentFit="contain"
-      />
-    </Pressable>
+  const card = (
+    <Image
+      source={getAsset('images/visa-platinum-card.png')}
+      alt="Solid VISA Platinum card"
+      style={{ width: '100%', aspectRatio: CARD_ASPECT_RATIO }}
+      contentFit="contain"
+    />
   );
+
+  if (!hasCard) {
+    return card;
+  }
+
+  return <Pressable onPress={() => router.push(path.CARD_DETAILS)}>{card}</Pressable>;
 };
 
 export default HomeWalletCard;

--- a/components/Navbar/HeaderProfileButton.tsx
+++ b/components/Navbar/HeaderProfileButton.tsx
@@ -1,0 +1,24 @@
+import { Pressable } from 'react-native';
+import { router } from 'expo-router';
+
+import ProfileIcon from '@/assets/images/profile';
+import { path } from '@/constants/path';
+
+/**
+ * Circular profile button for the top-left of the whitelisted mobile header.
+ * Icon-only (no chevron) to mirror the bell button on the right. Opens Settings.
+ */
+const HeaderProfileButton = () => {
+  return (
+    <Pressable
+      accessibilityLabel="Open account settings"
+      accessibilityRole="button"
+      onPress={() => router.push(path.SETTINGS)}
+      className="h-9 w-9 items-center justify-center rounded-full bg-[#2A2A2A] transition-all active:scale-95 active:opacity-80 web:hover:bg-secondary-hover"
+    >
+      <ProfileIcon width={16} height={20} />
+    </Pressable>
+  );
+};
+
+export default HeaderProfileButton;

--- a/components/Navbar/NavbarMobile.tsx
+++ b/components/Navbar/NavbarMobile.tsx
@@ -16,6 +16,7 @@ import useUser from '@/hooks/useUser';
 import { getAsset } from '@/lib/assets';
 
 import HeaderBellButton from './HeaderBellButton';
+import HeaderProfileButton from './HeaderProfileButton';
 import RegisterButtons from './RegisterButtons';
 import WhatsNewButton from './WhatsNewButton';
 
@@ -115,7 +116,7 @@ const NavbarMobile = ({
       )}
       <View className="flex-row items-center justify-between p-4">
         {showNewHeader ? (
-          <AccountCenterDropdown />
+          <HeaderProfileButton />
         ) : (
           <Image
             source={getAsset('images/solid-logo-4x.png')}

--- a/components/ThirdwebConnectionBridge.tsx
+++ b/components/ThirdwebConnectionBridge.tsx
@@ -1,5 +1,10 @@
 import { useEffect } from 'react';
-import { useActiveAccount, useActiveWallet, useActiveWalletConnectionStatus } from 'thirdweb/react';
+import {
+  useActiveAccount,
+  useActiveWallet,
+  useActiveWalletConnectionStatus,
+  useDisconnect,
+} from 'thirdweb/react';
 
 import { useDepositStore } from '@/store/useDepositStore';
 
@@ -17,11 +22,12 @@ export default function ThirdwebConnectionBridge() {
   const account = useActiveAccount();
   const wallet = useActiveWallet();
   const status = useActiveWalletConnectionStatus();
+  const { disconnect } = useDisconnect();
   const setExternalWallet = useDepositStore(state => state.setExternalWallet);
 
   useEffect(() => {
-    setExternalWallet({ address: account?.address, status, account, wallet });
-  }, [account, wallet, status, setExternalWallet]);
+    setExternalWallet({ address: account?.address, status, account, wallet, disconnect });
+  }, [account, wallet, status, disconnect, setExternalWallet]);
 
   return null;
 }

--- a/components/tabBar/NewCustomTabBar.tsx
+++ b/components/tabBar/NewCustomTabBar.tsx
@@ -36,6 +36,9 @@ const INACTIVE_TAB_COLOR = 'rgba(255, 255, 255, 0.5)';
 // measured tab slot so it reads as a pill rather than a full-width block.
 const PILL_INSET_X = 8;
 const PILL_INSET_Y = 2;
+// Extra vertical height (centered) so the icon + label sit inside the oval
+// rather than overflowing above/below it.
+const PILL_EXTRA_HEIGHT = 10;
 
 // Matches NavbarMobile's GLASS_TRANSITION so the app's glass motion feels of a piece.
 const SLIDE_TIMING = { duration: 320, easing: Easing.out(Easing.cubic) };
@@ -157,9 +160,9 @@ export function NewCustomTabBar({ state, descriptors, navigation }: BottomTabBar
     if (!layout) return;
 
     const targetX = layout.x + PILL_INSET_X;
-    const targetY = layout.y + PILL_INSET_Y;
+    const targetY = layout.y + PILL_INSET_Y - PILL_EXTRA_HEIGHT / 2;
     const targetWidth = Math.max(layout.width - PILL_INSET_X * 2, 0);
-    const targetHeight = Math.max(layout.height - PILL_INSET_Y * 2, 0);
+    const targetHeight = Math.max(layout.height - PILL_INSET_Y * 2 + PILL_EXTRA_HEIGHT, 0);
 
     // Vertical size/position is constant across tabs — set without animation.
     translateY.value = targetY;

--- a/store/useDepositStore.ts
+++ b/store/useDepositStore.ts
@@ -77,6 +77,8 @@ export interface ExternalWalletState {
   /** thirdweb account/wallet objects — present only on desktop (via ThirdwebConnectionBridge). */
   account?: Account;
   wallet?: Wallet;
+  /** thirdweb disconnect fn — present only on desktop (via ThirdwebConnectionBridge). */
+  disconnect?: (wallet: Wallet) => void;
 }
 
 interface DepositState {
@@ -127,6 +129,7 @@ export const useDepositStore = create<DepositState>()(
         status: 'disconnected',
         account: undefined,
         wallet: undefined,
+        disconnect: undefined,
       },
       setExternalWallet: data => set({ externalWallet: data }),
       setDepositFromSolid: (v: boolean) => set({ depositFromSolid: v }),


### PR DESCRIPTION
…der, verification box)

1. Fix native crash "useActiveWallet must be used within <ThirdwebProvider>" when closing the savings deposit modal opened from the new other-balances sheet. Closing runs resetDepositFlow (depositFromSolid → false) while DepositToVaultForm is still mounted, which briefly renders ConnectedWalletDropdown — it called thirdweb hooks directly. Decouple it via the store-bridge (account/wallet/disconnect) like the other consumers.
2. Always display the VISA Platinum card on the wallet page; only link to /card/details when the user actually has a card (HomeWalletCard `hasCard`).
3. Reduce the Rewards tab (lucide Star) icon 30% so it matches the Lottie icons.
4. Increase the sliding oval tab background height by 10px (centered) so the icon + label no longer overflow it.
5. Replace the top-left account pill with an icon-only circular profile button (no chevron), mirroring the bell button (new HeaderProfileButton).
6. New-home verification box (HomeVerificationCard): title "Finish verification", copy "You're a few steps from setting up your card.", brand "Get verified" CTA, progress arc kept on the right. Legacy HomeCardSetup is untouched.


Claude-Session: https://claude.ai/code/session_0141JefqAksx9sMJvtBXg8Go