### PR TITLE
feat(savings,rewards): whitelisted glass redesign for Savings + Rewards

### DIFF
--- a/app/(protected)/(tabs)/rewards/index.tsx
+++ b/app/(protected)/(tabs)/rewards/index.tsx
@@ -9,6 +9,7 @@ import ReferralProgramBanner from '@/components/Points/ReferralProgramBanner';
 import ReferralProgramModal from '@/components/Referral/ReferralProgramModal';
 import CashbackCard from '@/components/Rewards/CashbackCard';
 import GetCardRewardsBanner from '@/components/Rewards/GetCardRewardsBanner';
+import RewardsScreenNew from '@/components/Rewards/NewRewards/RewardsScreenNew';
 import RewardsDashboard from '@/components/Rewards/RewardsDashboard';
 import RewardsWelcomePopup from '@/components/Rewards/RewardsWelcomePopup';
 import TierBenefitsCards from '@/components/Rewards/TierBenefitsCards';
@@ -17,6 +18,7 @@ import { path } from '@/constants/path';
 import { TRACKING_EVENTS } from '@/constants/tracking-events';
 import { useCardStatus } from '@/hooks/useCardStatus';
 import { useDimension } from '@/hooks/useDimension';
+import { useIsTestUser } from '@/hooks/useIsTestUser';
 import { useOptInToRewards, useRewardsUserData } from '@/hooks/useRewards';
 import { track } from '@/lib/analytics';
 import { hasCard } from '@/lib/utils';
