### PR TITLE
fix(home): full-bleed card width, taller tab oval, fix native deposit…

### DIFF
--- a/components/Home/NewHome/HomeScreenNew.tsx
+++ b/components/Home/NewHome/HomeScreenNew.tsx
@@ -135,9 +135,14 @@ export default function HomeScreenNew() {
           </View>
         )}
 
-        <View className="gap-3 px-4">
+        {/* The card is rendered full-bleed (no px-4): the PNG's baked-in drop
+            shadow (~4% each side) acts as the gutter, so the card BODY lines up
+            with the px-4 sections below instead of looking inset/narrower. */}
+        <View className="gap-3">
           <HomeWalletCard hasCard={userHasCard} />
-          {!userHasCard && <HomeVerificationCard depositCompleted={depositCompleted} />}
+          {!userHasCard && (
+            <HomeVerificationCard depositCompleted={depositCompleted} className="px-4" />
+          )}
         </View>
 
         {showAssets && (

--- a/components/tabBar/NewCustomTabBar.tsx
+++ b/components/tabBar/NewCustomTabBar.tsx
@@ -38,7 +38,7 @@ const PILL_INSET_X = 8;
 const PILL_INSET_Y = 2;
 // Extra vertical height (centered) so the icon + label sit inside the oval
 // rather than overflowing above/below it.
-const PILL_EXTRA_HEIGHT = 10;
+const PILL_EXTRA_HEIGHT = 15;
 
 // Matches NavbarMobile's GLASS_TRANSITION so the app's glass motion feels of a piece.
 const SLIDE_TIMING = { duration: 320, easing: Easing.out(Easing.cubic) };

--- a/store/useDepositStore.ts
+++ b/store/useDepositStore.ts
@@ -65,10 +65,13 @@ interface DirectDepositSession {
  *
  * thirdweb is desktop-only (see components/ThirdwebConnectionBridge.tsx). On
  * mobile the bridge never mounts, so this stays { address: undefined,
- * status: 'disconnected' } — which is exactly how mobile behaved when the
- * thirdweb provider wrapped the whole app but no external wallet was connected.
- * Consumers (e.g. useDepositOption) read this instead of calling thirdweb hooks
- * directly, so they never crash when the provider is absent.
+ * status: 'unknown' } — which mirrors thirdweb's own idle status when the
+ * provider is mounted but no autoConnect runs and no wallet connects (it never
+ * resolves to 'disconnected'). This distinction matters: useDepositOption resets
+ * the deposit flow back to the type-selection screen when status ==='disconnected',
+ * so defaulting to 'unknown' keeps that recovery effect desktop-only and stops it
+ * from yanking mobile users back a step mid-flow. Consumers read this instead of
+ * calling thirdweb hooks directly, so they never crash when the provider is absent.
  */
 export type ExternalWalletStatus = 'unknown' | 'connecting' | 'connected' | 'disconnected';
 export interface ExternalWalletState {
@@ -126,7 +129,7 @@ export const useDepositStore = create<DepositState>()(
       depositFromSolid: false,
       externalWallet: {
         address: undefined,
-        status: 'disconnected',
+        status: 'unknown',
         account: undefined,
         wallet: undefined,
         disconnect: undefined,


### PR DESCRIPTION
… step glitch

- HomeWalletCard: render full-bleed (drop px-4) so the PNG's baked-in drop shadow acts as the gutter and the card body lines up with the other full-width sections instead of looking narrower/inset.
- NewCustomTabBar: increase the sliding oval height by another 5px.
- useDepositStore: default the mobile externalWallet.status to 'unknown' instead of 'disconnected'. thirdweb is desktop-only, so on mobile the store default is permanent; 'disconnected' made useDepositOption's recovery effect fire on every non-whitelisted step, snapping the user back to the cash/crypto screen. 'unknown' mirrors thirdweb's real idle status and keeps that effect desktop-only.


Claude-Session: https://claude.ai/code/session_0141JefqAksx9sMJvtBXg8Go