### PR TITLE
feat(home): three-balance pie + breakdown, passkey & fund-wallet copy

### DIFF
--- a/app/signup/passkey.tsx
+++ b/app/signup/passkey.tsx
@@ -148,7 +148,7 @@ export default function SignupPasskey() {
         {/* Header */}
         <View className="mb-8 mt-8 items-center">
           <Text className="mb-4 text-center text-[34px] font-semibold leading-none -tracking-[1px] text-white">
-            Secure sign-in{'\n'}with Passkey
+            Protect your account{'\n'}with a passkey
           </Text>
           <View className="px-4">
             <View className="flex-row flex-wrap items-baseline justify-center">

--- a/components/Home/FundWallet.tsx
+++ b/components/Home/FundWallet.tsx
@@ -44,7 +44,7 @@ const FundWallet = ({ className }: FundWalletProps) => {
           <View className="gap-2">
             <Text className="max-w-lg text-3xl font-semibold">Fund your wallet</Text>
             <Text className="text-base text-muted-foreground md:max-w-60">
-              Fund your account with crypto you already own or with cash
+              Add funds to start spending with your card
             </Text>
           </View>
           <DepositOptionModal trigger={getTrigger()} />

--- a/components/Home/NewHome/OtherBalancesDropdown/OtherBalancesDropdown.native.tsx
+++ b/components/Home/NewHome/OtherBalancesDropdown/OtherBalancesDropdown.native.tsx
@@ -5,17 +5,12 @@ import { BottomSheetBackdrop, BottomSheetModal, BottomSheetView } from '@gorhom/
 
 import { Text } from '@/components/ui/text';
 
-import {
-  type OtherBalances,
-  OtherBalancesPill,
-  SavingsBalanceRow,
-  SpendableBalancesGroup,
-} from '.';
+import { BalanceBreakdownRows, type OtherBalances, OtherBalancesPill } from '.';
 
 /**
- * Native balances control: a pill (savings) that presents a Gorhom bottom sheet
- * with the full breakdown — Wallet + Card (grouped, since they make up the
- * headline) and Savings. Mirrors InfoCenterDropdown.native.tsx.
+ * Native balances control: a pill (total + Wallet/Card/Savings donut) that
+ * presents a Gorhom bottom sheet with all three balances broken out. Mirrors
+ * InfoCenterDropdown.native.tsx.
  */
 const OtherBalancesDropdown = ({
   walletBalance,
@@ -37,7 +32,12 @@ const OtherBalancesDropdown = ({
 
   return (
     <View className="items-center">
-      <OtherBalancesPill savingsValue={savingsBalance} onPress={present} />
+      <OtherBalancesPill
+        walletValue={walletBalance}
+        cardValue={cardBalance}
+        savingsValue={savingsBalance}
+        onPress={present}
+      />
       <BottomSheetModal
         ref={bottomSheetModalRef}
         backdropComponent={renderBackdrop}
@@ -50,14 +50,11 @@ const OtherBalancesDropdown = ({
       >
         <BottomSheetView className="gap-1 pb-2 pt-1" style={{ paddingBottom: insets.bottom + 8 }}>
           <Text className="px-5 pb-1 text-lg font-semibold text-muted-foreground">Balances</Text>
-          <SpendableBalancesGroup
+          <BalanceBreakdownRows
             walletBalance={walletBalance}
             cardBalance={cardBalance}
-            userHasCard={userHasCard}
-            isLoading={isLoading}
-          />
-          <SavingsBalanceRow
             savingsBalance={savingsBalance}
+            userHasCard={userHasCard}
             isLoading={isLoading}
             onDismiss={dismiss}
           />

--- a/components/Home/NewHome/OtherBalancesDropdown/OtherBalancesDropdown.tsx
+++ b/components/Home/NewHome/OtherBalancesDropdown/OtherBalancesDropdown.tsx
@@ -3,12 +3,7 @@ import { View } from 'react-native';
 
 import { Dialog, DialogContent, DialogTitle, DialogTrigger } from '@/components/ui/dialog';
 
-import {
-  type OtherBalances,
-  OtherBalancesPill,
-  SavingsBalanceRow,
-  SpendableBalancesGroup,
-} from '.';
+import { BalanceBreakdownRows, type OtherBalances, OtherBalancesPill } from '.';
 
 /**
  * Default / web-mobile balances control. Gorhom bottom sheets are native-only in
@@ -29,18 +24,19 @@ const OtherBalancesDropdown = ({
     <View className="items-center">
       <Dialog open={open} onOpenChange={setOpen}>
         <DialogTrigger asChild>
-          <OtherBalancesPill savingsValue={savingsBalance} />
+          <OtherBalancesPill
+            walletValue={walletBalance}
+            cardValue={cardBalance}
+            savingsValue={savingsBalance}
+          />
         </DialogTrigger>
         <DialogContent className="gap-1 p-4">
           <DialogTitle className="px-2 pb-1 text-lg text-muted-foreground">Balances</DialogTitle>
-          <SpendableBalancesGroup
+          <BalanceBreakdownRows
             walletBalance={walletBalance}
             cardBalance={cardBalance}
-            userHasCard={userHasCard}
-            isLoading={isLoading}
-          />
-          <SavingsBalanceRow
             savingsBalance={savingsBalance}
+            userHasCard={userHasCard}
             isLoading={isLoading}
             onDismiss={dismiss}
           />

--- a/components/Home/NewHome/OtherBalancesDropdown/OtherBalancesPie.tsx
+++ b/components/Home/NewHome/OtherBalancesDropdown/OtherBalancesPie.tsx
@@ -14,8 +14,8 @@ const point = (angle: number): [number, number] => [
 /**
  * SVG arc for a segment starting at `startFraction` of the circle and spanning
  * `sweepFraction`, measured clockwise from 12 o'clock. Explicit arcs (rather than
- * strokeDasharray tricks) so both segments render deterministically on every
- * platform.
+ * strokeDasharray tricks) so every segment renders deterministically on all
+ * platforms.
  */
 const arcPath = (startFraction: number, sweepFraction: number) => {
   const a0 = -Math.PI / 2 + startFraction * 2 * Math.PI;
@@ -27,8 +27,10 @@ const arcPath = (startFraction: number, sweepFraction: number) => {
 };
 
 interface OtherBalancesPieProps {
+  walletValue: number;
   cardValue: number;
   savingsValue: number;
+  walletColor: string;
   cardColor: string;
   savingsColor: string;
 }
@@ -38,47 +40,49 @@ const fullRing = (color: string) => (
 );
 
 /**
- * Small donut showing how much Card vs Savings each contributes to the "other
- * balances" total (real proportions). Falls back to an empty grey ring when
- * there's no balance; draws a single full ring when only one side has a balance.
+ * Small donut showing how much Wallet (white), Card (green) and Savings (purple)
+ * each contribute to the total, in real proportions. Falls back to an empty grey
+ * ring when there's no balance; draws a single full ring when only one balance is
+ * non-zero.
  */
 const OtherBalancesPie = ({
+  walletValue,
   cardValue,
   savingsValue,
+  walletColor,
   cardColor,
   savingsColor,
 }: OtherBalancesPieProps) => {
-  const card = Math.max(cardValue, 0);
-  const savings = Math.max(savingsValue, 0);
-  const total = card + savings;
+  const segments = [
+    { value: Math.max(walletValue, 0), color: walletColor },
+    { value: Math.max(cardValue, 0), color: cardColor },
+    { value: Math.max(savingsValue, 0), color: savingsColor },
+  ].filter(segment => segment.value > 0);
+
+  const total = segments.reduce((sum, segment) => sum + segment.value, 0);
 
   let content: React.ReactNode;
   if (total <= 0) {
     content = fullRing(TRACK_COLOR);
-  } else if (card <= 0) {
-    content = fullRing(savingsColor);
-  } else if (savings <= 0) {
-    content = fullRing(cardColor);
+  } else if (segments.length === 1) {
+    content = fullRing(segments[0].color);
   } else {
-    const cardFraction = card / total;
-    content = (
-      <>
+    let start = 0;
+    content = segments.map(segment => {
+      const sweep = segment.value / total;
+      const path = (
         <Path
-          d={arcPath(0, cardFraction)}
-          stroke={cardColor}
+          key={segment.color}
+          d={arcPath(start, sweep)}
+          stroke={segment.color}
           strokeWidth={STROKE}
           fill="none"
           strokeLinecap="butt"
         />
-        <Path
-          d={arcPath(cardFraction, 1 - cardFraction)}
-          stroke={savingsColor}
-          strokeWidth={STROKE}
-          fill="none"
-          strokeLinecap="butt"
-        />
-      </>
-    );
+      );
+      start += sweep;
+      return path;
+    });
   }
 
   return (

--- a/components/Home/NewHome/OtherBalancesDropdown/index.tsx
+++ b/components/Home/NewHome/OtherBalancesDropdown/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Pressable, View } from 'react-native';
-import { ChevronDown, Info } from 'lucide-react-native';
+import { ChevronDown } from 'lucide-react-native';
 
 import CardDirectDepositModal from '@/components/Card/CardDirectDepositModal';
 import DepositOptionModal from '@/components/DepositOption/DepositOptionModal';
@@ -37,7 +37,7 @@ export const shouldShowCard = (cardBalance: number, userHasCard: boolean) =>
 /**
  * The headline figure: Wallet + Card. They're combined in the UI only — the two
  * balances stay separate under the hood (funds must be moved from the wallet to
- * the card before they can be spent), which the breakdown sheet spells out.
+ * the card before they can be spent), which the breakdown sheet lays out.
  */
 export const getSpendableTotal = ({
   walletBalance,
@@ -46,18 +46,29 @@ export const getSpendableTotal = ({
 }: Pick<OtherBalances, 'walletBalance' | 'cardBalance' | 'userHasCard'>) =>
   (walletBalance || 0) + (shouldShowCard(cardBalance, userHasCard) ? cardBalance || 0 : 0);
 
+/** Everything the user holds: Wallet + Card + Savings (the pill's figure). */
+export const getTotalBalance = ({
+  walletBalance,
+  cardBalance,
+  savingsBalance,
+  userHasCard,
+}: OtherBalances) =>
+  getSpendableTotal({ walletBalance, cardBalance, userHasCard }) + (savingsBalance || 0);
+
 type PillProps = {
-  /** Savings total — the balance that is NOT part of the headline. */
+  walletValue: number;
+  cardValue: number;
   savingsValue: number;
 } & React.ComponentProps<typeof Pressable>;
 
 /**
- * The dropdown pill trigger: savings ring + savings total + chevron. Wallet and
- * Card are already in the headline above, so the pill carries the remaining
- * balance — headline + pill = everything the user holds (no double counting).
+ * The dropdown pill trigger: a proportional Wallet/Card/Savings donut + the
+ * total across all three + chevron. Tapping opens the full breakdown.
  */
 export const OtherBalancesPill = React.forwardRef<View, PillProps>(
-  ({ savingsValue, ...props }, ref) => {
+  ({ walletValue, cardValue, savingsValue, ...props }, ref) => {
+    const total = (walletValue || 0) + (cardValue || 0) + (savingsValue || 0);
+
     return (
       <Pressable
         ref={ref}
@@ -67,12 +78,14 @@ export const OtherBalancesPill = React.forwardRef<View, PillProps>(
         {...props}
       >
         <OtherBalancesPie
-          cardValue={0}
+          walletValue={walletValue}
+          cardValue={cardValue}
           savingsValue={savingsValue}
+          walletColor={WALLET_COLOR}
           cardColor={CARD_COLOR}
           savingsColor={SAVINGS_COLOR}
         />
-        <Text className="text-base font-semibold text-white">{formatBalanceUSD(savingsValue)}</Text>
+        <Text className="text-base font-semibold text-white">{formatBalanceUSD(total)}</Text>
         <ChevronDown size={16} color="rgba(255,255,255,0.6)" />
       </Pressable>
     );
@@ -119,7 +132,7 @@ const BalanceRow = ({
   </View>
 );
 
-/** Wallet balance row. "Add" opens the standard Add Funds (deposit) flow. */
+/** Wallet balance row (white). "Add" opens the standard Add Funds flow. */
 export const WalletBalanceRow = ({
   walletBalance,
   isLoading,
@@ -132,8 +145,8 @@ export const WalletBalanceRow = ({
   </BalanceRow>
 );
 
-/** Card balance row. "Add" opens the "Fund your card" popup (share deposit
- *  address / transfer from wallet) — the same modal used on the card screen. */
+/** Card balance row (green). "Add" opens the "Fund your card" popup (share
+ *  deposit address / transfer from wallet) — same modal as the card screen. */
 export const CardBalanceRow = ({
   cardBalance,
   isLoading,
@@ -148,37 +161,7 @@ export const CardBalanceRow = ({
   </BalanceRow>
 );
 
-/**
- * Wallet + Card grouped together, matching the combined headline, with a note
- * making the separation explicit: the two are only added up for display, and
- * money has to be moved onto the card before it can be spent.
- */
-export const SpendableBalancesGroup = ({
-  walletBalance,
-  cardBalance,
-  userHasCard,
-  isLoading,
-}: Omit<OtherBalances, 'savingsBalance'>) => {
-  const showCard = shouldShowCard(cardBalance, userHasCard);
-
-  return (
-    <View className="bg-white/[0.03] py-1">
-      <WalletBalanceRow walletBalance={walletBalance} isLoading={isLoading} />
-      {showCard && <CardBalanceRow cardBalance={cardBalance} isLoading={isLoading} />}
-      {showCard && (
-        <View className="flex-row items-start gap-2 px-5 pb-3 pt-1">
-          <Info size={14} color="rgba(255,255,255,0.4)" />
-          <Text className="flex-1 text-xs leading-4 text-white/40">
-            Wallet and Card are added up in the balance above, but they&apos;re separate — move
-            funds to your card to spend them.
-          </Text>
-        </View>
-      )}
-    </View>
-  );
-};
-
-/** Savings balance row. "Add" opens the existing savings deposit modal (global). */
+/** Savings balance row (purple). "Add" opens the savings deposit modal (global). */
 export const SavingsBalanceRow = ({
   savingsBalance,
   isLoading,
@@ -200,4 +183,26 @@ export const SavingsBalanceRow = ({
       trigger={<AddButton />}
     />
   </BalanceRow>
+);
+
+/** The three balances, in order: Wallet, Card (when relevant), Savings. */
+export const BalanceBreakdownRows = ({
+  walletBalance,
+  cardBalance,
+  savingsBalance,
+  userHasCard,
+  isLoading,
+  onDismiss,
+}: OtherBalances & { onDismiss?: () => void }) => (
+  <>
+    <WalletBalanceRow walletBalance={walletBalance} isLoading={isLoading} />
+    {shouldShowCard(cardBalance, userHasCard) && (
+      <CardBalanceRow cardBalance={cardBalance} isLoading={isLoading} onDismiss={onDismiss} />
+    )}
+    <SavingsBalanceRow
+      savingsBalance={savingsBalance}
+      isLoading={isLoading}
+      onDismiss={onDismiss}
+    />
+  </>
 );


### PR DESCRIPTION
Branched off latest `qa` (no rebase needed).

## Changes

**1. Removed the combined-balance explanation**
The "Wallet and Card are added up in the balance above…" note is gone from the balances sheet, along with the grouped container it sat in. The three rows are now uniform.

**2. Three balances everywhere — Wallet white, Card green, Savings purple**
- **Pie:** rewritten to render up to three proportional segments (was Card/Savings only, and had been reduced to a savings-only ring). Falls back to a grey ring at zero and a single full ring when only one balance is non-zero.
- **Sheet:** already listed all three (Wallet row + white dot were added in the previous commit on `qa`) — so that half already existed; this PR makes the pie match.
- **Pill figure:** now the **total of all three**, so the number matches what the donut depicts. Previously it was savings-only.

**3. Copy**
- Signup passkey heading: "Secure sign-in with Passkey" → **"Protect your account with a passkey"** (kept the two-line break, matching the mockup).
- `FundWallet` description → **"Add funds to start spending with your card"**.

Headline still shows Wallet + Card — unchanged.

## Note on the fund-wallet card
"Fund your wallet" exists in exactly one place, `components/Home/FundWallet.tsx`, and that component **isn't rendered anywhere** — it's only re-exported from the `components/Home` barrel, which nothing imports. So the copy change is correct but won't be visible until the component is wired up (or if the card in the mockup is a new component still to be built). Happy to point it at the right place if you meant a different card.

## Verification
- `eslint --fix`: clean.
- `tsc --noEmit`: 9 errors, all pre-existing on `qa` (KycModalContent, CardBanner, VaultSelectorDropdown, prepareLottieSource, the two bridge hooks, useWithdrawRainCollateral) — none in touched files.
- Not run on device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0141JefqAksx9sMJvtBXg8Go)_