### PR TITLE
fix(card): glass oval (no blur), wider peek button, tighter card gap

### DIFF
--- a/app/(protected)/(tabs)/card/details.tsx
+++ b/app/(protected)/(tabs)/card/details.tsx
@@ -54,6 +54,7 @@ import { getAsset } from '@/lib/assets';
 import { isProduction } from '@/lib/config';
 import { CardHolderName, CardProvider, CardStatus, FreezeInitiator, KycStatus } from '@/lib/types';
 import { cn } from '@/lib/utils/utils';
+import { useCardHeroStore } from '@/store/useCardHeroStore';
 import { useCardWelcomePopupStore } from '@/store/useCardWelcomePopupStore';
 
 export default function CardDetails() {
@@ -65,6 +66,9 @@ export default function CardDetails() {
   // Balance headline, full-row Show details, card view-transition). Public users
   // and desktop keep the existing layout untouched.
   const isTestUser = useIsTestUser();
+  // While the card hero transition is flying, the real card is hidden; hide the
+  // peek button too so it doesn't sit detached under the empty card slot.
+  const heroActive = useCardHeroStore(state => state.active);
 
   useCardWithdrawals({ limit: 10 }, { refetchInterval: 300000 });
 
@@ -263,6 +267,7 @@ export default function CardDetails() {
               </View>
               <ShowDetailsButton
                 peek
+                hidden={heroActive}
                 isFlipped={isCardFlipped}
                 isLoading={isLoadingCardDetails}
                 onPress={handleCardFlip}

--- a/components/Card/NewCardDetails/CardGlyphBadge.tsx
+++ b/components/Card/NewCardDetails/CardGlyphBadge.tsx
@@ -1,5 +1,4 @@
 import { StyleSheet, View } from 'react-native';
-import { BlurView } from 'expo-blur';
 
 import { Text } from '@/components/ui/text';
 
@@ -16,53 +15,35 @@ interface CardGlyphBadgeProps {
 }
 
 /**
- * The frosted-glass oval ("••••" glyph + optional last-4 digits) shown on the
- * bottom-left of the VISA Platinum card. Drawn in code (the baked-in oval was
- * removed from the artwork) to mirror the Figma "Glass" style: a white-tinted
- * blurred pill with a hairline highlight. Positioned over the card face —
- * insets are proportional so it lands in the same spot at any render width.
+ * The glass glyph oval ("••••" + optional last-4 digits) on the bottom-left of
+ * the VISA Platinum card, drawn in code (the baked-in oval was removed from the
+ * artwork). Matches the Figma element: a translucent white pill (#FFFFFF @ 20%)
+ * over the card — no backdrop blur, so the card colour reads through as glass
+ * rather than an opaque white fill. Chunky 60×40-style padding around small dots.
  */
 const CardGlyphBadge = ({ last4, cardWidth }: CardGlyphBadgeProps) => {
   const scale = cardWidth && cardWidth > 0 ? cardWidth / REF_CARD_WIDTH : 1;
   const s = (n: number) => Math.round(n * scale * 100) / 100;
 
   const dot = s(5);
-  const gap = s(4);
+  const gap = s(6);
 
   return (
     <View style={styles.anchor} pointerEvents="none">
-      <View style={[styles.pill, { borderRadius: 999 }]}>
-        {/* experimentalBlurMethod enables real Gaussian blur on Android (default
-            is a flat tint there, which lets the card's line texture show
-            through); higher intensity fully frosts over the lines. */}
-        <BlurView
-          intensity={60}
-          tint="light"
-          experimentalBlurMethod="dimezisBlurView"
-          style={StyleSheet.absoluteFill}
-        />
-        <View style={[styles.content, { paddingHorizontal: s(10), paddingVertical: s(6), gap }]}>
-          <View style={{ flexDirection: 'row', gap }}>
-            {[0, 1, 2, 3].map(i => (
-              <View
-                key={i}
-                style={{
-                  width: dot,
-                  height: dot,
-                  borderRadius: dot / 2,
-                  backgroundColor: '#ffffff',
-                }}
-              />
-            ))}
-          </View>
-          {last4 ? (
-            <Text
-              style={{ color: '#ffffff', fontSize: s(13), fontWeight: '600', lineHeight: s(15) }}
-            >
-              {last4}
-            </Text>
-          ) : null}
+      <View style={[styles.pill, { paddingHorizontal: s(14), paddingVertical: s(11), gap }]}>
+        <View style={{ flexDirection: 'row', gap }}>
+          {[0, 1, 2, 3].map(i => (
+            <View
+              key={i}
+              style={{ width: dot, height: dot, borderRadius: dot / 2, backgroundColor: '#ffffff' }}
+            />
+          ))}
         </View>
+        {last4 ? (
+          <Text style={{ color: '#ffffff', fontSize: s(13), fontWeight: '600', lineHeight: s(15) }}>
+            {last4}
+          </Text>
+        ) : null}
       </View>
     </View>
   );
@@ -72,15 +53,15 @@ const styles = StyleSheet.create({
   // Bottom-left of the card face. The artwork has ~5.6% shadow on the left and
   // ~10% on the bottom, so these insets keep the pill just inside the face.
   anchor: { position: 'absolute', left: '9%', bottom: '14%' },
-  pill: { overflow: 'hidden' },
-  content: {
+  pill: {
     flexDirection: 'row',
     alignItems: 'center',
-    // Figma fill: #FFFFFF @ 20%.
+    overflow: 'hidden',
+    // Figma fill: #FFFFFF @ 20% (translucent — the card shows through as glass).
     backgroundColor: 'rgba(255,255,255,0.2)',
     borderRadius: 999,
     borderWidth: StyleSheet.hairlineWidth,
-    borderColor: 'rgba(255,255,255,0.35)',
+    borderColor: 'rgba(255,255,255,0.25)',
   },
 });
 

--- a/components/Card/NewCardDetails/ShowDetailsButton.tsx
+++ b/components/Card/NewCardDetails/ShowDetailsButton.tsx
@@ -11,10 +11,12 @@ interface ShowDetailsButtonProps {
   onPress: () => void;
   /**
    * When true, render as a "drawer" that peeks out from behind the card image
-   * (top edge tucked under the card, only bottom corners rounded, content padded
-   * down below the overlap) — mirrors the coins screen's "Earning yield" banner.
+   * (top edge tucked under the card, only bottom corners rounded) — mirrors the
+   * coins screen's "Earning yield" banner.
    */
   peek?: boolean;
+  /** Hidden (opacity 0) while the card hero transition is running. */
+  hidden?: boolean;
 }
 
 /**
@@ -27,6 +29,7 @@ const ShowDetailsButton = ({
   isLoading,
   onPress,
   peek = false,
+  hidden = false,
 }: ShowDetailsButtonProps) => {
   return (
     <Pressable
@@ -35,10 +38,12 @@ const ShowDetailsButton = ({
       className={cn(
         'flex-row items-center justify-center gap-2 bg-[#1C1C1C] transition-all active:scale-95 active:opacity-80',
         peek
-          ? // Tucked behind the card: pulled up under it, inset so it reads as a
-            // drawer, flat top, rounded bottom, content pushed below the overlap.
-            'mx-[8%] -mt-6 rounded-b-[28px] rounded-t-none px-6 pb-4 pt-9'
+          ? // Full width of the card (mx ≈ the card's shadow inset), tucked up
+            // behind it so it reads as a drawer: flat top, rounded bottom, pulled
+            // up far enough to sit snug under the visible card body.
+            'mx-[5.5%] -mt-8 rounded-b-[28px] rounded-t-none px-6 pb-4 pt-4'
           : 'mb-6 h-14 rounded-full',
+        hidden && 'opacity-0',
       )}
     >
       {isLoading ? (


### PR DESCRIPTION
- Card glyph oval: drop the backdrop blur (it rendered opaque white); match the Figma element exactly — a translucent #FFFFFF@20% pill so the card colour shows through as glass. Bump padding to the 60×40 proportions.
- Show details button (peek): widen to the card's width (mx ≈ shadow inset) and tuck it further up under the card (‑mt‑8, smaller top padding) so it sits snug against the card body instead of floating with a gap.
- Hide the peek button while the card hero transition is flying, so it doesn't appear detached under the (temporarily hidden) card.


Claude-Session: https://claude.ai/code/session_0141JefqAksx9sMJvtBXg8Go