### PR TITLE
feat(card): whitelisted card details screen with hero transition

### DIFF
--- a/app/(protected)/(tabs)/card/_layout.tsx
+++ b/app/(protected)/(tabs)/card/_layout.tsx
@@ -7,6 +7,9 @@ export default function CardLayout() {
       <Stack.Screen name="ready" />
       <Stack.Screen name="pending" />
       <Stack.Screen name="activate" />
+      {/* Fade (not slide) so the card view-transition from the wallet reads as a
+          continuous move rather than fighting a horizontal push. */}
+      <Stack.Screen name="details" options={{ animation: 'fade' }} />
     </Stack>
   );
 }

--- a/app/(protected)/(tabs)/card/details.tsx
+++ b/app/(protected)/(tabs)/card/details.tsx
@@ -22,6 +22,9 @@ import CardWelcomePopup from '@/components/Card/CardWelcomePopup';
 import { CircularActionButton } from '@/components/Card/CircularActionButton';
 import { CreditLineCards } from '@/components/Card/CreditLine/CreditLineCards';
 import ManagePinModal from '@/components/Card/ManagePinModal';
+import CardBalanceHeadline from '@/components/Card/NewCardDetails/CardBalanceHeadline';
+import CardHeroImage from '@/components/Card/NewCardDetails/CardHeroImage';
+import ShowDetailsButton from '@/components/Card/NewCardDetails/ShowDetailsButton';
 import WithdrawToCardModal from '@/components/Card/WithdrawToCardModal';
 import PageLayout from '@/components/PageLayout';
 import { Button } from '@/components/ui/button';
@@ -45,6 +48,7 @@ import { useCardProvider } from '@/hooks/useCardProvider';
 import { useCardWithdrawals } from '@/hooks/useCardWithdrawals';
 import { useCustomer } from '@/hooks/useCustomer';
 import { useDimension } from '@/hooks/useDimension';
+import { useIsTestUser } from '@/hooks/useIsTestUser';
 import { freezeCard, unfreezeCard } from '@/lib/api';
 import { getAsset } from '@/lib/assets';
 import { isProduction } from '@/lib/config';
