### PR TITLE
fix(card): smoother hero transition + reveal left padding

### DIFF
--- a/app/(protected)/(tabs)/card/_layout.tsx
+++ b/app/(protected)/(tabs)/card/_layout.tsx
@@ -7,9 +7,10 @@ export default function CardLayout() {
       <Stack.Screen name="ready" />
       <Stack.Screen name="pending" />
       <Stack.Screen name="activate" />
-      {/* Fade (not slide) so the card view-transition from the wallet reads as a
-          continuous move rather than fighting a horizontal push. */}
-      <Stack.Screen name="details" options={{ animation: 'fade' }} />
+      {/* No screen animation: the card hero overlay is the only motion, so the
+          details screen swaps in instantly (opaque) while the card flies to it,
+          instead of a fade competing with the transition. */}
+      <Stack.Screen name="details" options={{ animation: 'none' }} />
     </Stack>
   );
 }

--- a/app/(protected)/(tabs)/card/details.tsx
+++ b/app/(protected)/(tabs)/card/details.tsx
@@ -243,7 +243,11 @@ export default function CardDetails() {
   );
 
   return (
-    <PageLayout isLoading={isLoading}>
+    // Whitelisted screen renders immediately (never the full-screen loader): the
+    // card must be laid out right away so the hero transition can measure its
+    // destination and land smoothly. Data fills in as it arrives (balance/last-4
+    // are usually already warm from the home screen's query).
+    <PageLayout isLoading={isTestUser ? false : isLoading}>
       {/* Whitelisted screen drops the "Card" heading (Card Balance headline
           takes its place); public/desktop keep the heading. */}
       {!isTestUser && pageHeader}
@@ -761,7 +765,12 @@ function CardDetailsOverlay({
   // opacity 0 until the flip completes.
   return (
     <View
-      style={!visible ? styles.cardDetailsHidden : undefined}
+      style={[
+        !visible ? styles.cardDetailsHidden : null,
+        // The green card's artwork has ~6% transparent shadow on the left, so the
+        // default p-6 lands the details flush against the card body. Inset more.
+        isDark ? styles.revealDarkContent : null,
+      ]}
       className={cn(
         'absolute inset-0 justify-center rounded-2xl p-6',
         visible ? 'mt-12 md:mt-24' : 'mt-24',
@@ -1097,6 +1106,9 @@ const styles = StyleSheet.create({
 
   // Card details overlay
   cardDetailsHidden: { opacity: 0, pointerEvents: 'none' },
+  // Extra left inset for the reveal on the green card (clears the artwork shadow
+  // + gives the card number breathing room from the card body's edge).
+  revealDarkContent: { paddingLeft: '13%' },
   // Cashback display
   cashbackDivider: {
     height: 1,

--- a/components/Card/NewCardDetails/CardHeroOverlay.tsx
+++ b/components/Card/NewCardDetails/CardHeroOverlay.tsx
@@ -38,12 +38,16 @@ const CardHeroOverlay = () => {
   useEffect(() => {
     if (!active || !fromRect) return;
 
-    // Before the destination is measured, hold the clone at the source rect.
+    // Before the destination is measured, hold the clone at the source rect and
+    // arm a fallback so a screen that never lays out can't leave it stuck. Once
+    // toRect arrives this effect re-runs, clearing the timer (so it never cuts a
+    // real animation) and starting the flight, which ends itself on completion.
     if (!toRect) {
       tx.value = 0;
       ty.value = 0;
       scale.value = 1;
-      return;
+      const timer = setTimeout(() => end(), FALLBACK_MS);
+      return () => clearTimeout(timer);
     }
 
     const fromCx = fromRect.x + fromRect.width / 2;
@@ -57,12 +61,6 @@ const CardHeroOverlay = () => {
       if (finished) runOnJS(end)();
     });
   }, [active, fromRect, toRect, tx, ty, scale, end]);
-
-  useEffect(() => {
-    if (!active) return;
-    const timer = setTimeout(() => end(), FALLBACK_MS);
-    return () => clearTimeout(timer);
-  }, [active, end]);
 
   const animatedStyle = useAnimatedStyle(() => ({
     transform: [{ translateX: tx.value }, { translateY: ty.value }, { scale: scale.value }],


### PR DESCRIPTION
1. Transition glitch was the details screen's loading state: PageLayout renders a full-screen spinner while card data loads, so the destination card wasn't laid out and the flying clone froze at the source then jumped into place. The whitelisted screen now renders its content immediately (data fills in as it arrives, usually already warm from the home query), so the hero's destination is measured right away. Also:
   - card/details screen animation set to 'none' so the route transition no longer competes with the hero overlay (the card is the only motion).
   - hero fallback timer now only guards the "destination never measured" case and can't cut a running flight animation.
2. Add left padding to the revealed card details (number/expiry/CVV) on the green card — the artwork's ~6% shadow made the default p-6 sit flush against the card body.


Claude-Session: https://claude.ai/code/session_0141JefqAksx9sMJvtBXg8Go