### PR TITLE
fix(build): unblock iOS and Android builds for the Sumsub SDK

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -287,6 +287,13 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
     // Force FMT_USE_CONSTEVAL=0 so fmt 11.0.2 (pinned by RN 0.83) compiles under
     // Xcode 26+ clang. See plugins/withFmtConstevalFix.js.
     './plugins/withFmtConstevalFix.js',
+    // IdensicMobileSDK (Sumsub's native iOS SDK) lives in Sumsub's own
+    // CocoaPods spec repo, not trunk. See plugins/withSumsubPodSource.js.
+    './plugins/withSumsubPodSource.js',
+    // Sumsub ("face") and expo-camera ("barcode_ui") both declare the ML Kit
+    // vision DEPENDENCIES meta-data; merge them so the Android manifest merger
+    // does not fail. See plugins/withMlkitVisionDependencies.js.
+    './plugins/withMlkitVisionDependencies.js',
   ],
   experiments: {
     typedRoutes: true,

--- a/plugins/withMlkitVisionDependencies.js
+++ b/plugins/withMlkitVisionDependencies.js
@@ -1,0 +1,59 @@
+const { AndroidConfig, withAndroidManifest } = require('@expo/config-plugins');
+
+/**
+ * Expo config plugin: resolve the ML Kit vision-dependency manifest conflict.
+ *
+ * Google Play reads the `com.google.mlkit.vision.DEPENDENCIES` meta-data to
+ * decide which ML model modules to download when the app is installed. Two of
+ * our dependencies declare the same key with different values:
+ *   - com.sumsub.sns:idensic-mobile-sdk  -> "face"       (liveness / selfie)
+ *   - host.exp.exponent:expo.modules.camera -> "barcode_ui" (QR scanning)
+ *
+ * The manifest merger cannot pick a winner and fails the build:
+ *   Execution failed for task ':app:processReleaseMainManifest'.
+ *   > Manifest merger failed with multiple errors
+ *
+ * The attribute is a comma-separated module list, so we declare the union in
+ * the app manifest and mark it as the explicit override. Keeping both halves
+ * matters: dropping "face" breaks Sumsub liveness, dropping "barcode_ui"
+ * breaks expo-camera's scanner — each would fail at runtime, not build time.
+ *
+ * android/ is prebuild-generated (gitignored), so this re-applies on every
+ * `expo prebuild`.
+ */
+const META_DATA_NAME = 'com.google.mlkit.vision.DEPENDENCIES';
+const MERGED_VALUE = 'face,barcode_ui';
+const TOOLS_NAMESPACE = 'http://schemas.android.com/tools';
+
+module.exports = function withMlkitVisionDependencies(config) {
+  return withAndroidManifest(config, (config) => {
+    const androidManifest = config.modResults;
+
+    // `tools:replace` is only valid when the tools namespace is declared.
+    androidManifest.manifest.$ = androidManifest.manifest.$ || {};
+    if (!androidManifest.manifest.$['xmlns:tools']) {
+      androidManifest.manifest.$['xmlns:tools'] = TOOLS_NAMESPACE;
+    }
+
+    const mainApplication = AndroidConfig.Manifest.getMainApplicationOrThrow(androidManifest);
+    mainApplication['meta-data'] = mainApplication['meta-data'] || [];
+
+    const attributes = {
+      'android:name': META_DATA_NAME,
+      'android:value': MERGED_VALUE,
+      'tools:replace': 'android:value',
+    };
+
+    const existing = mainApplication['meta-data'].find(
+      (item) => item.$ && item.$['android:name'] === META_DATA_NAME,
+    );
+
+    if (existing) {
+      existing.$ = { ...existing.$, ...attributes };
+    } else {
+      mainApplication['meta-data'].push({ $: attributes });
+    }
+
+    return config;
+  });
+};

--- a/plugins/withSumsubPodSource.js
+++ b/plugins/withSumsubPodSource.js
@@ -1,0 +1,45 @@
+const { withDangerousMod } = require('@expo/config-plugins');
+const fs = require('fs');
+const path = require('path');
+
+/**
+ * Expo config plugin: register Sumsub's CocoaPods spec repo.
+ *
+ * `@sumsub/react-native-mobilesdk-module` depends on `IdensicMobileSDK`, which
+ * Sumsub publishes to its own spec repo (github.com/SumSubstance/Specs) rather
+ * than to CocoaPods trunk. Without it, `pod install` fails with:
+ *   [!] Unable to find a specification for `IdensicMobileSDK (= 1.44.0)`
+ *       depended upon by `react-native-mobilesdk-module`
+ *
+ * Declaring any `source` in a Podfile disables the implicit trunk default, so
+ * the CDN is re-declared here alongside Sumsub's repo — otherwise every other
+ * pod stops resolving.
+ *
+ * ios/ is prebuild-generated (gitignored), so this plugin re-applies on every
+ * `expo prebuild`.
+ */
+const MARKER = 'Sumsub spec repo (withSumsubPodSource)';
+
+const SNIPPET = `# ${MARKER}
+source 'https://github.com/SumSubstance/Specs.git'
+source 'https://cdn.cocoapods.org/'
+`;
+
+module.exports = function withSumsubPodSource(config) {
+  return withDangerousMod(config, [
+    'ios',
+    (config) => {
+      const podfilePath = path.join(config.modRequest.platformProjectRoot, 'Podfile');
+      const contents = fs.readFileSync(podfilePath, 'utf8');
+
+      if (contents.includes(MARKER)) {
+        return config;
+      }
+
+      // `source` is resolved before any target installs pods, so it belongs at
+      // the top of the Podfile, ahead of the autolinking requires.
+      fs.writeFileSync(podfilePath, `${SNIPPET}\n${contents}`);
+      return config;
+    },
+  ]);
+};


### PR DESCRIPTION
Both EAS internal builds failed on native config for @sumsub/react-native-mobilesdk-module.

iOS (Install pods):
  [!] Unable to find a specification for `IdensicMobileSDK (= 1.44.0)`
      depended upon by `react-native-mobilesdk-module`
Sumsub publishes IdensicMobileSDK to its own CocoaPods spec repo rather than to trunk. Add withSumsubPodSource to declare it in the Podfile, and re-declare the trunk CDN since any explicit source disables the implicit default.

Android (:app:processReleaseMainManifest):
  Attribute meta-data#com.google.mlkit.vision.DEPENDENCIES@value
  value=(face) from [com.sumsub.sns:idensic-mobile-sdk:1.44.1]
  is also present at [expo.modules.camera] value=(barcode_ui)
Sumsub needs the ML Kit face model and expo-camera needs barcode_ui, so the merger cannot pick a winner. Add withMlkitVisionDependencies to declare the union (face,barcode_ui) with tools:replace; keeping both halves preserves liveness capture and QR scanning.

ios/ and android/ are prebuild-generated, so both plugins re-apply on every prebuild and are idempotent.


Claude-Session: https://claude.ai/code/session_01PhpHmf6StXRrF2NwdQizy8