### PR TITLE
feat: in-app store review after soUSD cashback (qa)

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -67,6 +67,8 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
     googleServicesFile: process.env.GOOGLE_SERVICES_PLIST ?? './GoogleService-Info.plist',
     supportsTablet: false,
     bundleIdentifier: 'app.solid.xyz',
+    // Used by expo-store-review (StoreReview.storeUrl / hasAction) as the App Store listing.
+    appStoreUrl: 'https://apps.apple.com/app/id6758618401',
     infoPlist: {
       ITSAppUsesNonExemptEncryption: false,
       NSCameraUsageDescription: 'Solid needs camera access to scan QR codes for wallet addresses',
@@ -131,6 +133,8 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
       backgroundColor: '#94F27F',
     },
     package: 'xyz.solid.android',
+    // Used by expo-store-review (StoreReview.storeUrl / hasAction) as the Play Store listing.
+    playStoreUrl: 'https://play.google.com/store/apps/details?id=xyz.solid.android',
     splash: {
       image: './assets/splash/splash-icon.png',
       resizeMode: 'contain',

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -40,6 +40,7 @@ import AppErrorBoundary from '@/components/ErrorBoundary';
 import Intercom from '@/components/Intercom/index';
 import { LazyThirdwebProvider } from '@/components/LazyThirdwebProvider';
 import LazyWhatsNewModal from '@/components/LazyWhatsNewModal';
+import CashbackStoreReviewTrigger from '@/components/StoreReview/CashbackStoreReviewTrigger';
 import { toastProps } from '@/components/Toast';
 import { TurnkeyProvider } from '@/components/TurnkeyProvider';
 import { getInfoClient } from '@/graphql/clients';
@@ -437,6 +438,7 @@ function RootLayout() {
                       <PortalHost />
                       <DeferredModalProviders />
                       {hasSelectedUser && <WhatsNewWrapper />}
+                      {hasSelectedUser && Platform.OS !== 'web' && <CashbackStoreReviewTrigger />}
                     </BottomSheetModalProvider>
                   </GestureHandlerRootView>
                 </Intercom>

--- a/components/StoreReview/CashbackStoreReviewTrigger.tsx
+++ b/components/StoreReview/CashbackStoreReviewTrigger.tsx
@@ -1,0 +1,11 @@
+import { useCashbackStoreReview } from '@/hooks/useCashbackStoreReview';
+
+/**
+ * Headless component that asks the user to rate the app (via the native in-app
+ * store review sheet) after they successfully receive soUSD cashback. Renders
+ * nothing; mount it once inside the authenticated app tree.
+ */
+export default function CashbackStoreReviewTrigger() {
+  useCashbackStoreReview();
+  return null;
+}

--- a/constants/tracking-events.ts
+++ b/constants/tracking-events.ts
@@ -281,6 +281,12 @@ export const TRACKING_EVENTS = {
   QR_SCANNER_PERMISSION_REQUESTED: 'qr_scanner_permission_requested',
   QR_SCANNER_PERMISSION_GRANTED: 'qr_scanner_permission_granted',
   QR_SCANNER_PERMISSION_DENIED: 'qr_scanner_permission_denied',
+
+  // In-App Store Review Events
+  STORE_REVIEW_REQUESTED: 'store_review_requested',
+  STORE_REVIEW_SKIPPED: 'store_review_skipped',
+  STORE_REVIEW_UNAVAILABLE: 'store_review_unavailable',
+  STORE_REVIEW_ERROR: 'store_review_error',
 } as const;
 
 export type TrackingEvent = (typeof TRACKING_EVENTS)[keyof typeof TRACKING_EVENTS];

--- a/eas.json
+++ b/eas.json
@@ -20,7 +20,7 @@
         "disabled": true
       },
       "env": {
-        "SENTRY_AUTH_TOKEN": "$SENTRY_AUTH_TOKEN"
+        "SENTRY_ALLOW_FAILURE": "true"
       }
     }
   },

