### PR TITLE
Add smargonaq1 to test features allow list

### DIFF
--- a/lib/utils/testFeatures.ts
+++ b/lib/utils/testFeatures.ts
@@ -11,6 +11,7 @@ export const TEST_FEATURES_ALLOW_LIST = [
   'maxxb.34980',
   'cimal67977',
   'vesas62360',
+  'smargonaq1',
 ];
 
 export const isUserAllowedToUseTestFeature = (username: string) => {


### PR DESCRIPTION
## Summary
Added a new user to the test features allow list to grant access to experimental features.

## Changes
- Added `smargonaq1` to the `TEST_FEATURES_ALLOW_LIST` in `lib/utils/testFeatures.ts`

## Details
This change enables the user `smargonaq1` to access and test features that are currently behind the test features flag. The user will now be able to use any features gated by the `isUserAllowedToUseTestFeature()` function.

https://claude.ai/code/session_01Dq5zCczHKTfpUmtcuYz5hN