### PR TITLE
fix(kyc): keep the Sumsub widget open on a resubmission request

### DIFF
--- a/app/(protected)/(tabs)/sumsub-kyc.tsx
+++ b/app/(protected)/(tabs)/sumsub-kyc.tsx
@@ -30,6 +30,7 @@ export default function SumsubKycWeb() {
     fetchAccessToken,
     onVerificationComplete,
     onVerificationDeclined,
+    onVerificationRetry,
     onVerificationError,
   } = useSumsubSession();
   const launchedRef = useRef(false);
@@ -47,13 +48,23 @@ export default function SumsubKycWeb() {
       .withConf({ lang: 'en' })
       .withOptions({ addViewportTag: false, adaptIframeHeight: true })
       .on('idCheck.onApplicantStatusChanged', (payload: any) => {
-        // Fires when the applicant's review status changes. On a terminal
-        // 'completed' status, branch on the review answer.
+        // Fires when the applicant's review status changes. A 'completed' status
+        // is only terminal for GREEN or a FINAL rejection.
         if (payload?.reviewStatus === 'completed') {
-          launchedRef.current = false;
-          if (payload?.reviewResult?.reviewAnswer === 'RED') {
-            onVerificationDeclined();
+          const reviewResult = payload?.reviewResult;
+          if (reviewResult?.reviewAnswer === 'RED') {
+            // RETRY means Sumsub wants a resubmission and renders the re-upload
+            // step itself, so keep the widget mounted. Only FINAL is terminal.
+            // Treating every RED as declined ejected the user to /card/activate
+            // with "Verification declined" and left no way to re-upload.
+            if (reviewResult?.reviewRejectType === 'FINAL') {
+              launchedRef.current = false;
+              onVerificationDeclined();
+            } else {
+              onVerificationRetry(reviewResult?.moderationComment);
+            }
           } else {
+            launchedRef.current = false;
             onVerificationComplete();
           }
         }
@@ -72,6 +83,7 @@ export default function SumsubKycWeb() {
     markStarted,
     onVerificationComplete,
     onVerificationDeclined,
+    onVerificationRetry,
     onVerificationError,
   ]);
 

--- a/components/kyc/useSumsubSession.ts
+++ b/components/kyc/useSumsubSession.ts
@@ -162,6 +162,22 @@ export function useSumsubSession() {
     redirectBasedOnKycStatus(KycStatus.REJECTED);
   }, [redirectBasedOnKycStatus]);
 
+  /**
+   * Sumsub asked for a resubmission (RED + reviewRejectType RETRY, i.e. the
+   * mobile SDK's `TemporarilyDeclined`). The user must stay INSIDE the widget —
+   * that is where Sumsub renders the "re-upload your document" step. Redirecting
+   * away here is what previously made a re-upload request impossible to action.
+   */
+  const onVerificationRetry = useCallback((reason?: string) => {
+    Toast.show({
+      type: 'info',
+      text1: 'More information needed',
+      text2: reason || 'Please re-upload the requested document to continue.',
+      props: { badgeText: '' },
+    });
+    setSession({ phase: 'started' });
+  }, []);
+
   const onVerificationError = useCallback((message: string) => {
     Toast.show({
       type: 'error',
@@ -181,7 +197,12 @@ export function useSumsubSession() {
         const status = await withRefreshToken(() => getSumsubVerificationStatus());
         if (!status) return;
 
-        if (status.kycStatus === KycStatus.REJECTED || status.reviewAnswer === 'RED') {
+        // Only the canonical kycStatus may eject the user. A raw
+        // `reviewAnswer === 'RED'` check would also fire for a RETRY (a
+        // resubmission request), throwing the user out of the widget exactly when
+        // they need to stay in it. The backend already encodes RETRY as
+        // INCOMPLETE and FINAL as REJECTED.
+        if (status.kycStatus === KycStatus.REJECTED) {
           clearInterval(interval);
           onVerificationDeclined();
         } else if (status.kycStatus === KycStatus.APPROVED) {
@@ -212,6 +233,7 @@ export function useSumsubSession() {
     onVerificationComplete,
     onVerificationPending,
     onVerificationDeclined,
+    onVerificationRetry,
     onVerificationError,
   };
 }


### PR DESCRIPTION
Clicking "Continue verification" loaded the widget and immediately bounced back to /card/activate with "Verification declined", leaving no way to re-upload the requested document.

That toast is ours, not a provider message. The web screen treated every RED at reviewStatus 'completed' as terminal:

  if (payload?.reviewResult?.reviewAnswer === 'RED') onVerificationDeclined()

But RED covers two very different outcomes. With reviewRejectType RETRY Sumsub is requesting a resubmission and renders the re-upload step inside the widget itself — so ejecting the user is precisely the wrong move. Only FINAL is terminal. Now branch on reviewRejectType and add onVerificationRetry, which surfaces the applicant-safe moderationComment and keeps the widget mounted.

The status poll had the same flaw: it declined on a raw , which fires for a RETRY too. Only the canonical
kycStatus may eject the user now — the backend already encodes RETRY as INCOMPLETE and FINAL as REJECTED.

The native screen was already correct (it declines only on FinallyRejected and treats TemporarilyDeclined as pending); web now matches it.


Claude-Session: https://claude.ai/code/session_01PhpHmf6StXRrF2NwdQizy8