### PR TITLE
fix(card): subtle glass frost on oval, remove card↔button gap

### DIFF
--- a/app/(protected)/(tabs)/card/details.tsx
+++ b/app/(protected)/(tabs)/card/details.tsx
@@ -262,7 +262,7 @@ export default function CardDetails() {
             // match the home card width. The Show details button peeks out from
             // behind it (card sits above via z-10).
             <View style={styles.fullBleedCard} className="relative mb-6">
-              <View className="z-10">
+              <View className="z-10" style={styles.cardLift}>
                 <CardHeroTarget>{cardImageSection}</CardHeroTarget>
               </View>
               <ShowDetailsButton
@@ -1092,6 +1092,11 @@ const styles = StyleSheet.create({
   // Whitelisted card: extend past the container's px-4 (16px) padding so the
   // card is as wide as the home screen card.
   fullBleedCard: { marginHorizontal: -16 },
+  // The artwork's bottom ~6.5% is transparent drop-shadow. RN resolves % margins
+  // against the parent width, and that shadow height is also ~6.5% of the card
+  // width — so this negative margin reclaims exactly the shadow's layout space at
+  // any screen size, letting the Show details button sit against the card body.
+  cardLift: { marginBottom: '-6.5%' },
 
   // Card flip animation
   cardContainer: { position: 'relative', width: '100%' },

--- a/components/Card/NewCardDetails/CardGlyphBadge.tsx
+++ b/components/Card/NewCardDetails/CardGlyphBadge.tsx
@@ -1,4 +1,5 @@
 import { StyleSheet, View } from 'react-native';
+import { BlurView } from 'expo-blur';
 
 import { Text } from '@/components/ui/text';
 
@@ -17,9 +18,10 @@ interface CardGlyphBadgeProps {
 /**
  * The glass glyph oval ("••••" + optional last-4 digits) on the bottom-left of
  * the VISA Platinum card, drawn in code (the baked-in oval was removed from the
- * artwork). Matches the Figma element: a translucent white pill (#FFFFFF @ 20%)
- * over the card — no backdrop blur, so the card colour reads through as glass
- * rather than an opaque white fill. Chunky 60×40-style padding around small dots.
+ * artwork). Approximates the Figma "Glass" effect: a light backdrop blur (low
+ * intensity, like Figma's Frost 3 — expo-blur is the closest RN primitive, as
+ * refraction/dispersion have no RN equivalent) under a translucent #FFFFFF @ 20%
+ * fill, so the card colour reads through as glass rather than an opaque white.
  */
 const CardGlyphBadge = ({ last4, cardWidth }: CardGlyphBadgeProps) => {
   const scale = cardWidth && cardWidth > 0 ? cardWidth / REF_CARD_WIDTH : 1;
@@ -31,6 +33,16 @@ const CardGlyphBadge = ({ last4, cardWidth }: CardGlyphBadgeProps) => {
   return (
     <View style={styles.anchor} pointerEvents="none">
       <View style={[styles.pill, { paddingHorizontal: s(14), paddingVertical: s(11), gap }]}>
+        {/* Light frost. experimentalBlurMethod gives real (subtle) blur on
+            Android; low intensity keeps it glassy rather than opaque white. */}
+        <BlurView
+          intensity={12}
+          tint="light"
+          experimentalBlurMethod="dimezisBlurView"
+          style={StyleSheet.absoluteFill}
+        />
+        {/* Figma fill: #FFFFFF @ 20% — the translucent glass tint. */}
+        <View style={styles.tint} pointerEvents="none" />
         <View style={{ flexDirection: 'row', gap }}>
           {[0, 1, 2, 3].map(i => (
             <View
@@ -57,11 +69,13 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
     overflow: 'hidden',
-    // Figma fill: #FFFFFF @ 20% (translucent — the card shows through as glass).
-    backgroundColor: 'rgba(255,255,255,0.2)',
     borderRadius: 999,
     borderWidth: StyleSheet.hairlineWidth,
     borderColor: 'rgba(255,255,255,0.25)',
+  },
+  tint: {
+    ...StyleSheet.absoluteFillObject,
+    backgroundColor: 'rgba(255,255,255,0.2)',
   },
 });
 

--- a/components/Card/NewCardDetails/ShowDetailsButton.tsx
+++ b/components/Card/NewCardDetails/ShowDetailsButton.tsx
@@ -39,9 +39,10 @@ const ShowDetailsButton = ({
         'flex-row items-center justify-center gap-2 bg-[#1C1C1C] transition-all active:scale-95 active:opacity-80',
         peek
           ? // Full width of the card (mx ≈ the card's shadow inset), tucked up
-            // behind it so it reads as a drawer: flat top, rounded bottom, pulled
-            // up far enough to sit snug under the visible card body.
-            'mx-[5.5%] -mt-8 rounded-b-[28px] rounded-t-none px-6 pb-4 pt-4'
+            // behind it so it reads as a drawer: flat top, rounded bottom. The
+            // card's shadow space is reclaimed by cardLift, so a small overlap
+            // sits it snug against the card body.
+            'mx-[5.5%] -mt-4 rounded-b-[28px] rounded-t-none px-6 pb-4 pt-5'
           : 'mb-6 h-14 rounded-full',
         hidden && 'opacity-0',
       )}


### PR DESCRIPTION
- Card glyph oval: re-add a low-intensity backdrop blur (expo-blur, real blur on Android via experimentalBlurMethod) layered under the translucent #FFFFFF@20% fill — approximates the Figma "Glass"/Frost look without the opaque-white result of the previous high-intensity blur. (No RN library reproduces Figma's refraction/dispersion; blur is the closest primitive.)
- Card ↔ Show details gap: the artwork's bottom ~6.5% (of width) is transparent drop-shadow that was still taking layout space. Reclaim it with a proportional negative bottom margin (RN resolves % margins against parent width, so this tracks the shadow at any screen size), so the peek button now sits snug against the card body.


Claude-Session: https://claude.ai/code/session_0141JefqAksx9sMJvtBXg8Go