@@ -24,6 +26,14 @@ import { useRewards } from '@/store/useRewardsStore';
 import { useRewardsWelcomePopupStore } from '@/store/useRewardsWelcomePopupStore';
 
 export default function Rewards() {
+  // Whitelisted internal team members see the redesigned rewards screen; all
+  // other users — and every desktop-web user — keep the existing design.
+  const { isDesktop } = useDimension();
+  const showNew = useIsTestUser() && !isDesktop;
+  return showNew ? <RewardsScreenNew /> : <LegacyRewards />;
+}
+
+function LegacyRewards() {
   const { isScreenMedium } = useDimension();
   const { data: rewardsData, isLoading, isError, refetch } = useRewardsUserData();
   const { setSelectedTierModalId } = useRewards();

--- a/app/(protected)/(tabs)/savings.tsx
+++ b/app/(protected)/(tabs)/savings.tsx
@@ -12,6 +12,7 @@ import PageLayout from '@/components/PageLayout';
 import Ping from '@/components/Ping';
 import SavingCountUp from '@/components/SavingCountUp';
 import SavingsEmptyState from '@/components/Savings/EmptyState';
+import SavingsScreenNew from '@/components/Savings/NewSavings/SavingsScreenNew';
 import SavingsAnalytics from '@/components/Savings/SavingsAnalytics';
 import SavingsHeaderButtonsMobile from '@/components/Savings/SavingsHeaderButtonsMobile';
 import SavingVault from '@/components/Savings/SavingVault';
@@ -29,6 +30,7 @@ import {
 } from '@/hooks/useAnalytics';
 import { useDepositCalculations } from '@/hooks/useDepositCalculations';
 import { useDimension } from '@/hooks/useDimension';
+import { useIsTestUser } from '@/hooks/useIsTestUser';
 import { MONITORED_COMPONENTS, useRenderMonitor } from '@/hooks/useRenderMonitor';
 import { useSavingsSummary } from '@/hooks/useSavingsSummary';
 import useUser from '@/hooks/useUser';
@@ -42,6 +44,14 @@ import { useDepositStore } from '@/store/useDepositStore';
 import { useSavingStore } from '@/store/useSavingStore';
 
 export default function Savings() {
+  // Whitelisted internal team members see the redesigned savings screen; all
+  // other users — and every desktop-web user — keep the existing design.
+  const { isDesktop } = useDimension();
+  const showNew = useIsTestUser() && !isDesktop;
+  return showNew ? <SavingsScreenNew /> : <LegacySavings />;
+}
+
+function LegacySavings() {
   useRenderMonitor({ componentName: MONITORED_COMPONENTS.SAVINGS_SCREEN });
 
   const { vault: vaultParam } = useLocalSearchParams<{ vault?: string }>();

--- a/components/Rewards/NewRewards/DailyBenefits.tsx
+++ b/components/Rewards/NewRewards/DailyBenefits.tsx
@@ -1,0 +1,51 @@
+import { View } from 'react-native';
+import { Image } from 'expo-image';
+
+import { Text } from '@/components/ui/text';
+import { TIER_BENEFITS } from '@/constants/rewards';
+import { type AssetPath, getAsset } from '@/lib/assets';
+import { RewardsTier, TierBenefitItem } from '@/lib/types';
+
+const BenefitCard = ({ benefit }: { benefit: TierBenefitItem }) => (
+  <View className="flex-1 items-center gap-2 rounded-twice bg-card p-4">
+    <View className="h-12 w-12 items-center justify-center rounded-full bg-rewards/20">
+      <Image
+        source={getAsset(benefit.icon as AssetPath)}
+        style={{ width: 30, height: 30 }}
+        contentFit="contain"
+      />
+    </View>
+    <Text className="text-center text-sm font-bold text-white" numberOfLines={2}>
+      {benefit.title}
+    </Text>
+    <Text className="text-center text-xs leading-tight text-muted-foreground" numberOfLines={2}>
+      {benefit.description}
+    </Text>
+  </View>
+);
+
+interface DailyBenefitsProps {
+  tier: RewardsTier;
+}
+
+/**
+ * "Your daily benefits" — the three benefits of the user's CURRENT tier only
+ * (per-tier config in constants/rewards.ts). Full tier comparison lives on the
+ * rewards benefits screen (reached via the "Explore tiers" button).
+ */
+const DailyBenefits = ({ tier }: DailyBenefitsProps) => {
+  const benefits = TIER_BENEFITS[tier] ?? [];
+
+  return (
+    <View className="gap-3 px-4">
+      <Text className="text-lg font-semibold text-muted-foreground">Your daily benefits</Text>
+      <View className="flex-row gap-3">
+        {benefits.map((benefit, index) => (
+          <BenefitCard key={`${benefit.title}-${index}`} benefit={benefit} />
+        ))}
+      </View>
+    </View>
+  );
+};
+
+export default DailyBenefits;

--- a/components/Rewards/NewRewards/PointsHeadline.tsx
+++ b/components/Rewards/NewRewards/PointsHeadline.tsx
@@ -1,0 +1,42 @@
+import { TextStyle, View } from 'react-native';
+
+import { Text } from '@/components/ui/text';
+import { getTierDisplayName } from '@/constants/rewards';
+import { RewardsTier } from '@/lib/types';
+import { compactNumberFormat } from '@/lib/utils';
+
+// Same 50px Mona Sans treatment as the redesigned Wallet/Savings headlines, with
+// a greyed "pt's" suffix (points are shown compact, e.g. "10.5M").
+const NUMBER_STYLE: TextStyle = {
+  fontSize: 50,
+  fontWeight: '500',
+  fontFamily: 'MonaSans_500Medium',
+  color: '#ffffff',
+};
+const SUFFIX_STYLE: TextStyle = {
+  ...NUMBER_STYLE,
+  fontSize: 32,
+  color: '#666666',
+};
+
+interface PointsHeadlineProps {
+  tier: RewardsTier;
+  points: number;
+}
+
+/** Current-tier label + big compact points count (e.g. "Prime" / "10.5M pt's"). */
+const PointsHeadline = ({ tier, points }: PointsHeadlineProps) => {
+  return (
+    <View className="items-center gap-1 pt-2">
+      <Text className="text-base font-medium text-muted-foreground">
+        {getTierDisplayName(tier)}
+      </Text>
+      <View className="flex-row items-baseline">
+        <Text style={NUMBER_STYLE}>{compactNumberFormat(points ?? 0)}</Text>
+        <Text style={[SUFFIX_STYLE, { marginLeft: 8 }]}>pt&apos;s</Text>
+      </View>
+    </View>
+  );
+};
+
+export default PointsHeadline;

--- a/components/Rewards/NewRewards/RewardsScreenNew.tsx
+++ b/components/Rewards/NewRewards/RewardsScreenNew.tsx
@@ -1,0 +1,137 @@
+import { useEffect, useState } from 'react';
+import { Pressable, View } from 'react-native';
+import { router, useLocalSearchParams } from 'expo-router';
+import { RotateCw } from 'lucide-react-native';
+
+import PageLayout from '@/components/PageLayout';
+import ReferralProgramModal from '@/components/Referral/ReferralProgramModal';
+import RewardsWelcomePopup from '@/components/Rewards/RewardsWelcomePopup';
+import { Text } from '@/components/ui/text';
+import { path } from '@/constants/path';
+import { useOptInToRewards, useReferralSummary, useRewardsUserData } from '@/hooks/useRewards';
+import { useRewardsWelcomePopupStore } from '@/store/useRewardsWelcomePopupStore';
+
+import DailyBenefits from './DailyBenefits';
+import PointsHeadline from './PointsHeadline';
+import RewardsSummaryCard from './RewardsSummaryCard';
+
+/**
+ * Redesigned rewards screen (Apple "glass" style), shown only to whitelisted
+ * internal users via the dispatcher in rewards/index.tsx. Public users and all
+ * desktop-web users keep the legacy rewards screen.
+ *
+ * Shows the user's CURRENT tier + points, a rewards summary (cashback +
+ * referrals), and the current tier's daily benefits. "Invite friends" opens the
+ * referral program popup; "Explore tiers" opens the rewards benefits screen
+ * (full tier comparison).
+ */
+export default function RewardsScreenNew() {
+  const { data: rewardsData, isLoading, isError, refetch } = useRewardsUserData();
+  const { data: referralSummary } = useReferralSummary();
+  const { mutate: joinRewards, isPending: isJoining } = useOptInToRewards();
+  const welcomeDismissed = useRewardsWelcomePopupStore(state => state.dismissed);
+  const setWelcomeDismissed = useRewardsWelcomePopupStore(state => state.setDismissed);
+
+  const { referral: referralParam } = useLocalSearchParams<{ referral?: string }>();
+  const [isReferralModalOpen, setIsReferralModalOpen] = useState(false);
+
+  // The rewards program requires an explicit opt-in; `hasOptedIn` defaults to
+  // true when the backend doesn't send it, so we never prompt prematurely.
+  const hasOptedIn = rewardsData?.hasOptedIn ?? true;
+  const rewardsLocked = Boolean(rewardsData && !hasOptedIn);
+  const legacyPoints = rewardsData?.legacyPoints ?? 0;
+  const showWelcomePopup = rewardsLocked && !welcomeDismissed;
+
+  useEffect(() => {
+    if (rewardsLocked && welcomeDismissed) {
+      router.replace(path.HOME);
+    }
+  }, [rewardsLocked, welcomeDismissed]);
+
+  // Support the `/rewards?referral=open` deep link (e.g. settings "Refer & Earn").
+  useEffect(() => {
+    if (referralParam === 'open') {
+      setIsReferralModalOpen(true);
+      router.setParams({ referral: undefined });
+    }
+  }, [referralParam]);
+
+  if (isError && !isLoading) {
+    return (
+      <PageLayout>
+        <View className="flex-1 items-center justify-center px-4 py-12">
+          <Text className="mb-4 text-gray-400">Failed to load rewards</Text>
+          <Pressable
+            onPress={() => refetch()}
+            className="flex-row items-center rounded-lg bg-[#2E2E2E] px-4 py-2"
+          >
+            <RotateCw size={16} color="white" className="mr-2" />
+            <Text className="text-white">Try Again</Text>
+          </Pressable>
+        </View>
+      </PageLayout>
+    );
+  }
+
+  if (isLoading || !rewardsData) {
+    return <PageLayout isLoading={true}>{null}</PageLayout>;
+  }
+
+  const { currentTier, totalPoints } = rewardsData;
+
+  if (rewardsLocked) {
+    return (
+      <PageLayout isLoading={welcomeDismissed}>
+        <RewardsWelcomePopup
+          isOpen={showWelcomePopup}
+          variant={legacyPoints > 0 ? 'existing' : 'new'}
+          oldPoints={legacyPoints}
+          legacyCarryoverPoints={rewardsData.legacyCarryoverPoints ?? 0}
+          startingTier={rewardsData.startingTier ?? currentTier}
+          isJoining={isJoining}
+          onAgree={() => joinRewards()}
+          onClose={() => {
+            setWelcomeDismissed(true);
+            router.replace(path.HOME);
+          }}
+        />
+      </PageLayout>
+    );
+  }
+
+  const cashback = rewardsData.cashbackThisMonth ?? 0;
+  const referrals = referralSummary?.totalRewardedUsd ?? 0;
+
+  return (
+    <PageLayout mobileTitle={null}>
+      <View className="mb-5 w-full gap-8 pb-24">
+        <View className="gap-5">
+          <PointsHeadline tier={currentTier} points={totalPoints} />
+          <View className="flex-row gap-3 px-4">
+            <Pressable
+              onPress={() => setIsReferralModalOpen(true)}
+              className="h-14 flex-1 items-center justify-center rounded-full bg-white transition-all active:scale-95 active:opacity-80"
+            >
+              <Text className="text-base font-bold text-black">Invite friends</Text>
+            </Pressable>
+            <Pressable
+              onPress={() => router.push(path.REWARDS_BENEFITS)}
+              className="h-14 flex-1 items-center justify-center rounded-full bg-[#1C1C1C] transition-all active:scale-95 active:opacity-80"
+            >
+              <Text className="text-base font-semibold text-white">Explore tiers</Text>
+            </Pressable>
+          </View>
+        </View>
+
+        <RewardsSummaryCard cashback={cashback} referrals={referrals} />
+
+        <DailyBenefits tier={currentTier} />
+      </View>
+
+      <ReferralProgramModal
+        isOpen={isReferralModalOpen}
+        onClose={() => setIsReferralModalOpen(false)}
+      />
+    </PageLayout>
+  );
+}

--- a/components/Rewards/NewRewards/RewardsSummaryCard.tsx
+++ b/components/Rewards/NewRewards/RewardsSummaryCard.tsx
@@ -1,0 +1,45 @@
+import { View } from 'react-native';
+import { Sparkles } from 'lucide-react-native';
+
+import { Text } from '@/components/ui/text';
+import { formatBalanceUSD } from '@/lib/utils';
+
+interface RewardsSummaryCardProps {
+  cashback: number;
+  referrals: number;
+}
+
+/**
+ * "Rewards" summary card: combined rewards total on top, then Cashback and
+ * Referrals split into two columns (mirrors the mockup).
+ */
+const RewardsSummaryCard = ({ cashback, referrals }: RewardsSummaryCardProps) => {
+  const total = (cashback || 0) + (referrals || 0);
+
+  return (
+    <View className="mx-4 rounded-twice bg-card p-5">
+      <View className="flex-row items-center justify-between">
+        <View className="flex-row items-center gap-2">
+          <Sparkles size={18} color="#ffffff" />
+          <Text className="text-base font-semibold text-white">Rewards</Text>
+        </View>
+        <Text className="text-base font-semibold text-white">{formatBalanceUSD(total)}</Text>
+      </View>
+
+      <View className="my-4 h-px bg-border/40" />
+
+      <View className="flex-row">
+        <View className="flex-1 gap-1">
+          <Text className="text-sm text-muted-foreground">Cashback</Text>
+          <Text className="text-2xl font-semibold text-white">{formatBalanceUSD(cashback)}</Text>
+        </View>
+        <View className="flex-1 gap-1">
+          <Text className="text-sm text-muted-foreground">Referrals</Text>
+          <Text className="text-2xl font-semibold text-white">{formatBalanceUSD(referrals)}</Text>
+        </View>
+      </View>
+    </View>
+  );
+};
+
+export default RewardsSummaryCard;

--- a/components/Savings/NewSavings/AmountDropdown.tsx
+++ b/components/Savings/NewSavings/AmountDropdown.tsx
@@ -1,0 +1,79 @@
+import React from 'react';
+import { Pressable, View } from 'react-native';
+import { ChevronDown } from 'lucide-react-native';
+
+import { Text } from '@/components/ui/text';
+import { cn, formatNumber } from '@/lib/utils';
+
+import SelectSheet from './SelectSheet';
+
+/** Preset principals offered by the "Simulate your savings" amount dropdown. */
+export const SIMULATE_AMOUNTS = [100, 1000, 10000] as const;
+
+const formatAmount = (amount: number) => `$${formatNumber(amount, 0, 0)}`;
+
+type AmountPillProps = {
+  amount: number;
+} & React.ComponentProps<typeof Pressable>;
+
+/** Compact "$10,000 ⌄" pill that opens the amount selector. */
+export const AmountPill = React.forwardRef<View, AmountPillProps>(({ amount, ...props }, ref) => {
+  return (
+    <Pressable
+      ref={ref}
+      accessibilityRole="button"
+      accessibilityLabel="Change simulation amount"
+      className="flex-row items-center gap-1 rounded-full bg-[#262626] py-1.5 pl-3 pr-2 transition-all active:scale-95 active:opacity-80"
+      {...props}
+    >
+      <Text className="text-sm font-semibold text-white">{formatAmount(amount)}</Text>
+      <ChevronDown size={14} color="rgba(255,255,255,0.6)" />
+    </Pressable>
+  );
+});
+AmountPill.displayName = 'AmountPill';
+
+interface AmountDropdownProps {
+  amount: number;
+  onSelect: (amount: number) => void;
+  className?: string;
+}
+
+/**
+ * "$10,000 ⌄" dropdown for the simulation card. Opens a sheet with the preset
+ * amounts (100 / 1,000 / 10,000) as buttons in a single row.
+ */
+const AmountDropdown = ({ amount, onSelect, className }: AmountDropdownProps) => {
+  return (
+    <View className={cn('items-end', className)}>
+      <SelectSheet trigger={<AmountPill amount={amount} />} title="Simulate amount">
+        {dismiss => (
+          <View className="flex-row gap-2 px-5 py-2">
+            {SIMULATE_AMOUNTS.map(preset => {
+              const active = preset === amount;
+              return (
+                <Pressable
+                  key={preset}
+                  onPress={() => {
+                    onSelect(preset);
+                    dismiss();
+                  }}
+                  className={cn(
+                    'flex-1 items-center rounded-full py-3 transition-all active:scale-95',
+                    active ? 'bg-white' : 'bg-[#262626]',
+                  )}
+                >
+                  <Text className={cn('text-base font-bold', active ? 'text-black' : 'text-white')}>
+                    {formatAmount(preset)}
+                  </Text>
+                </Pressable>
+              );
+            })}
+          </View>
+        )}
+      </SelectSheet>
+    </View>
+  );
+};
+
+export default AmountDropdown;

--- a/components/Savings/NewSavings/ApyDropdown.tsx
+++ b/components/Savings/NewSavings/ApyDropdown.tsx
@@ -1,0 +1,124 @@
+import React from 'react';
+import { Pressable, View } from 'react-native';
+import { Image } from 'expo-image';
+import { Check, ChevronDown } from 'lucide-react-native';
+
+import { Text } from '@/components/ui/text';
+import { getAsset } from '@/lib/assets';
+import { VaultType } from '@/lib/types';
+import { cn } from '@/lib/utils';
+
+import {
+  type ApyByType,
+  formatApyLabel,
+  getVaultDisplay,
+  SAVINGS_VAULTS,
+} from './savingsVaultData';
+import SelectSheet from './SelectSheet';
+
+type ApyPillProps = {
+  vaultType: VaultType;
+  apyByType: ApyByType;
+} & React.ComponentProps<typeof Pressable>;
+
+/** The APY dropdown pill: selected vault icon + "X% APY" + chevron. */
+export const ApyPill = React.forwardRef<View, ApyPillProps>(
+  ({ vaultType, apyByType, ...props }, ref) => {
+    const vault = getVaultDisplay(vaultType);
+    const { maxAPY, isAPYsLoading } = apyByType[vaultType];
+    return (
+      <Pressable
+        ref={ref}
+        accessibilityRole="button"
+        accessibilityLabel="Show vault APYs"
+        className="flex-row items-center gap-2 self-center rounded-full bg-[#1C1C1C] py-2 pl-2 pr-3 transition-all active:scale-95 active:opacity-80"
+        {...props}
+      >
+        <Image
+          source={getAsset(vault.icon)}
+          style={{ width: 20, height: 20, borderRadius: 10 }}
+          contentFit="contain"
+        />
+        <Text className="text-base font-semibold text-brand">
+          {formatApyLabel(maxAPY, isAPYsLoading)} APY
+        </Text>
+        <ChevronDown size={16} color="rgba(255,255,255,0.6)" />
+      </Pressable>
+    );
+  },
+);
+ApyPill.displayName = 'ApyPill';
+
+const VaultApyRow = ({
+  vaultType,
+  apyByType,
+  selected,
+  onPress,
+}: {
+  vaultType: VaultType;
+  apyByType: ApyByType;
+  selected: boolean;
+  onPress: () => void;
+}) => {
+  const vault = getVaultDisplay(vaultType);
+  const { maxAPY, isAPYsLoading } = apyByType[vaultType];
+  return (
+    <Pressable
+      onPress={onPress}
+      className="flex-row items-center justify-between px-5 py-3 web:hover:bg-card-hover"
+    >
+      <View className="flex-row items-center gap-3">
+        <Image
+          source={getAsset(vault.icon)}
+          style={{ width: 32, height: 32, borderRadius: 16 }}
+          contentFit="contain"
+        />
+        <Text className="text-base font-semibold text-white">{vault.name}</Text>
+        {selected && <Check size={16} color="#94F27F" />}
+      </View>
+      <Text className="text-base font-semibold text-brand">
+        {formatApyLabel(maxAPY, isAPYsLoading)} APY
+      </Text>
+    </Pressable>
+  );
+};
+
+interface ApyDropdownProps {
+  vaultType: VaultType;
+  apyByType: ApyByType;
+  onSelect: (vaultType: VaultType) => void;
+  className?: string;
+}
+
+/**
+ * "X% APY" pill that opens a bottom sheet (native) / dialog (web) listing every
+ * vault's APY. Defaults to (and highlights) the currently selected vault — USDC
+ * by default on the redesigned savings screen.
+ */
+const ApyDropdown = ({ vaultType, apyByType, onSelect, className }: ApyDropdownProps) => {
+  return (
+    <View className={cn('items-center', className)}>
+      <SelectSheet
+        trigger={<ApyPill vaultType={vaultType} apyByType={apyByType} />}
+        title="Vault APY"
+      >
+        {dismiss =>
+          SAVINGS_VAULTS.map(vault => (
+            <VaultApyRow
+              key={vault.type}
+              vaultType={vault.type}
+              apyByType={apyByType}
+              selected={vault.type === vaultType}
+              onPress={() => {
+                onSelect(vault.type);
+                dismiss();
+              }}
+            />
+          ))
+        }
+      </SelectSheet>
+    </View>
+  );
+};
+
+export default ApyDropdown;

--- a/components/Savings/NewSavings/MoreSavingsOptions.tsx
+++ b/components/Savings/NewSavings/MoreSavingsOptions.tsx
@@ -1,0 +1,59 @@
+import { Fragment } from 'react';
+import { Pressable, View } from 'react-native';
+import { Image } from 'expo-image';
+
+import { Text } from '@/components/ui/text';
+import { getAsset } from '@/lib/assets';
+import { VaultType } from '@/lib/types';
+
+import { type ApyByType, formatApyLabel, SAVINGS_VAULTS } from './savingsVaultData';
+
+interface MoreSavingsOptionsProps {
+  selectedType: VaultType;
+  apyByType: ApyByType;
+  onSelect: (vaultType: VaultType) => void;
+}
+
+/**
+ * "More savings options" — the vaults other than the currently selected one,
+ * each showing its APY. Tapping a row switches the active vault (updating the
+ * APY pill + simulation above).
+ */
+const MoreSavingsOptions = ({ selectedType, apyByType, onSelect }: MoreSavingsOptionsProps) => {
+  const others = SAVINGS_VAULTS.filter(vault => vault.type !== selectedType);
+  if (others.length === 0) return null;
+
+  return (
+    <View className="gap-3 px-4">
+      <Text className="text-lg font-semibold text-muted-foreground">More savings options</Text>
+      <View className="overflow-hidden rounded-twice bg-card">
+        {others.map((vault, index) => {
+          const { maxAPY, isAPYsLoading } = apyByType[vault.type];
+          return (
+            <Fragment key={vault.type}>
+              {index > 0 && <View className="h-px bg-border/40" />}
+              <Pressable
+                onPress={() => onSelect(vault.type)}
+                className="flex-row items-center justify-between px-5 py-4 web:hover:bg-card-hover"
+              >
+                <View className="flex-row items-center gap-3">
+                  <Image
+                    source={getAsset(vault.icon)}
+                    style={{ width: 36, height: 36, borderRadius: 18 }}
+                    contentFit="contain"
+                  />
+                  <Text className="text-base font-semibold text-white">{vault.name}</Text>
+                </View>
+                <Text className="text-base font-semibold text-brand">
+                  {formatApyLabel(maxAPY, isAPYsLoading)} APY
+                </Text>
+              </Pressable>
+            </Fragment>
+          );
+        })}
+      </View>
+    </View>
+  );
+};
+
+export default MoreSavingsOptions;

--- a/components/Savings/NewSavings/SavingsBalanceHeadline.tsx
+++ b/components/Savings/NewSavings/SavingsBalanceHeadline.tsx
@@ -1,0 +1,45 @@
+import { TextStyle, View } from 'react-native';
+
+import CountUp from '@/components/CountUp';
+import { Text } from '@/components/ui/text';
+
+// Same big-number treatment as the redesigned home headline (50px Mona Sans,
+// greyed decimals) so Wallet and Savings share one balance style.
+const WHOLE_STYLE: TextStyle = {
+  fontSize: 50,
+  fontWeight: '500',
+  fontFamily: 'MonaSans_500Medium',
+  color: '#ffffff',
+};
+const DECIMAL_STYLE: TextStyle = { ...WHOLE_STYLE, color: '#666666' };
+const SEPARATOR_STYLE: TextStyle = { ...WHOLE_STYLE };
+
+interface SavingsBalanceHeadlineProps {
+  balance: number;
+}
+
+/**
+ * "Savings Balance" label + big number for the redesigned savings screen.
+ * `balance` is the total redeemable savings value in USD (useTotalSavingsUSD).
+ */
+const SavingsBalanceHeadline = ({ balance }: SavingsBalanceHeadlineProps) => {
+  return (
+    <View className="items-center gap-1 pt-2">
+      <Text className="text-base font-medium text-muted-foreground">Savings Balance</Text>
+      <CountUp
+        prefix="$"
+        count={balance ?? 0}
+        decimalPlaces={2}
+        animateOnMount={false}
+        classNames={{ wrapper: 'text-foreground' }}
+        styles={{
+          wholeText: WHOLE_STYLE,
+          decimalText: DECIMAL_STYLE,
+          decimalSeparator: SEPARATOR_STYLE,
+        }}
+      />
+    </View>
+  );
+};
+
+export default SavingsBalanceHeadline;

--- a/components/Savings/NewSavings/SavingsScreenNew.tsx
+++ b/components/Savings/NewSavings/SavingsScreenNew.tsx
@@ -1,0 +1,82 @@
+import { useState } from 'react';
+import { View } from 'react-native';
+
+import PageLayout from '@/components/PageLayout';
+import Skeleton from '@/components/ui/skeleton';
+import { useMaxAPY } from '@/hooks/useAnalytics';
+import { MONITORED_COMPONENTS, useRenderMonitor } from '@/hooks/useRenderMonitor';
+import { useTotalSavingsUSD } from '@/hooks/useTotalSavingsUSD';
+import { VaultType } from '@/lib/types';
+import { formatBalanceUSD } from '@/lib/utils';
+
+import ApyDropdown from './ApyDropdown';
+import MoreSavingsOptions from './MoreSavingsOptions';
+import SavingsBalanceHeadline from './SavingsBalanceHeadline';
+import SimulateSavingsCard from './SimulateSavingsCard';
+import StartEarningButton from './StartEarningButton';
+
+import type { ApyByType } from './savingsVaultData';
+
+/**
+ * Redesigned savings screen (Apple "glass" style), shown only to whitelisted
+ * internal users via the dispatcher in savings.tsx. Public users and all
+ * desktop-web users keep the legacy savings screen.
+ *
+ * Big "Savings Balance" number = total redeemable savings USD. An APY pill opens
+ * a per-vault APY breakdown (default USDC). "Simulate your savings" projects the
+ * balance forward with a draggable chart handle.
+ */
+export default function SavingsScreenNew() {
+  useRenderMonitor({ componentName: MONITORED_COMPONENTS.SAVINGS_SCREEN });
+
+  const [selectedVaultType, setSelectedVaultType] = useState<VaultType>(VaultType.USDC);
+
+  const { data: totalSavingsUSD, isLoading: isSavingsLoading } = useTotalSavingsUSD();
+
+  const usdcApy = useMaxAPY(VaultType.USDC);
+  const fuseApy = useMaxAPY(VaultType.FUSE);
+  const ethApy = useMaxAPY(VaultType.ETH);
+
+  const apyByType: ApyByType = {
+    [VaultType.USDC]: { maxAPY: usdcApy.maxAPY, isAPYsLoading: usdcApy.isAPYsLoading },
+    [VaultType.FUSE]: { maxAPY: fuseApy.maxAPY, isAPYsLoading: fuseApy.isAPYsLoading },
+    [VaultType.ETH]: { maxAPY: ethApy.maxAPY, isAPYsLoading: ethApy.isAPYsLoading },
+  };
+
+  const savingsBalance = totalSavingsUSD ?? 0;
+  const isBalanceLoading = isSavingsLoading || totalSavingsUSD === undefined;
+  const mobileTitle = isBalanceLoading ? null : formatBalanceUSD(savingsBalance);
+  const selectedApy = apyByType[selectedVaultType].maxAPY;
+
+  return (
+    <PageLayout mobileTitle={mobileTitle}>
+      <View className="mb-5 w-full gap-8 pb-24">
+        {isBalanceLoading ? (
+          <View className="items-center gap-6 pt-6">
+            <Skeleton className="h-16 w-48 rounded-xl" />
+            <Skeleton className="h-9 w-32 rounded-full" />
+            <Skeleton className="h-14 w-11/12 rounded-full" />
+          </View>
+        ) : (
+          <View className="gap-5">
+            <SavingsBalanceHeadline balance={savingsBalance} />
+            <ApyDropdown
+              vaultType={selectedVaultType}
+              apyByType={apyByType}
+              onSelect={setSelectedVaultType}
+            />
+            <StartEarningButton vaultType={selectedVaultType} />
+          </View>
+        )}
+
+        <SimulateSavingsCard apy={selectedApy} />
+
+        <MoreSavingsOptions
+          selectedType={selectedVaultType}
+          apyByType={apyByType}
+          onSelect={setSelectedVaultType}
+        />
+      </View>
+    </PageLayout>
+  );
+}

--- a/components/Savings/NewSavings/SelectSheet.native.tsx
+++ b/components/Savings/NewSavings/SelectSheet.native.tsx
@@ -1,0 +1,50 @@
+import React, { useCallback, useRef } from 'react';
+import { View } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { BottomSheetBackdrop, BottomSheetModal, BottomSheetView } from '@gorhom/bottom-sheet';
+
+import { Text } from '@/components/ui/text';
+
+import type { SelectSheetProps } from './SelectSheet.types';
+
+/**
+ * Native reusable "pill → bottom sheet" primitive. The pill trigger opens a
+ * Gorhom bottom sheet whose body is provided by `children(dismiss)`. Mirrors the
+ * OtherBalancesDropdown.native sheet styling so the redesign's sheets match.
+ * Web uses the Dialog-based variant in SelectSheet.tsx.
+ */
+const SelectSheet = ({ trigger, title, children }: SelectSheetProps) => {
+  const insets = useSafeAreaInsets();
+  const sheetRef = useRef<BottomSheetModal>(null);
+
+  const present = useCallback(() => sheetRef.current?.present(), []);
+  const dismiss = useCallback(() => sheetRef.current?.dismiss(), []);
+
+  const renderBackdrop = useCallback(
+    (props: any) => <BottomSheetBackdrop {...props} appearsOnIndex={0} disappearsOnIndex={-1} />,
+    [],
+  );
+
+  return (
+    <View className="items-center">
+      {React.cloneElement(trigger, { onPress: present })}
+      <BottomSheetModal
+        ref={sheetRef}
+        backdropComponent={renderBackdrop}
+        backgroundStyle={{ backgroundColor: '#1c1c1c', borderRadius: 20 }}
+        handleIndicatorStyle={{
+          backgroundColor: 'rgba(255,255,255,0.2)',
+          width: 74,
+          height: 8,
+        }}
+      >
+        <BottomSheetView className="gap-1 pb-2 pt-1" style={{ paddingBottom: insets.bottom + 8 }}>
+          <Text className="px-5 pb-1 text-lg font-semibold text-muted-foreground">{title}</Text>
+          {children(dismiss)}
+        </BottomSheetView>
+      </BottomSheetModal>
+    </View>
+  );
+};
+
+export default SelectSheet;

--- a/components/Savings/NewSavings/SelectSheet.tsx
+++ b/components/Savings/NewSavings/SelectSheet.tsx
@@ -1,0 +1,30 @@
+import { useState } from 'react';
+import { View } from 'react-native';
+
+import { Dialog, DialogContent, DialogTitle, DialogTrigger } from '@/components/ui/dialog';
+
+import type { SelectSheetProps } from './SelectSheet.types';
+
+/**
+ * Default / web-mobile reusable "pill → sheet" primitive. Gorhom bottom sheets
+ * are native-only in this repo, so the base variant uses the Dialog primitive;
+ * the native override lives in SelectSheet.native.tsx.
+ */
+const SelectSheet = ({ trigger, title, children }: SelectSheetProps) => {
+  const [open, setOpen] = useState(false);
+  const dismiss = () => setOpen(false);
+
+  return (
+    <View className="items-center">
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogTrigger asChild>{trigger}</DialogTrigger>
+        <DialogContent className="gap-1 p-4">
+          <DialogTitle className="px-2 pb-1 text-lg text-muted-foreground">{title}</DialogTitle>
+          {children(dismiss)}
+        </DialogContent>
+      </Dialog>
+    </View>
+  );
+};
+
+export default SelectSheet;

--- a/components/Savings/NewSavings/SelectSheet.types.ts
+++ b/components/Savings/NewSavings/SelectSheet.types.ts
@@ -1,0 +1,11 @@
+import type React from 'react';
+
+/** Shared prop contract for the native (bottom sheet) and web (dialog) SelectSheet. */
+export type SelectSheetProps = {
+  /** The pill/button that opens the sheet. Must forward props + ref (see pills). */
+  trigger: React.ReactElement<{ onPress?: () => void }>;
+  /** Sheet heading. */
+  title: string;
+  /** Sheet body. Receives `dismiss` so rows/buttons can close on selection. */
+  children: (dismiss: () => void) => React.ReactNode;
+};

--- a/components/Savings/NewSavings/SimulateChart.native.tsx
+++ b/components/Savings/NewSavings/SimulateChart.native.tsx
@@ -1,0 +1,125 @@
+import React, { useCallback, useMemo, useState } from 'react';
+import { View } from 'react-native';
+import { useAnimatedReaction } from 'react-native-reanimated';
+import { LineChart } from 'react-native-wagmi-charts';
+import { scheduleOnRN } from 'react-native-worklets';
+import { ChevronsLeftRight } from 'lucide-react-native';
+
+import { ChartPayload } from '@/lib/types';
+
+const CHART_HEIGHT = 150;
+const BRAND = '#94F27F';
+
+/**
+ * Bridges the wagmi chart's draggable cursor (a worklet shared value) back to JS
+ * so the parent can update the future-balance / earned readouts. Renders nothing;
+ * must live inside LineChart.Provider.
+ */
+const CursorReactor = ({
+  count,
+  onActiveIndexChange,
+}: {
+  count: number;
+  onActiveIndexChange: (index: number) => void;
+}) => {
+  const { currentIndex, isActive } = LineChart.useChart();
+
+  const report = useCallback(
+    (index: number, active: boolean) => {
+      if (active && index >= 0 && index < count) {
+        onActiveIndexChange(index);
+      }
+    },
+    [count, onActiveIndexChange],
+  );
+
+  useAnimatedReaction(
+    () => ({ index: currentIndex.value, active: isActive.value }),
+    (current, previous) => {
+      if (current.index !== previous?.index || current.active !== previous?.active) {
+        scheduleOnRN(report, current.index, current.active);
+      }
+    },
+    [report],
+  );
+
+  return null;
+};
+
+interface SimulateChartProps {
+  data: ChartPayload[];
+  /** Resting handle position (series index). */
+  activeIndex: number;
+  onActiveIndexChange: (index: number) => void;
+}
+
+/**
+ * Native projection chart: a wagmi LineChart whose draggable crosshair drives the
+ * readouts, plus a resting "chevron handle" (vertical guide + circular grip) at
+ * the active index — matching the mockup's left/right drag handle.
+ */
+const SimulateChart = ({ data, activeIndex, onActiveIndexChange }: SimulateChartProps) => {
+  const [width, setWidth] = useState<number | undefined>(undefined);
+
+  const wagmiData = useMemo(
+    () =>
+      data.map(d => ({
+        timestamp: typeof d.time === 'string' ? new Date(d.time).getTime() : d.time,
+        value: d.value,
+      })),
+    [data],
+  );
+
+  if (data.length < 2) return <View style={{ height: CHART_HEIGHT }} />;
+
+  const handleX = width ? (activeIndex / (data.length - 1)) * width : 0;
+
+  return (
+    <View style={{ height: CHART_HEIGHT }} onLayout={e => setWidth(e.nativeEvent.layout.width)}>
+      {width !== undefined && (
+        <>
+          <LineChart.Provider data={wagmiData}>
+            <LineChart height={CHART_HEIGHT} width={width}>
+              <LineChart.Path color={BRAND} width={2}>
+                <LineChart.Gradient color={BRAND} />
+              </LineChart.Path>
+              <LineChart.CursorCrosshair color={BRAND} size={8} outerSize={18} snapToPoint />
+            </LineChart>
+            <CursorReactor count={data.length} onActiveIndexChange={onActiveIndexChange} />
+          </LineChart.Provider>
+
+          {/* Resting handle (drag feedback comes from the crosshair above). */}
+          <View
+            pointerEvents="none"
+            style={{
+              position: 'absolute',
+              top: 0,
+              bottom: 0,
+              left: handleX - 1,
+              width: 2,
+              backgroundColor: 'rgba(148, 242, 127, 0.45)',
+            }}
+          />
+          <View
+            pointerEvents="none"
+            style={{
+              position: 'absolute',
+              top: CHART_HEIGHT / 2 - 16,
+              left: handleX - 16,
+              width: 32,
+              height: 32,
+              borderRadius: 16,
+              backgroundColor: BRAND,
+              alignItems: 'center',
+              justifyContent: 'center',
+            }}
+          >
+            <ChevronsLeftRight size={16} color="#0A0A0A" />
+          </View>
+        </>
+      )}
+    </View>
+  );
+};
+
+export default SimulateChart;

--- a/components/Savings/NewSavings/SimulateChart.tsx
+++ b/components/Savings/NewSavings/SimulateChart.tsx
@@ -1,0 +1,68 @@
+import { useMemo } from 'react';
+import { View } from 'react-native';
+import { Area, AreaChart, ReferenceLine, ResponsiveContainer, XAxis, YAxis } from 'recharts';
+
+import { ChartPayload } from '@/lib/types';
+
+const CHART_HEIGHT = 150;
+const BRAND = '#94F27F';
+
+interface SimulateChartProps {
+  data: ChartPayload[];
+  /** Handle position (series index). */
+  activeIndex: number;
+  onActiveIndexChange: (index: number) => void;
+}
+
+/**
+ * Default / web-mobile projection chart (recharts). Moving the pointer/finger
+ * over the chart updates the active index (the readouts animate); a vertical
+ * reference line marks the current handle position. The native drag-handle
+ * variant lives in SimulateChart.native.tsx.
+ */
+const SimulateChart = ({ data, activeIndex, onActiveIndexChange }: SimulateChartProps) => {
+  const chartData = useMemo(() => data.map((d, index) => ({ index, value: d.value })), [data]);
+
+  const handleMove = (state: any) => {
+    const idx = state?.activeTooltipIndex;
+    if (idx !== undefined && idx !== null) {
+      onActiveIndexChange(Number(idx));
+    }
+  };
+
+  if (data.length < 2) return <View style={{ height: CHART_HEIGHT }} />;
+
+  return (
+    <ResponsiveContainer width="100%" height={CHART_HEIGHT}>
+      <AreaChart
+        data={chartData}
+        margin={{ top: 8, right: 0, left: 0, bottom: 0 }}
+        onMouseMove={handleMove}
+        onMouseDown={handleMove}
+        onTouchMove={handleMove}
+      >
+        <defs>
+          <linearGradient id="simGrad" x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%" stopColor={BRAND} stopOpacity={0.25} />
+            <stop offset="100%" stopColor={BRAND} stopOpacity={0} />
+          </linearGradient>
+        </defs>
+        <XAxis dataKey="index" type="number" domain={[0, chartData.length - 1]} hide />
+        <YAxis type="number" domain={['dataMin', 'dataMax']} hide />
+        <Area
+          type="monotone"
+          dataKey="value"
+          stroke={BRAND}
+          strokeWidth={2}
+          fill="url(#simGrad)"
+          isAnimationActive={false}
+          dot={false}
+          activeDot={{ r: 5, fill: BRAND, stroke: BRAND }}
+        />
+        <ReferenceLine x={activeIndex} stroke={BRAND} strokeWidth={2} />
+      </AreaChart>
+    </ResponsiveContainer>
+  );
+};
+
+export default SimulateChart;

--- a/components/Savings/NewSavings/SimulateSavingsCard.tsx
+++ b/components/Savings/NewSavings/SimulateSavingsCard.tsx
@@ -1,0 +1,88 @@
+import { useMemo, useState } from 'react';
+import { TextStyle, View } from 'react-native';
+
+import CountUp from '@/components/CountUp';
+import { Text } from '@/components/ui/text';
+
+import AmountDropdown from './AmountDropdown';
+import { buildProjectionSeries, formatHorizonLabel, SIMULATE_YEARS } from './savingsProjection';
+import SimulateChart from './SimulateChart';
+
+const FUTURE_STYLE: TextStyle = {
+  fontSize: 30,
+  fontWeight: '600',
+  fontFamily: 'MonaSans_500Medium',
+  color: '#ffffff',
+};
+const EARNED_STYLE: TextStyle = {
+  fontSize: 15,
+  fontWeight: '600',
+  color: '#94F27F',
+};
+
+const DEFAULT_PRINCIPAL = 10000;
+// Default handle position: the end of the horizon (SIMULATE_YEARS out).
+const LAST_INDEX = SIMULATE_YEARS * 12;
+
+interface SimulateSavingsCardProps {
+  /** Selected vault's headline APY (percent). */
+  apy: number;
+}
+
+/**
+ * "Simulate your savings" card: pick a principal (100 / 1,000 / 10,000), then
+ * drag the chart handle to scrub the projection horizon. Future balance and
+ * earned amounts animate (CountUp) as the handle moves.
+ */
+const SimulateSavingsCard = ({ apy }: SimulateSavingsCardProps) => {
+  const [principal, setPrincipal] = useState<number>(DEFAULT_PRINCIPAL);
+  const [activeIndex, setActiveIndex] = useState<number>(LAST_INDEX);
+
+  const safeApy = Number.isFinite(apy) && apy > 0 ? apy : 5;
+  const series = useMemo(() => buildProjectionSeries(principal, safeApy), [principal, safeApy]);
+
+  const clampedIndex = Math.min(Math.max(activeIndex, 0), series.length - 1);
+  const futureBalance = series[clampedIndex]?.value ?? principal;
+  const earned = Math.max(futureBalance - principal, 0);
+  const horizonLabel = formatHorizonLabel(clampedIndex);
+
+  return (
+    <View className="mx-4 gap-4 rounded-twice bg-card p-5">
+      <View className="flex-row items-center justify-between">
+        <Text className="text-lg font-semibold text-white">Simulate your savings</Text>
+        <AmountDropdown amount={principal} onSelect={setPrincipal} />
+      </View>
+
+      <View className="gap-0.5">
+        <Text className="text-sm font-medium text-muted-foreground">Future Balance</Text>
+        <CountUp
+          prefix="$"
+          count={futureBalance}
+          decimalPlaces={0}
+          isTrailingZero={false}
+          animateOnMount={false}
+          styles={{ wholeText: FUTURE_STYLE }}
+        />
+        <View className="flex-row items-baseline gap-1">
+          <CountUp
+            prefix="$"
+            count={earned}
+            decimalPlaces={0}
+            isTrailingZero={false}
+            animateOnMount={false}
+            styles={{ wholeText: EARNED_STYLE }}
+          />
+          <Text className="text-sm text-muted-foreground">Earned in {horizonLabel}</Text>
+        </View>
+      </View>
+
+      <SimulateChart
+        data={series}
+        activeIndex={clampedIndex}
+        onActiveIndexChange={setActiveIndex}
+      />
+    </View>
+  );
+};
+
+export default SimulateSavingsCard;

--- a/components/Savings/NewSavings/StartEarningButton.tsx
+++ b/components/Savings/NewSavings/StartEarningButton.tsx
@@ -1,0 +1,54 @@
+import { Pressable, View } from 'react-native';
+
+import DepositTrigger from '@/components/DepositOption/DepositTrigger';
+import { Text } from '@/components/ui/text';
+import { DEPOSIT_MODAL } from '@/constants/modals';
+import { VAULTS } from '@/constants/vaults';
+import { VaultType } from '@/lib/types';
+import { cn } from '@/lib/utils';
+import { useDepositStore } from '@/store/useDepositStore';
+import { useSavingStore } from '@/store/useSavingStore';
+
+// DepositTrigger injects its open handler via SlotTrigger.cloneElement({ onPress }),
+// so this trigger MUST forward props to its root Pressable (same rule as the
+// home WalletActions triggers).
+const StartEarningTrigger = (props: React.ComponentProps<typeof Pressable>) => (
+  <Pressable
+    {...props}
+    className="h-14 w-full flex-row items-center justify-center rounded-full bg-white transition-all active:scale-95 active:opacity-80"
+  >
+    <Text className="text-base font-bold text-black">Start earning</Text>
+  </Pressable>
+);
+
+interface StartEarningButtonProps {
+  /** Vault to pre-select for the deposit (mirrors the chosen APY vault). */
+  vaultType: VaultType;
+  className?: string;
+}
+
+/**
+ * Full-width white "Start earning" CTA. Opens the shared savings deposit flow
+ * (deposit-from-Solid) pre-selecting the currently chosen vault.
+ */
+const StartEarningButton = ({ vaultType, className }: StartEarningButtonProps) => {
+  return (
+    <View className={cn('px-4', className)}>
+      <DepositTrigger
+        modal={DEPOSIT_MODAL.OPEN_FORM}
+        preserveSelectedVault
+        source="savings_start_earning"
+        onBeforeOpen={() => {
+          const index = VAULTS.findIndex(vault => vault.type === vaultType);
+          if (index >= 0) {
+            useSavingStore.getState().selectVaultForDeposit(index);
+          }
+          useDepositStore.getState().setDepositFromSolid(true);
+        }}
+        trigger={<StartEarningTrigger />}
+      />
+    </View>
+  );
+};
+
+export default StartEarningButton;

--- a/components/Savings/NewSavings/savingsProjection.ts
+++ b/components/Savings/NewSavings/savingsProjection.ts
@@ -1,0 +1,42 @@
+import { ChartPayload } from '@/lib/types';
+
+/** Simulation horizon and sampling for the "Simulate your savings" chart. */
+export const SIMULATE_YEARS = 10;
+const POINTS_PER_YEAR = 12; // monthly samples → a smooth curve
+const MONTH_MS = 30 * 24 * 60 * 60 * 1000;
+// Fixed base time so the series is stable across renders (x is only used for
+// ordering; the chart shows no date axis).
+const BASE_TIME = 1704067200000; // 2024-01-01
+
+/**
+ * Compound-growth projection: value(t) = principal * (1 + apy)^t over
+ * SIMULATE_YEARS, sampled monthly. Returns ChartPayload[] for the chart and the
+ * future-balance / earned readouts.
+ */
+export const buildProjectionSeries = (principal: number, apyPercent: number): ChartPayload[] => {
+  const rate = Math.max(apyPercent, 0) / 100;
+  const totalMonths = SIMULATE_YEARS * POINTS_PER_YEAR;
+  const series: ChartPayload[] = [];
+  for (let month = 0; month <= totalMonths; month++) {
+    const years = month / POINTS_PER_YEAR;
+    const value = principal * Math.pow(1 + rate, years);
+    series.push({ time: BASE_TIME + month * MONTH_MS, value });
+  }
+  return series;
+};
+
+/** Number of months represented by a series index (0-based). */
+export const indexToYears = (index: number) => index / POINTS_PER_YEAR;
+
+/** Human label for a fractional-year position, e.g. "10 years" / "6 months". */
+export const formatHorizonLabel = (index: number) => {
+  const years = indexToYears(index);
+  if (years < 1) {
+    const months = Math.round(years * 12);
+    return `${months} month${months === 1 ? '' : 's'}`;
+  }
+  const rounded = Math.round(years * 10) / 10;
+  const isWhole = rounded % 1 === 0;
+  const display = isWhole ? rounded.toFixed(0) : rounded.toFixed(1);
+  return `${display} year${rounded === 1 ? '' : 's'}`;
+};

--- a/components/Savings/NewSavings/savingsVaultData.ts
+++ b/components/Savings/NewSavings/savingsVaultData.ts
@@ -1,0 +1,38 @@
+import { VAULTS } from '@/constants/vaults';
+import { VaultType } from '@/lib/types';
+
+import type { AssetPath } from '@/lib/assets';
+
+/** Per-vault max APY + loading flag, keyed by VaultType. */
+export type ApyByType = Record<VaultType, { maxAPY: number; isAPYsLoading: boolean }>;
+
+/** Friendly display names for the redesigned savings UI (mockup wording). */
+const DISPLAY_NAMES: Record<VaultType, string> = {
+  [VaultType.USDC]: 'USDC',
+  [VaultType.FUSE]: 'Fuse',
+  [VaultType.ETH]: 'Ethereum',
+};
+
+export type SavingsVaultDisplay = {
+  type: VaultType;
+  name: string;
+  icon: AssetPath;
+  index: number;
+};
+
+/** Ordered list [USDC, FUSE, ETH] with display name + icon, for the vault rows. */
+export const SAVINGS_VAULTS: SavingsVaultDisplay[] = VAULTS.map((vault, index) => ({
+  type: vault.type,
+  name: DISPLAY_NAMES[vault.type] ?? vault.name,
+  icon: vault.icon,
+  index,
+}));
+
+export const getVaultDisplay = (type: VaultType): SavingsVaultDisplay =>
+  SAVINGS_VAULTS.find(vault => vault.type === type) ?? SAVINGS_VAULTS[0];
+
+/** APY formatted for display, e.g. "6.5% APY". Falls back to "—% APY" while loading. */
+export const formatApyLabel = (apy: number | undefined, isLoading: boolean) => {
+  if (isLoading || apy === undefined) return '—';
+  return `${apy.toFixed(1)}%`;
+};


### PR DESCRIPTION
Adds redesigned Savings and Rewards screens for whitelisted internal users (useIsTestUser), mirroring the new home screen. Public users and all desktop-web users keep the existing screens via the same dispatcher pattern (useIsTestUser() && !isDesktop) in savings.tsx and rewards/index.tsx.

Savings (components/Savings/NewSavings):
- Big 'Savings Balance' headline (useTotalSavingsUSD) reusing the home CountUp treatment.
- APY pill → per-vault APY breakdown sheet (USDC/Fuse/Ethereum), default USDC; selecting a vault drives the pill + simulation.
- Full-width 'Start earning' white CTA (shared deposit-from-Solid flow).
- 'Simulate your savings' card: amount dropdown (100/1,000/10,000 in one row), compound-growth projection, and a draggable chart handle (wagmi cursor on native, recharts on web) that animates the future-balance + earned readouts via the existing CountUp.
- 'More savings options' rows for the other vaults.
- Reusable SelectSheet primitive (Gorhom bottom sheet on native, Dialog on web), matching the home OtherBalancesDropdown split.

Rewards (components/Rewards/NewRewards):
- Current-tier + compact points headline ('Prime' / '10.5M pt's').
- 'Invite friends' → referral program popup (ReferralProgramModal); 'Explore tiers' → rewards benefits screen.
- Rewards summary card (combined total, Cashback + Referrals columns).
- 'Your daily benefits' — the current tier's 3 benefits only (per-tier config); full tier comparison stays on the benefits screen.
- Preserves the legacy loading / error / opt-in (welcome popup) + referral deep-link handling.


Claude-Session: https://claude.ai/code/session_0141JefqAksx9sMJvtBXg8Go