### PR TITLE
fix(card): tuck peek button past rounded corners, revert oval frost t…

### DIFF
--- a/components/Card/NewCardDetails/CardGlyphBadge.tsx
+++ b/components/Card/NewCardDetails/CardGlyphBadge.tsx
@@ -35,10 +35,12 @@ const CardGlyphBadge = ({ last4, cardWidth }: CardGlyphBadgeProps) => {
   return (
     <View style={styles.anchor} pointerEvents="none">
       <View style={[styles.pill, { paddingHorizontal: s(14), paddingVertical: s(11), gap }]}>
-        {/* Frost. experimentalBlurMethod gives real blur on Android; intensity
-            tuned to hide the card lines without turning opaque white. */}
+        {/* Light frost. experimentalBlurMethod gives real (subtle) blur on
+            Android; kept low so it stays glassy rather than opaque white.
+            (Hiding the card lines fully needs a proper liquid-glass approach —
+            TBD.) */}
         <BlurView
-          intensity={40}
+          intensity={12}
           tint="light"
           experimentalBlurMethod="dimezisBlurView"
           style={StyleSheet.absoluteFill}

--- a/components/Card/NewCardDetails/ShowDetailsButton.tsx
+++ b/components/Card/NewCardDetails/ShowDetailsButton.tsx
@@ -39,10 +39,10 @@ const ShowDetailsButton = ({
         'flex-row items-center justify-center gap-2 bg-[#1C1C1C] transition-all active:scale-95 active:opacity-80',
         peek
           ? // Full width of the card (mx ≈ the card's shadow inset), tucked up
-            // behind it so it reads as a drawer: flat top, rounded bottom. The
-            // card's shadow space is reclaimed by cardLift, so a small overlap
-            // sits it snug against the card body.
-            'mx-[5.5%] -mt-6 rounded-b-[28px] rounded-t-none px-6 pb-4 pt-5'
+            // behind it so it reads as a drawer: flat top, rounded bottom. Pulled
+            // up past the card's rounded bottom corners (so no gap shows at the
+            // sides), with generous top padding to keep the icon/text in view.
+            'mx-[5.5%] -mt-[34px] rounded-b-[28px] rounded-t-none px-6 pb-4 pt-[30px]'
           : 'mb-6 h-14 rounded-full',
         hidden && 'opacity-0',
       )}


### PR DESCRIPTION
…o 12

- Show details button: pull the tucked top further up (‑mt‑6 → ‑mt‑34px) so it sits behind the straight part of the card body above the rounded bottom corners — removes the gap that showed at the left/right sides — and add ~10px more top padding (pt‑5 → pt‑30px) so the icon/text keep breathing room.
- Card glyph oval: revert the frost intensity back to 12 (40 whitened it without hiding the lines). Sheen kept; a proper liquid-glass approach TBD.


Claude-Session: https://claude.ai/code/session_0141JefqAksx9sMJvtBXg8Go