### PR TITLE
fix(toast): stop labelling non-blockchain toasts "Onchain"

### DIFF
--- a/app/(protected)/(tabs)/card/deposit.tsx
+++ b/app/(protected)/(tabs)/card/deposit.tsx
@@ -166,6 +166,7 @@ const DepositToCard = () => {
         text1: 'Card deposit initiated',
         text2: `${amount} ${selectedToken.contractTickerSymbol} sent to card`,
         props: {
+          badgeText: 'Onchain',
           link: `https://etherscan.io/tx/${transaction.transactionHash}`,
           linkText: 'View on Etherscan',
           image: getAsset('images/usdc-4x.png'),
@@ -193,6 +194,7 @@ const DepositToCard = () => {
         type: 'error',
         text1: 'Deposit failed',
         text2: 'Please try again',
+        props: { badgeText: 'Onchain' },
       });
     }
   };

--- a/app/(protected)/rescue-token.tsx
+++ b/app/(protected)/rescue-token.tsx
@@ -1,9 +1,9 @@
 import { useMemo } from 'react';
 import { ActivityIndicator, View } from 'react-native';
 import Toast from 'react-native-toast-message';
+import { Image } from 'expo-image';
 import { useRouter } from 'expo-router';
 import { useQuery } from '@tanstack/react-query';
-import { Image } from 'expo-image';
 import { Address, encodeFunctionData, erc20Abi, formatEther, formatUnits } from 'viem';
 import { mainnet } from 'viem/chains';
 import { useBalance, useReadContract } from 'wagmi';
