### PR TITLE
fix(cards): do not gate KYC completion on knowing the card issuer

### DIFF
--- a/hooks/useCardSteps/__tests__/buildCardSteps.test.ts
+++ b/hooks/useCardSteps/__tests__/buildCardSteps.test.ts
@@ -122,6 +122,24 @@ describe('buildCardSteps - Wirex (Sumsub) KYC completion', () => {
   const buildWirex = (kycStatus: KycStatus) =>
     build({ options: { cardIssuer: CardProvider.WIREX, rainApplicationStatus: null, kycStatus } });
 
+  // /cards/status does not return cardProvider, so in production cardIssuer is
+  // null for a Wirex user. Completion must not depend on knowing the issuer.
+  const buildUnknownIssuer = (kycStatus: KycStatus) =>
+    build({ options: { cardIssuer: null, rainApplicationStatus: null, kycStatus } });
+
+  it('completes KYC on approval even when cardIssuer is unknown', () => {
+    const [kyc, activate] = buildUnknownIssuer(KycStatus.APPROVED);
+    expect(kyc.completed).toBe(true);
+    expect(activate.buttonText).toBe('Activate card');
+    expect(activate.onPress).toBeDefined();
+  });
+
+  it('leaves KYC incomplete when an unknown issuer is still under review', () => {
+    const [kyc, activate] = buildUnknownIssuer(KycStatus.UNDER_REVIEW);
+    expect(kyc.completed).toBe(false);
+    expect(activate.buttonText).toBeUndefined();
+  });
+
   it('completes the KYC step and enables activation once Wirex has approved', () => {
     // Wirex users have no Bridge endorsement and no Rain application, so before
     // this the check fell through to the endorsement branch, stayed false, and

--- a/hooks/useCardSteps/stepHelpers.ts
+++ b/hooks/useCardSteps/stepHelpers.ts
@@ -70,9 +70,14 @@ export function buildCardSteps(
   const isKycComplete =
     options?.cardIssuer === CardProvider.RAIN
       ? isRainKycApproved
-      : options?.cardIssuer === CardProvider.WIREX
-        ? options?.kycStatus === KycStatus.APPROVED
-        : cardsEndorsement?.status === EndorsementStatus.APPROVED;
+      : // Deliberately NOT gated on cardIssuer === WIREX: /cards/status does not
+        // return cardProvider, so cardIssuer is null for Wirex users and a
+        // provider-specific branch never matched — leaving the step incomplete
+        // and the activate button unrendered even with kycStatus "approved".
+        // kycStatus is the canonical backend decision for every non-Rain issuer,
+        // with the Bridge endorsement kept as the legacy fallback.
+        options?.kycStatus === KycStatus.APPROVED ||
+        cardsEndorsement?.status === EndorsementStatus.APPROVED;
 
   const orderCardDesc = activationBlocked
     ? activationBlockedReason || 'There was an issue activating your card. Please contact support.'


### PR DESCRIPTION
The activate button was still unrendered with kycStatus "approved". My previous fix added a WIREX branch to isKycComplete, but /cards/status does not return cardProvider — the response is just {"kycStatus":"approved"} — so cardIssuer is null for a Wirex user and the branch never matched. It fell to the Bridge endorsement check again and stayed false.

The two display helpers I changed key on kycStatus alone, so they did take effect. That is why step 1 showed "Identity verification complete" while remaining the active (expanded) step: description came from kycStatus, completion did not. AnimatedStepContent only renders a step's body when it is active, so the activate step stayed collapsed and its button never appeared.

Treat kycStatus APPROVED as complete for every non-Rain issuer instead of naming providers, keeping the Bridge endorsement as the legacy fallback. Rain still resolves from its application status. Tests cover the null-cardIssuer case that production actually hits.


Claude-Session: https://claude.ai/code/session_01PhpHmf6StXRrF2NwdQizy8