### PR TITLE
ci: enable qa CI/CD (internal-distribution builds for team testing)

### DIFF
--- a/.eas/workflows/deploy-mobile-qa.yml
+++ b/.eas/workflows/deploy-mobile-qa.yml
@@ -1,20 +1,63 @@
 name: Deploy mobile QA
 
-# Disabled - workflow will not trigger
-# on:
-#   push:
-#     branches: ['qa']
+# Internal (QR-installable) builds for team testing. On every push to `qa`:
+#   1. fingerprint the native layer
+#   2. reuse an existing internal build when the fingerprint is unchanged,
+#      and publish an EAS Update (fast JS-only iteration) instead of rebuilding
+#   3. otherwise build a fresh internal-distribution build (preview profile),
+#      which EAS surfaces with a QR code / install link testers can scan
+# No store submission — these are internal builds, not store releases.
+on:
+  push:
+    branches: ['qa']
 
 jobs:
-  android_build:
-    name: Build Android
+  fingerprint:
+    name: Fingerprint
+    type: fingerprint
+  get_android_build:
+    name: Check for existing android build
+    needs: [fingerprint]
+    type: get-build
+    params:
+      fingerprint_hash: ${{ needs.fingerprint.outputs.android_fingerprint_hash }}
+      profile: preview
+  get_ios_build:
+    name: Check for existing ios build
+    needs: [fingerprint]
+    type: get-build
+    params:
+      fingerprint_hash: ${{ needs.fingerprint.outputs.ios_fingerprint_hash }}
+      profile: preview
+  build_android:
+    name: Build Android (internal)
+    needs: [get_android_build]
+    if: ${{ !needs.get_android_build.outputs.build_id }}
     type: build
     params:
       platform: android
       profile: preview
-  ios_build:
-    name: Build iOS
+  build_ios:
+    name: Build iOS (internal)
+    needs: [get_ios_build]
+    if: ${{ !needs.get_ios_build.outputs.build_id }}
     type: build
     params:
       platform: ios
       profile: preview
+  publish_android_update:
+    name: Publish Android QA update
+    needs: [get_android_build]
+    if: ${{ needs.get_android_build.outputs.build_id }}
+    type: update
+    params:
+      branch: preview
+      platform: android
+  publish_ios_update:
+    name: Publish iOS QA update
+    needs: [get_ios_build]
+    if: ${{ needs.get_ios_build.outputs.build_id }}
+    type: update
+    params:
+      branch: preview
+      platform: ios


### PR DESCRIPTION
## What
Enables a qa CI/CD pipeline for internal, QR-installable team-testing builds. The qa workflow existed but was disabled (its push trigger was commented out), so there was no qa pipeline.

## Pipeline (on push to `qa`)
Modeled on the production workflow, minus store submission:
1. **Fingerprint** the native layer.
2. If the fingerprint is unchanged, publish an **EAS Update** (fast JS-only iteration) instead of rebuilding.
3. Otherwise build a fresh **internal-distribution** build (`preview` profile) — EAS surfaces it with a **QR code / install link** testers scan to install directly, no app store involved.

## Notes
- The `development` and `preview` EAS build profiles already exist in `eas.json`, so no eas.json change is needed for development builds (`eas build --profile development`).
- iOS internal distribution requires tester devices to be registered (`eas device:create`, which itself yields a QR to register the device).
- Update jobs publish to EAS Update branch `preview` to match the `preview` profile's channel — if your channel→branch mapping differs, that's the one line to adjust.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017LWh8sKPgZWEF7JNvFxq3g

---
_Generated by [Claude Code](https://claude.ai/code/session_017LWh8sKPgZWEF7JNvFxq3g)_