--- a/hooks/useCashbackStoreReview.ts
+++ b/hooks/useCashbackStoreReview.ts
@@ -1,0 +1,63 @@
+import { useEffect } from 'react';
+import { Platform } from 'react-native';
+
+import { useCardStatus } from '@/hooks/useCardStatus';
+import { useCashbacks } from '@/hooks/useCashbacks';
+import { useStoreReview } from '@/hooks/useStoreReview';
+import { hasCard } from '@/lib/utils';
+import { getNewlyReceivedCashbackIds, getReceivedSoUsdCashbackIds } from '@/lib/utils/storeReview';
+import { useStoreReviewStore } from '@/store/useStoreReviewStore';
+
+// Small settle delay so the rating sheet lands at a resting moment rather than
+// popping the instant fresh data arrives (e.g. during a refetch or navigation).
+const REVIEW_PROMPT_DELAY_MS = 2000;
+
+/**
+ * Watches the user's cashbacks and asks for an in-app store review the first time
+ * a *new* soUSD cashback payout is received. Payouts that already existed the
+ * first time this device runs the feature are captured as a silent baseline, so
+ * existing users aren't prompted simply for upgrading — only for a fresh payout.
+ *
+ * Runs headlessly (renders nothing) and is a no-op on web.
+ */
+export const useCashbackStoreReview = () => {
+  const { requestReview } = useStoreReview();
+
+  const { data: cardStatus } = useCardStatus();
+  const userHasCard = hasCard(cardStatus);
+
+  // Only card holders can receive cashback, so avoid the extra request otherwise.
+  const { data: cashbacks } = useCashbacks({
+    enabled: Platform.OS !== 'web' && userHasCard,
+  });
+
+  useEffect(() => {
+    if (Platform.OS === 'web') return;
+    // Wait for the first successful load ([] once resolved, undefined while pending).
+    if (!cashbacks) return;
+
+    const receivedIds = getReceivedSoUsdCashbackIds(cashbacks);
+
+    const state = useStoreReviewStore.getState();
+
+    // First time we see this device's cashbacks: treat whatever is already paid
+    // as pre-existing and don't prompt. Anything new after this is prompt-worthy.
+    if (!state.hasCapturedBaseline) {
+      state.captureBaseline(receivedIds);
+      return;
+    }
+
+    const newlyReceived = getNewlyReceivedCashbackIds(receivedIds, state.reviewedCashbackIds);
+    if (newlyReceived.length === 0) return;
+
+    // Mark them accounted for immediately so refetches don't reprocess the same
+    // payout; the review request itself is throttled inside useStoreReview.
+    state.markSeen(receivedIds);
+
+    const timer = setTimeout(() => {
+      void requestReview({ trigger: 'cashback_received', count: newlyReceived.length });
+    }, REVIEW_PROMPT_DELAY_MS);
+
+    return () => clearTimeout(timer);
+  }, [cashbacks, requestReview]);
+};

--- a/hooks/useCashbacks.ts
+++ b/hooks/useCashbacks.ts
@@ -3,10 +3,11 @@ import { useQuery } from '@tanstack/react-query';
 import { getCashbacks } from '@/lib/api';
 import { Cashback } from '@/lib/types';
 
