### PR TITLE
feat(gate): enable test features on internal/QA builds by channel (drop allow-list reliance)

### DIFF
--- a/lib/utils/testFeatures.ts
+++ b/lib/utils/testFeatures.ts
@@ -1,3 +1,5 @@
+import * as Updates from 'expo-updates';
+
 export const TEST_FEATURES_ALLOW_LIST = [
   'Mark1',
   'mayank18',
@@ -14,7 +16,22 @@ export const TEST_FEATURES_ALLOW_LIST = [
   'smargonaq1',
 ];
 
+/**
+ * Whether this build is an internal/QA build (EAS "preview" or "development"
+ * channel) or local dev. On these builds every user sees the test features, so
+ * QA testers no longer need to be added to the allow-list. Production builds
+ * (the "production" channel) fall back to the per-user allow-list below.
+ */
+export const isInternalBuild = (): boolean => {
+  if (__DEV__) return true;
+  // Updates.channel is the EAS channel the build was created for; null on web /
+  // when updates aren't configured.
+  const channel = Updates.channel;
+  return channel === 'preview' || channel === 'development';
+};
+
 export const isUserAllowedToUseTestFeature = (username: string) => {
+  if (isInternalBuild()) return true;
   return (
     TEST_FEATURES_ALLOW_LIST.includes(username.toLowerCase()) ||
     TEST_FEATURES_ALLOW_LIST.includes(username)


### PR DESCRIPTION
## What

`isUserAllowedToUseTestFeature` now returns `true` for **every** user on internal/QA builds — EAS `preview` / `development` channels (via `Updates.channel`) and local dev (`__DEV__`). Production builds are unchanged and still use the per-user `TEST_FEATURES_ALLOW_LIST`.

## Why

The redesigned home / card / savings screens (and the other test-gated features) are gated by `useIsTestUser`. This let QA see them by adding usernames to an allow-list — the thing we want to stop maintaining. With this change, the **QA (preview) build shows the new screens to everyone**, so the QA build itself is the gate; production stays exactly as it is today.

## Why this instead of reverting the redesign out of master
The redesign is spread across **21 interleaved merged PRs (#2250–#2279)**; an automated code-revert conflicts (create/modify/delete across the PRs) and isn't safe to land blind on production. This channel gate reaches the same goal — new screens only surface on QA/internal builds, no allow-list — without a risky production revert. If you specifically want the redesign **code** removed from the master binary, that's a manual per-PR revert we can do as a follow-up.

## Note
On web (no EAS channel) `Updates.channel` is null, so non-dev web falls back to the allow-list. Native QA builds are the target here.

Part of the QA/EAS setup (2 of 3 PRs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0141JefqAksx9sMJvtBXg8Go)_