@@ -58,13 +58,7 @@ export default function RescueToken() {
   });
 
   const { data: gasCostWei, isLoading: isGasLoading } = useQuery({
-    queryKey: [
-      'rescue-token-gas',
-      mainnet.id,
-      eoaAddress,
-      safeAddress,
-      usdcBalance?.toString(),
-    ],
+    queryKey: ['rescue-token-gas', mainnet.id, eoaAddress, safeAddress, usdcBalance?.toString()],
     queryFn: async () => {
       if (!eoaAddress || !safeAddress) return 0n;
       const client = publicClient(mainnet.id);
@@ -109,16 +103,10 @@ export default function RescueToken() {
   );
 
   const hasUsdc = (usdcBalance ?? 0n) > 0n;
-  const hasEnoughEth =
-    !!gasCostWei && !!ethBalance && ethBalance.value >= gasCostWei;
+  const hasEnoughEth = !!gasCostWei && !!ethBalance && ethBalance.value >= gasCostWei;
   const isRescuing = status === Status.PENDING;
   const isDisabled =
-    isRescuing ||
-    isUsdcLoading ||
-    isEthLoading ||
-    isGasLoading ||
-    !hasUsdc ||
-    !hasEnoughEth;
+    isRescuing || isUsdcLoading || isEthLoading || isGasLoading || !hasUsdc || !hasEnoughEth;
 
   const getButtonText = () => {
     if (isRescuing) return 'Rescuing...';
@@ -136,6 +124,7 @@ export default function RescueToken() {
         text1: 'Tokens rescued',
         text2: `${formatNumber(usdcAmount)} USDC sent to your Solid wallet`,
         props: {
+          badgeText: 'Onchain',
           link: `https://etherscan.io/tx/${transactionHash}`,
           linkText: eclipseAddress(transactionHash),
           image: { type: 'image', source: getAsset('images/usdc-4x.png') },
@@ -165,12 +154,10 @@ export default function RescueToken() {
 
         <View className="mb-10 mt-8">
           <View className="rounded-2xl border border-white/5 bg-[#1C1C1C] px-6 pb-8 pt-10">
-            <Text className="text-center text-2xl font-bold text-white">
-              Recover stuck USDC
-            </Text>
+            <Text className="text-center text-2xl font-bold text-white">Recover stuck USDC</Text>
             <Text className="mb-6 mt-3 text-center text-base leading-tight text-[#ACACAC]">
-              USDC was sent to your signer wallet on Ethereum by mistake. Sign with your
-              passkey to move it into your Solid wallet.
+              USDC was sent to your signer wallet on Ethereum by mistake. Sign with your passkey to
+              move it into your Solid wallet.
             </Text>
 
             <View className="gap-4">
@@ -219,12 +206,7 @@ export default function RescueToken() {
                         {formatNumber(gasEthAmount, 6, 6)} ETH
                       </Text>
                     </View>
-                    <Text
-                      className={cn(
-                        'text-sm',
-                        hasEnoughEth ? 'opacity-50' : 'text-red-400',
-                      )}
-                    >
+                    <Text className={cn('text-sm', hasEnoughEth ? 'opacity-50' : 'text-red-400')}>
                       {isEthLoading ? '—' : `Balance: ${formatNumber(ethAmount, 6, 6)} ETH`}
                     </Text>
                   </View>
@@ -239,9 +221,7 @@ export default function RescueToken() {
               className="mt-8 h-14 w-full rounded-2xl"
             >
               {isRescuing && <ActivityIndicator color="black" />}
-              <Text className="text-base font-bold text-primary-foreground">
-                {getButtonText()}
-              </Text>
+              <Text className="text-base font-bold text-primary-foreground">{getButtonText()}</Text>
             </Button>
           </View>
         </View>

--- a/components/Agent/AgentDepositBorrowForm.tsx
+++ b/components/Agent/AgentDepositBorrowForm.tsx
@@ -52,7 +52,7 @@ const AgentDepositBorrowForm = ({ agentEoaAddress, onSuccess }: Props) => {
         text1: 'Deposit submitted',
         text2:
           'Borrowed against soUSD on Fuse and sent via Stargate. Funds arrive on Base in ~1–5 min.',
-        props: { badgeText: 'Success' },
+        props: { badgeText: 'Onchain' },
       });
       onSuccess();
     } catch (err) {
@@ -60,7 +60,7 @@ const AgentDepositBorrowForm = ({ agentEoaAddress, onSuccess }: Props) => {
         type: 'error',
         text1: 'Deposit failed',
         text2: err instanceof Error ? err.message : 'Unknown error',
-        props: { badgeText: 'Error' },
+        props: { badgeText: 'Onchain' },
       });
     }
   };

--- a/components/Card/CardDepositExternalForm.tsx
+++ b/components/Card/CardDepositExternalForm.tsx
@@ -270,6 +270,7 @@ export default function CardDepositExternalForm() {
           type: 'error',
           text1: 'Deposit failed',
           text2: 'Please try again or check your wallet balance',
+          props: { badgeText: 'Onchain' },
         });
       }
     },

--- a/components/Card/CardDepositInternalForm.tsx
+++ b/components/Card/CardDepositInternalForm.tsx
@@ -798,6 +798,7 @@ export default function CardDepositInternalForm() {
           type: 'error',
           text1: 'Bridge failed',
           text2: error instanceof Error ? error.message : 'Unknown error occurred',
+          props: { badgeText: 'Onchain' },
         });
       }
     },

--- a/components/Card/CardRepayForm.tsx
+++ b/components/Card/CardRepayForm.tsx
@@ -503,6 +503,7 @@ export default function CardRepayForm() {
           type: 'error',
           text1: 'Repay failed',
           text2: 'Please try again or check your wallet balance',
+          props: { badgeText: 'Onchain' },
         });
       }
     },