@@ -57,6 +61,10 @@ export default function CardDetails() {
   const { provider } = useCardProvider();
   const { data: customer } = useCustomer();
   const { isScreenMedium } = useDimension();
+  // Whitelisted internal users get the redesigned mobile card screen (Card
+  // Balance headline, full-row Show details, card view-transition). Public users
+  // and desktop keep the existing layout untouched.
+  const isTestUser = useIsTestUser();
 
   useCardWithdrawals({ limit: 10 }, { refetchInterval: 300000 });
 
@@ -217,22 +225,37 @@ export default function CardDetails() {
   }
 
   // Mobile layout
+  const cardImageSection = (
+    <CardImageSection
+      isScreenMedium={isScreenMedium}
+      isCardFrozen={isCardFrozen}
+      flipAnimation={flipAnimation}
+      isCardFlipped={isCardFlipped}
+      cardholderName={cardDetails?.cardholder_name}
+      shouldRevealDetails={shouldRevealDetails}
+      onCardDetailsLoaded={handleCardDetailsLoaded}
+      provider={provider}
+    />
+  );
+
   return (
     <PageLayout isLoading={isLoading}>
       {pageHeader}
       <View className="mx-auto w-full max-w-lg px-4">
         <View className="flex-1">
-          <BalanceDisplay amount={availableAmount} />
-          <CardImageSection
-            isScreenMedium={isScreenMedium}
-            isCardFrozen={isCardFrozen}
-            flipAnimation={flipAnimation}
-            isCardFlipped={isCardFlipped}
-            cardholderName={cardDetails?.cardholder_name}
-            shouldRevealDetails={shouldRevealDetails}
-            onCardDetailsLoaded={handleCardDetailsLoaded}
-            provider={provider}
-          />
+          {isTestUser ? (
+            <CardBalanceHeadline amount={availableAmount} />
+          ) : (
+            <BalanceDisplay amount={availableAmount} />
+          )}
+          {isTestUser ? <CardHeroImage>{cardImageSection}</CardHeroImage> : cardImageSection}
+          {isTestUser && (
+            <ShowDetailsButton
+              isFlipped={isCardFlipped}
+              isLoading={isLoadingCardDetails}
+              onPress={handleCardFlip}
+            />
+          )}
           <CardActions
             isCardFrozen={isCardFrozen}
             canUnfreeze={!!canUnfreeze}
@@ -243,6 +266,7 @@ export default function CardDetails() {
             onFreezeToggle={handleFreezeToggle}
             isWithdrawFromCardAllowed={isWithdrawFromCardAllowed}
             isRain={provider === CardProvider.RAIN}
+            hideCardDetailsButton={isTestUser}
           />
           <CreditLineCards className="mb-4" />
           <CashbackDisplay cashback={cardDetails?.cashback} />
@@ -786,6 +810,8 @@ interface CardActionsProps {
   onFreezeToggle: () => Promise<void>;
   isWithdrawFromCardAllowed: boolean;
   isRain: boolean;
+  /** Hide the circular "Card details" action (whitelisted screen uses a full-row button instead). */
+  hideCardDetailsButton?: boolean;
 }
 
 function CardActions({
@@ -798,6 +824,7 @@ function CardActions({
   onFreezeToggle,
   isWithdrawFromCardAllowed,
   isRain,
+  hideCardDetailsButton = false,
 }: CardActionsProps) {
   const [isManageSheetOpen, setIsManageSheetOpen] = useState(false);
   const showManageButton = isRain || !isCardFrozen || canUnfreeze;
@@ -815,23 +842,25 @@ function CardActions({
           }
         />
       )}
-      <View className="items-center">
-        <Pressable
-          onPress={onCardDetails}
-          className="items-center justify-center rounded-full bg-[#303030] web:hover:opacity-70"
-          style={{ width: 50, height: 50 }}
-          disabled={isLoadingCardDetails}
-        >
-          {isLoadingCardDetails ? (
-            <ActivityIndicator size="small" color="#BFBFBF" />
-          ) : (
-            <Asterisk size={24} color="#BFBFBF" />
-          )}
-        </Pressable>
-        <Text className="mt-2 text-[#BFBFBF]">
-          {isCardFlipped ? 'Hide details' : 'Card details'}
-        </Text>
-      </View>
+      {!hideCardDetailsButton && (
+        <View className="items-center">
+          <Pressable
+            onPress={onCardDetails}
+            className="items-center justify-center rounded-full bg-[#303030] web:hover:opacity-70"
+            style={{ width: 50, height: 50 }}
+            disabled={isLoadingCardDetails}
+          >
+            {isLoadingCardDetails ? (
+              <ActivityIndicator size="small" color="#BFBFBF" />
+            ) : (
+              <Asterisk size={24} color="#BFBFBF" />
+            )}
+          </Pressable>
+          <Text className="mt-2 text-[#BFBFBF]">
+            {isCardFlipped ? 'Hide details' : 'Card details'}
+          </Text>
+        </View>
+      )}
       {showManageButton && (
         <Dialog open={isManageSheetOpen} onOpenChange={setIsManageSheetOpen}>
           <DialogTrigger asChild>

--- a/components/Card/NewCardDetails/CardBalanceHeadline.tsx
+++ b/components/Card/NewCardDetails/CardBalanceHeadline.tsx
@@ -1,0 +1,45 @@
+import { TextStyle, View } from 'react-native';
+
+import CountUp from '@/components/CountUp';
+import { Text } from '@/components/ui/text';
+
+// Same 50px Mona Sans treatment (greyed decimals) as the redesigned Wallet /
+// Savings headlines, so the card screen matches.
+const WHOLE_STYLE: TextStyle = {
+  fontSize: 50,
+  fontWeight: '500',
+  fontFamily: 'MonaSans_500Medium',
+  color: '#ffffff',
+};
+const DECIMAL_STYLE: TextStyle = { ...WHOLE_STYLE, color: '#666666' };
+const SEPARATOR_STYLE: TextStyle = { ...WHOLE_STYLE };
+
+interface CardBalanceHeadlineProps {
+  /** Spendable card balance as a string (from cardDetails.balances.available.amount). */
+  amount: string;
+}
+
+/** "Card Balance" label + big number, shown above the card image (whitelisted). */
+const CardBalanceHeadline = ({ amount }: CardBalanceHeadlineProps) => {
+  const value = Number.parseFloat(amount) || 0;
+
+  return (
+    <View className="items-center gap-1 pt-2">
+      <Text className="text-base font-medium text-muted-foreground">Card Balance</Text>
+      <CountUp
+        prefix="$"
+        count={value}
+        decimalPlaces={2}
+        animateOnMount={false}
+        classNames={{ wrapper: 'text-foreground' }}
+        styles={{
+          wholeText: WHOLE_STYLE,
+          decimalText: DECIMAL_STYLE,
+          decimalSeparator: SEPARATOR_STYLE,
+        }}
+      />
+    </View>
+  );
+};
+
+export default CardBalanceHeadline;

--- a/components/Card/NewCardDetails/CardHeroImage.tsx
+++ b/components/Card/NewCardDetails/CardHeroImage.tsx
@@ -1,0 +1,85 @@
+import { useEffect, useRef, useState } from 'react';
+import { View } from 'react-native';
+import Animated, {
+  Easing,
+  runOnJS,
+  useAnimatedStyle,
+  useSharedValue,
+  withTiming,
+} from 'react-native-reanimated';
+
+import { useCardHeroStore } from '@/store/useCardHeroStore';
+
+const TIMING = { duration: 400, easing: Easing.out(Easing.cubic) };
+
+/**
+ * Wraps the card image on the new card-details screen and, when arriving from
+ * the home wallet card (fromRect set in useCardHeroStore), animates the card
+ * from that window rect up to its resting position — a lightweight "view
+ * transition" for the card. Measures its own resting rect, so it tracks the real
+ * home-card position. Degrades to a no-op when there's no fromRect (e.g. direct
+ * navigation) or measurement is unavailable.
+ */
+const CardHeroImage = ({ children }: { children: React.ReactNode }) => {
+  const fromRect = useCardHeroStore(state => state.fromRect);
+  const clear = useCardHeroStore(state => state.clear);
+
+  const measureRef = useRef<View>(null);
+  const tx = useSharedValue(0);
+  const ty = useSharedValue(0);
+  const scale = useSharedValue(1);
+  // Start hidden only when a hero is pending, so we don't flash the resting
+  // position before measuring.
+  const opacity = useSharedValue(fromRect ? 0 : 1);
+  const [done, setDone] = useState(false);
+
+  useEffect(() => {
+    if (!fromRect || done) return;
+
+    const raf = requestAnimationFrame(() => {
+      const node = measureRef.current;
+      if (!node) {
+        opacity.value = 1;
+        return;
+      }
+      node.measureInWindow((x, y, width, height) => {
+        setDone(true);
+        if (!width || !height) {
+          opacity.value = 1;
+          clear();
+          return;
+        }
+        const fromCx = fromRect.x + fromRect.width / 2;
+        const fromCy = fromRect.y + fromRect.height / 2;
+        const toCx = x + width / 2;
+        const toCy = y + height / 2;
+
+        tx.value = fromCx - toCx;
+        ty.value = fromCy - toCy;
+        scale.value = fromRect.width / width;
+        opacity.value = 1;
+
+        tx.value = withTiming(0, TIMING);
+        ty.value = withTiming(0, TIMING);
+        scale.value = withTiming(1, TIMING, finished => {
+          if (finished) runOnJS(clear)();
+        });
+      });
+    });
+
+    return () => cancelAnimationFrame(raf);
+  }, [fromRect, done, tx, ty, scale, opacity, clear]);
+
+  const animatedStyle = useAnimatedStyle(() => ({
+    opacity: opacity.value,
+    transform: [{ translateX: tx.value }, { translateY: ty.value }, { scale: scale.value }],
+  }));
+
+  return (
+    <View ref={measureRef} collapsable={false}>
+      <Animated.View style={animatedStyle}>{children}</Animated.View>
+    </View>
+  );
+};
+
+export default CardHeroImage;

--- a/components/Card/NewCardDetails/ShowDetailsButton.tsx
+++ b/components/Card/NewCardDetails/ShowDetailsButton.tsx
@@ -1,0 +1,38 @@
+import { ActivityIndicator, Pressable } from 'react-native';
+import { Eye, EyeOff } from 'lucide-react-native';
+
+import { Text } from '@/components/ui/text';
+
+interface ShowDetailsButtonProps {
+  /** Whether the card is currently flipped to reveal details. */
+  isFlipped: boolean;
+  isLoading: boolean;
+  onPress: () => void;
+}
+
+/**
+ * Full-row "Show details" / "Hide details" button (lucide eye open/close),
+ * replacing the small circular "Card details" action for whitelisted users.
+ */
+const ShowDetailsButton = ({ isFlipped, isLoading, onPress }: ShowDetailsButtonProps) => {
+  return (
+    <Pressable
+      onPress={onPress}
+      disabled={isLoading}
+      className="mb-6 h-14 flex-row items-center justify-center gap-2 rounded-full bg-[#1C1C1C] transition-all active:scale-95 active:opacity-80"
+    >
+      {isLoading ? (
+        <ActivityIndicator size="small" color="white" />
+      ) : isFlipped ? (
+        <EyeOff size={20} color="white" />
+      ) : (
+        <Eye size={20} color="white" />
+      )}
+      <Text className="text-base font-bold text-white">
+        {isFlipped ? 'Hide details' : 'Show details'}
+      </Text>
+    </Pressable>
+  );
+};
+
+export default ShowDetailsButton;

--- a/components/Home/NewHome/HomeWalletCard.tsx
+++ b/components/Home/NewHome/HomeWalletCard.tsx
@@ -1,9 +1,11 @@
-import { Pressable } from 'react-native';
+import { useRef } from 'react';
+import { Pressable, View } from 'react-native';
 import { Image } from 'expo-image';
 import { useRouter } from 'expo-router';
 
 import { path } from '@/constants/path';
 import { getAsset } from '@/lib/assets';
+import { useCardHeroStore } from '@/store/useCardHeroStore';
 
 // Intrinsic size of assets/images/visa-platinum-card.png (includes the card's
 // drop shadow), used to render the artwork full-width without distortion.
@@ -17,11 +19,13 @@ interface HomeWalletCardProps {
 /**
  * The merged green VISA Platinum "glass" card shown on the wallet page. Always
  * displayed; only navigates to the card management page (/card/details) once the
- * user actually has a card. The card artwork — including the "•••" menu glyph and
- * the "VISA Platinum" wordmark — is baked into the image.
+ * user actually has a card. On tap it records its window rect (useCardHeroStore)
+ * so the card-details screen can animate the card up from here.
  */
 const HomeWalletCard = ({ hasCard }: HomeWalletCardProps) => {
   const router = useRouter();
+  const setFromRect = useCardHeroStore(state => state.setFromRect);
+  const ref = useRef<View>(null);
 
   const card = (
     <Image
@@ -36,7 +40,26 @@ const HomeWalletCard = ({ hasCard }: HomeWalletCardProps) => {
     return card;
   }
 
-  return <Pressable onPress={() => router.push(path.CARD_DETAILS)}>{card}</Pressable>;
+  const handlePress = () => {
+    const node = ref.current;
+    if (!node) {
+      router.push(path.CARD_DETAILS);
+      return;
+    }
+    // Capture the card's position, then navigate (measureInWindow is async).
+    node.measureInWindow((x, y, width, height) => {
+      if (width && height) {
+        setFromRect({ x, y, width, height });
+      }
+      router.push(path.CARD_DETAILS);
+    });
+  };
+
+  return (
+    <Pressable ref={ref} collapsable={false} onPress={handlePress}>
+      {card}
+    </Pressable>
+  );
 };
 
 export default HomeWalletCard;

--- a/store/useCardHeroStore.ts
+++ b/store/useCardHeroStore.ts
@@ -1,0 +1,21 @@
+import { create } from 'zustand';
+
+export type CardHeroRect = { x: number; y: number; width: number; height: number };
+
+interface CardHeroState {
+  /**
+   * Window-space rect of the home wallet card at the moment it was tapped.
+   * The new card-details screen animates its card from here to its resting
+   * position (a lightweight "view transition"), then clears it. Transient — not
+   * persisted.
+   */
+  fromRect: CardHeroRect | null;
+  setFromRect: (rect: CardHeroRect) => void;
+  clear: () => void;
+}
+
+export const useCardHeroStore = create<CardHeroState>(set => ({
+  fromRect: null,
+  setFromRect: rect => set({ fromRect: rect }),
+  clear: () => set({ fromRect: null }),
+}));


### PR DESCRIPTION
For internal test users only (isTestUser); public + desktop unchanged.

- Card Balance headline + big amount above the card image (mirrors the new Wallet/Savings headlines), replacing the small spendable-balance row.
- Full-row "Show details" / "Hide details" button (lucide eye open/close), replacing the circular "Card details" action (hidden via new hideCardDetailsButton prop on CardActions).
- Card view-transition: tapping the home wallet card records its window rect (useCardHeroStore); the details card animates up from that rect to its resting position (Reanimated translate + scale), masked by a route fade on the card/details screen.


Claude-Session: https://claude.ai/code/session_0141JefqAksx9sMJvtBXg8Go