### PR TITLE
fix(lint): waive restricted Image import in RotatingWheelImage.web

### DIFF
--- a/components/RotatingWheelImage.web.tsx
+++ b/components/RotatingWheelImage.web.tsx
@@ -1,4 +1,8 @@
 import { forwardRef, useCallback, useEffect, useImperativeHandle, useRef } from 'react';
+// Image here is only used for resolveAssetSource() (asset module -> URL). This
+// component renders a raw <img> so it can be driven by the Web Animations API,
+// so no React Native / expo-image component is ever mounted.
+// eslint-disable-next-line no-restricted-imports
 import { Image, StyleSheet } from 'react-native';
 
 import type { RotatingWheelImageHandle, RotatingWheelImageProps } from './RotatingWheelImage';


### PR DESCRIPTION
Fixes the `Lint & Format` CI failure:

```
components/RotatingWheelImage.web.tsx
  2:10  error  'Image' import from 'react-native' is restricted.
               Use Image from "expo-image" or "@/components/ui/Image" instead  no-restricted-imports
```

## Why a waiver rather than a swap

The rule exists to push image **rendering** onto `expo-image` for performance/caching. This component never mounts an Image — it renders a raw `<img>` so the wheel element can be driven by the **Web Animations API** (`element.animate(...)`), which needs a real DOM node. The `react-native` import is used on exactly one line:

```ts
const resolvedSource = Image.resolveAssetSource(source);
```

i.e. asset module → URL, which is then set as `src` on the `<img>`.

The alternatives were worse:
- `@/components/ui/Image` / `expo-image` — expose no `resolveAssetSource`.
- `expo-image/build/utils/resolveAssetSource` — a private internal path.
- `expo-asset`'s `Asset.fromModule()` — would work, but it isn't a declared dependency (only transitively present), and it narrows the accepted `ImageSourcePropType` (the current call handles `number | {uri} | array` uniformly). Changing resolution behaviour in an untestable-here web animation wasn't worth it.

So: a single-line `eslint-disable-next-line` with a comment explaining the exemption. No runtime behaviour change.

Happy to switch to `expo-asset` (declaring it properly in `package.json`) if you'd prefer no disable comments in the codebase.

## Verification
`npm run lint` (the exact CI step) now reports **0 errors** for this file. The only two remaining repo errors are `import/no-unresolved` for `@sumsub/react-native-mobilesdk-module` and `@sumsub/websdk` — both are declared in `package.json` but not installed in my sandbox, so they resolve fine under CI's `npm ci`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0141JefqAksx9sMJvtBXg8Go)_