--- a/components/Card/CardWithdrawForm.tsx
+++ b/components/Card/CardWithdrawForm.tsx
@@ -187,6 +187,7 @@ export default function CardWithdrawForm() {
             text1: 'Withdrawal started',
             text2: `$${data.amount} collateral withdrawal.`,
             onPress: () => Linking.openURL(explorerUrl),
+            props: { badgeText: 'Onchain' },
           });
         } else {
           const response = await withdrawFromCard({

--- a/components/Card/CreditLine/CreditLineConfirm.tsx
+++ b/components/Card/CreditLine/CreditLineConfirm.tsx
@@ -106,6 +106,7 @@ export default function CreditLineConfirm() {
         type: 'error',
         text1: 'Borrow failed',
         text2: error instanceof Error ? error.message : 'Unknown error occurred',
+        props: { badgeText: 'Onchain' },
       });
     } finally {
       setIsSubmitting(false);

--- a/components/Deposit/index.tsx
+++ b/components/Deposit/index.tsx
@@ -96,6 +96,7 @@ const Deposit = () => {
         text1: 'Deposit transaction completed',
         text2: `${data.amount} USDC`,
         props: {
+          badgeText: 'Onchain',
           link: `https://etherscan.io/tx/${transaction.transactionHash}`,
           linkText: eclipseAddress(transaction.transactionHash),
           image: getTokenIcon({ tokenSymbol: 'USDC' }),
@@ -105,6 +106,7 @@ const Deposit = () => {
       Toast.show({
         type: 'error',
         text1: 'Error while depositing',
+        props: { badgeText: 'Onchain' },
       });
     }
   };

--- a/components/DepositToVault/DepositToVaultForm.tsx
+++ b/components/DepositToVault/DepositToVaultForm.tsx
@@ -480,6 +480,7 @@ function DepositToVaultForm() {
       text1: `Depositing ${toastToken}`,
       text2: `Staking ${toastToken} to the protocol`,
       props: {
+        badgeText: 'Onchain',
         link: `${explorerUrl}/tx/${hashForVault}`,
         linkText: eclipseAddress(hashForVault),
         image: getAsset(toastIcon),

--- a/components/Send/SendReview.tsx
+++ b/components/Send/SendReview.tsx
@@ -130,6 +130,7 @@ const SendReview: React.FC = () => {
         text1: 'Send transaction completed',
         text2: `${amount} ${selectedToken?.contractTickerSymbol}`,
         props: {
+          badgeText: 'Onchain',
           link: `${getChain(selectedToken?.chainId)?.blockExplorers?.default.url}/tx/${transaction.transactionHash}`,
           linkText: eclipseAddress(transaction.transactionHash),
           image: getTokenIcon({
@@ -150,6 +151,7 @@ const SendReview: React.FC = () => {
       Toast.show({
         type: 'error',
         text1: 'Error while sending',
+        props: { badgeText: 'Onchain' },
       });
     }
   };

--- a/components/Stake/index.tsx
+++ b/components/Stake/index.tsx
@@ -96,6 +96,7 @@ const Stake = () => {
         text1: 'Deposit transaction completed',
         text2: `${data.amount} soUSD`,
         props: {
+          badgeText: 'Onchain',
           link: `https://etherscan.io/tx/${transaction.transactionHash}`,
           linkText: eclipseAddress(transaction.transactionHash),
           image: getTokenIcon({ tokenSymbol: 'SoUSD' }),
@@ -105,6 +106,7 @@ const Stake = () => {
       Toast.show({
         type: 'error',
         text1: 'Error while withdrawing',
+        props: { badgeText: 'Onchain' },
       });
     }
   };

--- a/components/Toast.tsx
+++ b/components/Toast.tsx
@@ -24,7 +24,10 @@ interface IBaseToast extends BaseToastProps {
 }
 
 const BaseToast = ({ text1, text2, classNames, props }: IBaseToast) => {
-  const { link, linkText, image, badgeText = 'Onchain' } = props || {};
+  // No badge unless a toast opts in. "Onchain" must be passed explicitly and
+  // only for actual blockchain transactions — it used to be the default, which
+  // mislabelled every non-chain toast (login, KYC, QR, validation errors…).
+  const { link, linkText, image, badgeText = '' } = props || {};
   return (
     <View
       className="ml-auto h-full w-full max-w-md flex-row justify-between rounded-2xl bg-card"
@@ -62,7 +65,7 @@ const BaseToast = ({ text1, text2, classNames, props }: IBaseToast) => {
       <Button
         onPress={() => Toast.hide()}
         variant="ghost"
-        className="native:!h-full web:!h-auto rounded-l-none rounded-r-2xl border-l border-primary/10 px-4 text-accent-foreground web:hover:border-accent"
+        className="native:!h-full rounded-l-none rounded-r-2xl border-l border-primary/10 px-4 text-accent-foreground web:!h-auto web:hover:border-accent"
       >
         <X color="white" />
       </Button>

--- a/components/Unstake/FastWithdrawForm.tsx
+++ b/components/Unstake/FastWithdrawForm.tsx
@@ -148,6 +148,7 @@ const FastWithdrawForm = () => {
             text1: 'Fast withdraw transaction completed',
             text2: `${data.amount} soUSD`,
             props: {
+              badgeText: 'Onchain',
               link: `https://explorer.fuse.io/tx/${tx.transactionHash}`,
               linkText: eclipseAddress(tx.transactionHash),
               image: getTokenIcon({ tokenSymbol: 'SoUSD' }),
@@ -176,6 +177,7 @@ const FastWithdrawForm = () => {
             text1: 'Withdraw transaction submitted',
             text2: `${data.amount} soUSD`,
             props: {
+              badgeText: 'Onchain',
               link: `https://layerzeroscan.com/tx/${tx.transactionHash}`,
               linkText: eclipseAddress(tx.transactionHash),
               image: getTokenIcon({ tokenSymbol: 'SoUSD' }),
@@ -192,6 +194,7 @@ const FastWithdrawForm = () => {
           type: 'error',
           text1: 'Bridge failed',
           text2: error instanceof Error ? error.message : 'Unknown error occurred',
+          props: { badgeText: 'Onchain' },
         });
       }
     },

--- a/components/Unstake/RegularWithdrawForm.tsx
+++ b/components/Unstake/RegularWithdrawForm.tsx
@@ -280,6 +280,7 @@ const RegularWithdrawForm = () => {
       Toast.show({
         type: 'error',
         text1: 'Error while withdrawing',
+        props: { badgeText: 'Onchain' },
       });
     }
   };
@@ -299,6 +300,7 @@ const RegularWithdrawForm = () => {
         text1: 'Withdrawal transaction submitted',
         text2: `${data.amount} ${selectedToken?.contractTickerSymbol || 'soUSD'}`,
         props: {
+          badgeText: 'Onchain',
           link: `https://etherscan.io/tx/${transaction.transactionHash}`,
           linkText: eclipseAddress(transaction.transactionHash),
           image: getTokenIcon({
@@ -310,6 +312,7 @@ const RegularWithdrawForm = () => {
       Toast.show({
         type: 'error',
         text1: 'Error while withdrawing',
+        props: { badgeText: 'Onchain' },
       });
     }
   };
@@ -328,6 +331,7 @@ const RegularWithdrawForm = () => {
         text1: 'Withdraw submitted',
         text2: `${data.amount} soFUSE → WFUSE on Fuse`,
         props: {
+          badgeText: 'Onchain',
           link: `https://explorer.fuse.io/tx/${transaction.transactionHash}`,
           linkText: eclipseAddress(transaction.transactionHash),
           image: getTokenIcon({ tokenSymbol: 'FUSE' }),
@@ -337,6 +341,7 @@ const RegularWithdrawForm = () => {
       Toast.show({
         type: 'error',
         text1: 'Error while withdrawing',
+        props: { badgeText: 'Onchain' },
       });
     }
   };
@@ -353,6 +358,7 @@ const RegularWithdrawForm = () => {
       Toast.show({
         type: 'error',
         text1: 'Error while bridging soETH',
+        props: { badgeText: 'Onchain' },
       });
     }
   };
@@ -372,6 +378,7 @@ const RegularWithdrawForm = () => {
         text1: 'Withdraw submitted',
         text2: `${data.amount} soETH → WETH on Ethereum`,
         props: {
+          badgeText: 'Onchain',
           link: `https://etherscan.io/tx/${transaction.transactionHash}`,
           linkText: eclipseAddress(transaction.transactionHash),
           image: getTokenIcon({ tokenSymbol: 'WETH' }),
@@ -381,6 +388,7 @@ const RegularWithdrawForm = () => {
       Toast.show({
         type: 'error',
         text1: 'Error while withdrawing soETH',
+        props: { badgeText: 'Onchain' },
       });
     }
   };

--- a/components/Unstake/index.tsx
+++ b/components/Unstake/index.tsx
@@ -96,6 +96,7 @@ const Unstake = () => {
         text1: 'Withdraw transaction submitted',
         text2: `${data.amount} soUSD`,
         props: {
+          badgeText: 'Onchain',
           link: `https://layerzeroscan.com/tx/${transaction.transactionHash}`,
           linkText: eclipseAddress(transaction.transactionHash),
           image: getTokenIcon({ tokenSymbol: 'SoUSD' }),
@@ -105,6 +106,7 @@ const Unstake = () => {
       Toast.show({
         type: 'error',
         text1: 'Error while withdrawing',
+        props: { badgeText: 'Onchain' },
       });
     }
   };

--- a/components/Withdraw/index.tsx
+++ b/components/Withdraw/index.tsx
@@ -97,6 +97,7 @@ const Withdraw = () => {
         text1: 'Withdrawal transaction completed',
         text2: `${data.amount} soUSD`,
         props: {
+          badgeText: 'Onchain',
           link: `https://etherscan.io/tx/${transaction.transactionHash}`,
           linkText: eclipseAddress(transaction.transactionHash),
           image: getTokenIcon({ tokenSymbol: 'SoUSD' }),
@@ -122,6 +123,7 @@ const Withdraw = () => {
       Toast.show({
         type: 'error',
         text1: 'Error while withdrawing',
+        props: { badgeText: 'Onchain' },
       });
     }
   };

--- a/hooks/useCardDeposit.ts
+++ b/hooks/useCardDeposit.ts
@@ -160,6 +160,7 @@ const useCardDeposit = (): CardDepositResult => {
           type: 'error',
           text1: 'Deposit failed',
           text2: err instanceof Error ? err.message : 'Please try again',
+          props: { badgeText: 'Onchain' },
         });
         throw err;
       }

--- a/hooks/useGoodDollarClaim.ts
+++ b/hooks/useGoodDollarClaim.ts
@@ -466,7 +466,7 @@ const useGoodDollarClaim = () => {
         type: 'success',
         text1: `Claimed ${amount} G$`,
         text2: 'Your GoodDollar UBI is on the way.',
-        props: { badgeText: 'Success' },
+        props: { badgeText: 'Onchain' },
       });
 
       await refresh();
@@ -486,7 +486,7 @@ const useGoodDollarClaim = () => {
         text2: isUserCancelled(error)
           ? 'Passkey prompt was cancelled'
           : getErrorMessage(error, 'Please try again'),
-        props: { badgeText: 'Error' },
+        props: { badgeText: 'Onchain' },
       });
     } finally {
       setIsClaiming(false);
@@ -601,7 +601,7 @@ const useGoodDollarClaim = () => {
         type: 'success',
         text1: `Moved ${amount} G$ to your wallet`,
         text2: 'It’s now available across Solid.',
-        props: { badgeText: 'Success' },
+        props: { badgeText: 'Onchain' },
       });
 
       await refresh();
@@ -621,7 +621,7 @@ const useGoodDollarClaim = () => {
         text2: isUserCancelled(error)
           ? 'Passkey prompt was cancelled'
           : getErrorMessage(error, 'Please try again'),
-        props: { badgeText: 'Error' },
+        props: { badgeText: 'Onchain' },
       });
     } finally {
       setIsSweeping(false);

--- a/hooks/useTransactionAwait.tsx
+++ b/hooks/useTransactionAwait.tsx
@@ -124,6 +124,7 @@ export function useTransactionAwait(
           text1: successInfo.title,
           text2: successInfo.description,
           props: {
+            badgeText: 'Onchain',
             link: `${getChain(successInfo.chainId || 122)?.blockExplorers?.default.url}/tx/${hash}`,
             linkText: eclipseAddress(hash),
             image: getTokenIcon({


### PR DESCRIPTION
The badge defaulted to "Onchain" in BaseToast, so every toast that didn't pass one — login failures, KYC, QR scans, Apple/Google Wallet, validation errors — was labelled as a blockchain operation (74 call sites relied on that default).

- Default badgeText is now '' (no badge). "Onchain" must be opted into.
- Added explicit badgeText: 'Onchain' to the 32 toasts that report an actual chain transaction (send, deposit, withdraw, unstake/bridge, rescue, card deposit/repay/borrow, useTransactionAwait).
- Converted 6 chain-operation toasts that used outcome words to 'Onchain': the agent borrow+Stargate bridge, and the GoodDollar claim/sweep txs (writeContract with a tx hash).
- Non-blockchain API operations keep short single-word badges where they add meaning (Success / Error / Copied: contacts, agent provisioning, API keys, GoodDollar identity verification, copy-to-clipboard).
- Everything else — auth, KYC, QR, wallet provisioning, precondition and validation errors — now shows no badge, since the toast title already states the operation.

Final split: 38 Onchain, 10 single-word, 79 no badge.


Claude-Session: https://claude.ai/code/session_0141JefqAksx9sMJvtBXg8Go