### PR TITLE
chore(eas): enable QA internal-distribution builds on push to qa

### DIFF
--- a/.eas/workflows/deploy-mobile-qa.yml
+++ b/.eas/workflows/deploy-mobile-qa.yml
@@ -1,9 +1,10 @@
 name: Deploy mobile QA
 
-# Disabled - workflow will not trigger
-# on:
-#   push:
-#     branches: ['qa']
+# Builds internal-distribution (preview) apps on every push to `qa`, so QA
+# testers can install the latest QA build by scanning the EAS build QR code.
+on:
+  push:
+    branches: ['qa']
 
 jobs:
   android_build:


### PR DESCRIPTION
## What

Enables the existing QA EAS Workflow (`.eas/workflows/deploy-mobile-qa.yml`) by uncommenting its `on: push: branches: ['qa']` trigger.

## Why

The QA build pipeline was already defined but disabled. With this enabled, **every push to `qa` builds the `preview` profile** (`distribution: internal`) for Android + iOS. Those are **internal-distribution builds installable by scanning the EAS build QR code** — no store review — which is the intended QA testing flow.

## Notes / dashboard follow-ups (no code)
- The EAS project is already linked (`projectId` in `app.config.ts`), and `eas.json` already has the `preview` profile + `preview` channel.
- To make the trigger fire, ensure the **GitHub → EAS integration** is connected (Expo project settings → GitHub).
- For iOS internal builds, register tester device UDIDs (`eas device:create`) or use a TestFlight internal group. Android internal APKs install directly from the QR link.

Part of the QA/EAS setup (1 of 3 PRs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0141JefqAksx9sMJvtBXg8Go)_