-export const useCashbacks = () => {
+export const useCashbacks = (options?: { enabled?: boolean }) => {
   return useQuery<Cashback[], Error>({
     queryKey: cashbacksQueryKey,
     queryFn: getCashbacks,
+    enabled: options?.enabled ?? true,
   });
 };
 

--- a/hooks/useStoreReview.ts
+++ b/hooks/useStoreReview.ts
@@ -1,0 +1,71 @@
+import { useCallback } from 'react';
+import { AppState, Platform } from 'react-native';
+import * as StoreReview from 'expo-store-review';
+
+import { TRACKING_EVENTS } from '@/constants/tracking-events';
+import { track } from '@/lib/analytics';
+import { useStoreReviewStore } from '@/store/useStoreReviewStore';
+
+// Minimum time between two native review prompts. The OS enforces its own quota
+// (iOS shows the sheet at most a few times a year; Android is quota-limited too),
+// but we add a generous cooldown so we never nag a user who keeps earning cashback.
+const REVIEW_REQUEST_COOLDOWN_MS = 1000 * 60 * 60 * 24 * 120; // 120 days
+
+interface RequestReviewOptions {
+  /** Free-form context for analytics, e.g. what triggered the prompt. */
+  trigger?: string;
+  [key: string]: unknown;
+}
+
+/**
+ * Thin wrapper around expo-store-review that asks for an in-app rating without
+ * leaving the app. All Apple/Google guidance around *when* to prompt lives in the
+ * caller — this hook only owns availability checks, cooldown, foreground guard,
+ * and analytics. It never opens the store listing (that would leave the app),
+ * so it no-ops whenever the native in-app prompt isn't available.
+ */
+export const useStoreReview = () => {
+  const requestReview = useCallback(async (options: RequestReviewOptions = {}) => {
+    // The native in-app prompt only exists on iOS/Android.
+    if (Platform.OS === 'web') return;
+
+    const { lastReviewRequestAt } = useStoreReviewStore.getState();
+
+    // Respect our own cooldown before touching the SDK.
+    if (lastReviewRequestAt && Date.now() - lastReviewRequestAt < REVIEW_REQUEST_COOLDOWN_MS) {
+      track(TRACKING_EVENTS.STORE_REVIEW_SKIPPED, { reason: 'cooldown', ...options });
+      return;
+    }
+
+    // Don't surface the sheet while the app is backgrounded/transitioning.
+    if (AppState.currentState !== 'active') {
+      track(TRACKING_EVENTS.STORE_REVIEW_SKIPPED, { reason: 'not_active', ...options });
+      return;
+    }
+
+    try {
+      const isAvailable = await StoreReview.isAvailableAsync();
+      if (!isAvailable) {
+        track(TRACKING_EVENTS.STORE_REVIEW_UNAVAILABLE, { reason: 'not_available', ...options });
+        return;
+      }
+
+      // Re-check foreground state after the async availability call.
+      if (AppState.currentState !== 'active') {
+        track(TRACKING_EVENTS.STORE_REVIEW_SKIPPED, { reason: 'not_active', ...options });
+        return;
+      }
+
+      await StoreReview.requestReview();
+      useStoreReviewStore.getState().recordReviewRequest(Date.now());
+      track(TRACKING_EVENTS.STORE_REVIEW_REQUESTED, options);
+    } catch (error) {
+      track(TRACKING_EVENTS.STORE_REVIEW_ERROR, {
+        message: error instanceof Error ? error.message : String(error),
+        ...options,
+      });
+    }
+  }, []);
+
+  return { requestReview };
+};

--- a/hooks/useUser.ts
+++ b/hooks/useUser.ts
@@ -34,6 +34,7 @@ import { useAttributionStore } from '@/store/useAttributionStore';
 import { useBalanceStore } from '@/store/useBalanceStore';
 import { useKycStore } from '@/store/useKycStore';
 import { usePointsStore } from '@/store/usePointsStore';
+import { useStoreReviewStore } from '@/store/useStoreReviewStore';
 import { useUserStore } from '@/store/useUserStore';
 
 import { fetchIsDeposited } from './useAnalytics';
@@ -209,6 +210,7 @@ const useUser = (): UseUserReturn => {
     // Start every new session from a clean query cache so this login can never
     // read data cached under user-agnostic keys (e.g. Rewards) by a prior one.
     queryClient.clear();
+    useStoreReviewStore.getState().reset();
 
     // Get attribution context for login tracking
     const attributionStore = useAttributionStore.getState();
@@ -459,6 +461,7 @@ const useUser = (): UseUserReturn => {
     // keys, so without this the previous wallet's details would be served to
     // the next wallet on web until gcTime expires or the page is hard-refreshed.
     queryClient.clear();
+    useStoreReviewStore.getState().reset();
     intercom?.shutdown();
     intercom?.boot();
 
@@ -498,6 +501,7 @@ const useUser = (): UseUserReturn => {
       // session before authenticating, so the incoming user never sees stale
       // data cached under user-agnostic keys (e.g. Rewards).
       queryClient.clear();
+      useStoreReviewStore.getState().reset();
 
       // Find the selected user
       const selectedUser = users.find(u => u.userId === userId);
@@ -566,6 +570,7 @@ const useUser = (): UseUserReturn => {
     clearKycLinkId(); // Clear KYC data when removing all users
     removeEvents();
     queryClient.clear(); // Drop all cached queries belonging to the forgotten users
+    useStoreReviewStore.getState().reset();
     router.replace(path.ONBOARDING);
   }, [users, removeUsers, clearKycLinkId, removeEvents, router, queryClient]);
 
@@ -585,6 +590,7 @@ const useUser = (): UseUserReturn => {
     // Purge cached queries so a re-login (possibly as a different user) starts
     // from a clean cache instead of the expired session's data.
     queryClient.clear();
+    useStoreReviewStore.getState().reset();
     intercom?.shutdown();
     intercom?.boot();
 
@@ -619,6 +625,7 @@ const useUser = (): UseUserReturn => {
       removeUsers();
       clearKycLinkId();
       queryClient.clear();
+      useStoreReviewStore.getState().reset();
 
       // Navigate to onboarding (no users left after deletion)
       router.replace(path.ONBOARDING);

--- a/lib/utils/__tests__/storeReview.test.ts
+++ b/lib/utils/__tests__/storeReview.test.ts
@@ -1,0 +1,92 @@
+/// <reference types="jest" />
+import { Cashback, CashbackStatus } from '@/lib/types';
+import {
+  getNewlyReceivedCashbackIds,
+  getReceivedSoUsdCashbackIds,
+  isReceivedSoUsdCashback,
+} from '@/lib/utils/storeReview';
+
+/**
+ * Factory for minimal Cashback fixtures. Defaults to a valid *received* soUSD
+ * payout; override fields to exercise the other branches.
+ */
+function makeCashback(overrides: Partial<Cashback> & { _id: string }): Cashback {
+  return {
+    transactionId: `tx-${overrides._id}`,
+    status: CashbackStatus.Paid,
+    soUsdAmount: '1.5',
+    soUsdRate: '1',
+    createdAt: '2026-07-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+describe('isReceivedSoUsdCashback', () => {
+  it('is true for a Paid cashback with a positive soUSD amount', () => {
+    expect(isReceivedSoUsdCashback(makeCashback({ _id: '1', soUsdAmount: '2.5' }))).toBe(true);
+  });
+
+  it('is false while the cashback is still pending or escrowed', () => {
+    expect(
+      isReceivedSoUsdCashback(makeCashback({ _id: '1', status: CashbackStatus.Pending })),
+    ).toBe(false);
+    expect(
+      isReceivedSoUsdCashback(makeCashback({ _id: '2', status: CashbackStatus.Escrowed })),
+    ).toBe(false);
+  });
+
+  it('is false for non-received terminal states', () => {
+    expect(
+      isReceivedSoUsdCashback(makeCashback({ _id: '1', status: CashbackStatus.FullyRefunded })),
+    ).toBe(false);
+    expect(isReceivedSoUsdCashback(makeCashback({ _id: '2', status: CashbackStatus.Failed }))).toBe(
+      false,
+    );
+  });
+
+  it('is false when there is no soUSD amount or it is zero', () => {
+    expect(isReceivedSoUsdCashback(makeCashback({ _id: '1', soUsdAmount: undefined }))).toBe(false);
+    expect(isReceivedSoUsdCashback(makeCashback({ _id: '2', soUsdAmount: '0' }))).toBe(false);
+  });
+
+  it('excludes legacy FUSE-only payouts (no soUSD amount)', () => {
+    const legacy = makeCashback({
+      _id: '1',
+      soUsdAmount: undefined,
+      fuseAmount: '10',
+      fuseUsdPrice: '0.05',
+    });
+    expect(isReceivedSoUsdCashback(legacy)).toBe(false);
+  });
+});
+
+describe('getReceivedSoUsdCashbackIds', () => {
+  it('returns ids for only the received soUSD payouts', () => {
+    const cashbacks = [
+      makeCashback({ _id: 'paid-1' }),
+      makeCashback({ _id: 'pending-1', status: CashbackStatus.Pending }),
+      makeCashback({ _id: 'paid-2', soUsdAmount: '0.75' }),
+      makeCashback({ _id: 'legacy-1', soUsdAmount: undefined, fuseAmount: '5' }),
+    ];
+
+    expect(getReceivedSoUsdCashbackIds(cashbacks)).toEqual(['paid-1', 'paid-2']);
+  });
+
+  it('returns an empty array when nothing has been received', () => {
+    expect(getReceivedSoUsdCashbackIds([])).toEqual([]);
+  });
+});
+
+describe('getNewlyReceivedCashbackIds', () => {
+  it('returns only received ids not already known', () => {
+    expect(getNewlyReceivedCashbackIds(['a', 'b', 'c'], ['a'])).toEqual(['b', 'c']);
+  });
+
+  it('returns an empty array when everything is already known', () => {
+    expect(getNewlyReceivedCashbackIds(['a', 'b'], ['a', 'b', 'c'])).toEqual([]);
+  });
+
+  it('accepts a Set of known ids', () => {
+    expect(getNewlyReceivedCashbackIds(['a', 'b'], new Set(['b']))).toEqual(['a']);
+  });
+});

--- a/lib/utils/storeReview.ts
+++ b/lib/utils/storeReview.ts
@@ -1,0 +1,26 @@
+import { Cashback, CashbackStatus } from '@/lib/types';
+
+/**
+ * A cashback counts as "successfully received" once it has been Paid out and
+ * carries a positive soUSD payout amount. Legacy FUSE-only cashbacks are
+ * intentionally excluded — the in-app review prompt is tied specifically to
+ * receiving soUSD cashback.
+ */
+export const isReceivedSoUsdCashback = (cashback: Cashback): boolean => {
+  if (cashback.status !== CashbackStatus.Paid) return false;
+  const soUsdAmount = cashback.soUsdAmount ? parseFloat(cashback.soUsdAmount) : 0;
+  return soUsdAmount > 0;
+};
+
+/** Ids of every cashback that represents a successfully received soUSD payout. */
+export const getReceivedSoUsdCashbackIds = (cashbacks: Cashback[]): string[] =>
+  cashbacks.filter(isReceivedSoUsdCashback).map(cashback => cashback._id);
+
+/** Received-payout ids that aren't already accounted for in `knownIds`. */
+export const getNewlyReceivedCashbackIds = (
+  receivedIds: string[],
+  knownIds: Iterable<string>,
+): string[] => {
+  const known = new Set(knownIds);
+  return receivedIds.filter(id => !known.has(id));
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -89,6 +89,7 @@
         "expo-observe": "~0.2.2",
         "expo-router": "~55.0.11",
         "expo-splash-screen": "~55.0.16",
+        "expo-store-review": "~55.0.15",
         "expo-symbols": "~55.0.7",
         "expo-system-ui": "~55.0.14",
         "expo-tracking-transparency": "~55.0.12",
@@ -23235,6 +23236,16 @@
       },
       "peerDependencies": {
         "expo": "*"
+      }
+    },
+    "node_modules/expo-store-review": {
+      "version": "55.0.15",
+      "resolved": "https://registry.npmjs.org/expo-store-review/-/expo-store-review-55.0.15.tgz",
+      "integrity": "sha512-p4hnMPMqP/CzX9rI32dI8xwWzIAXYQgCldUpx/me/xA3SBwQhjC1OzaCvmtHolxpVv19ut9YtxH2JXTAoadrVw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*",
+        "react-native": "*"
       }
     },
     "node_modules/expo-structured-headers": {

--- a/package.json
+++ b/package.json
@@ -110,6 +110,7 @@
     "expo-observe": "~0.2.2",
     "expo-router": "~55.0.11",
     "expo-splash-screen": "~55.0.16",
+    "expo-store-review": "~55.0.15",
     "expo-symbols": "~55.0.7",
     "expo-system-ui": "~55.0.14",
     "expo-tracking-transparency": "~55.0.12",

--- a/store/useStoreReviewStore.ts
+++ b/store/useStoreReviewStore.ts
@@ -1,0 +1,69 @@
+import { create } from 'zustand';
+import { createJSONStorage, persist } from 'zustand/middleware';
+
+import mmkvStorage from '@/lib/mmvkStorage';
+
+/**
+ * Persisted bookkeeping for the in-app store review prompt.
+ *
+ * The prompt is only ever shown after a user *receives* soUSD cashback, so we
+ * track which cashback payouts we've already accounted for. `hasCapturedBaseline`
+ * lets us distinguish a brand-new payout (prompt-worthy) from cashback that
+ * already existed the first time this device saw the feature (not prompt-worthy).
+ */
+interface StoreReviewState {
+  /** True once we've recorded the set of payouts that pre-dated this feature on this device. */
+  hasCapturedBaseline: boolean;
+  /** Cashback ids already observed as received, so we never prompt twice for the same payout. */
+  reviewedCashbackIds: string[];
+  /** Epoch ms of the last time we actually invoked the native review prompt. */
+  lastReviewRequestAt: number | null;
+  /** How many times we've invoked the native review prompt (for diagnostics). */
+  reviewRequestCount: number;
+  captureBaseline: (ids: string[]) => void;
+  markSeen: (ids: string[]) => void;
+  recordReviewRequest: (at: number) => void;
+  reset: () => void;
+}
+
+const STORE_REVIEW_STORAGE_KEY = 'store-review-storage';
+
+// Cap how many ids we retain so MMKV storage can't grow unbounded for heavy card
+// users. The cashback API only returns a recent window, so keeping the most
+// recent ids is enough to detect genuinely new payouts.
+const MAX_TRACKED_IDS = 500;
+
+const uniqueRecent = (ids: string[]): string[] => Array.from(new Set(ids)).slice(-MAX_TRACKED_IDS);
+
+export const useStoreReviewStore = create<StoreReviewState>()(
+  persist(
+    set => ({
+      hasCapturedBaseline: false,
+      reviewedCashbackIds: [],
+      lastReviewRequestAt: null,
+      reviewRequestCount: 0,
+      captureBaseline: (ids: string[]) =>
+        set({ hasCapturedBaseline: true, reviewedCashbackIds: uniqueRecent(ids) }),
+      markSeen: (ids: string[]) =>
+        set(state => ({
+          reviewedCashbackIds: uniqueRecent([...state.reviewedCashbackIds, ...ids]),
+        })),
+      recordReviewRequest: (at: number) =>
+        set(state => ({
+          lastReviewRequestAt: at,
+          reviewRequestCount: state.reviewRequestCount + 1,
+        })),
+      reset: () =>
+        set({
+          hasCapturedBaseline: false,
+          reviewedCashbackIds: [],
+          lastReviewRequestAt: null,
+          reviewRequestCount: 0,
+        }),
+    }),
+    {
+      name: STORE_REVIEW_STORAGE_KEY,
+      storage: createJSONStorage(() => mmkvStorage(STORE_REVIEW_STORAGE_KEY)),
+    },
+  ),
+);


### PR DESCRIPTION
## What
Ports the in-app store-review feature from `claude/in-app-store-review-yxs26b` onto `qa` for internal testing. Companion to the revert PR that removes it from `master`.

## Behavior (unchanged from the original)
The native store-review sheet is requested **only after a user receives a new soUSD cashback payout** — native-only, throttled (120-day cooldown + foreground guard), with a persisted per-device baseline so existing users are only prompted on a genuinely new payout. `store_review_requested` is emitted to analytics when we hand off to the OS (the platforms don't report whether the user actually rated).

## Conflict-resolution notes (qa is ~4k commits diverged from master)
- **`hooks/useUser.ts`**: qa does **not** reset the points store at auth transitions, so I added **only** `useStoreReviewStore.getState().reset()` at the 6 auth-transition points (login / switch / logout / session-expired / forget / delete). I did not introduce the `usePointsStore.reset()` behavior qa lacks.
- **`eas.json`**: also carries the branch's Sentry fix — dropped the non-interpolated `"$SENTRY_AUTH_TOKEN"` literal and set `SENTRY_ALLOW_FAILURE=true`.
- All other files (new store-review files, `_layout.tsx` mount, tracking events, `app.config.ts` store URLs, `package.json`) applied cleanly.

## Testing
Install the qa internal build (see the qa CI/CD PR), trigger a soUSD cashback payout, and confirm the native rating sheet appears once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017LWh8sKPgZWEF7JNvFxq3g

---
_Generated by [Claude Code](https://claude.ai/code/session_017LWh8sKPgZWEF7JNvFxq3g)_