### PR TITLE
Add desktop sidebar navigation and layout system

### DIFF
--- a/app/(protected)/(tabs)/_layout.tsx
+++ b/app/(protected)/(tabs)/_layout.tsx
@@ -17,7 +17,9 @@ import { path } from '@/constants/path';
 import { useDimension } from '@/hooks/useDimension';
 
 export default function TabLayout() {
-  const { isDesktop } = useDimension();
+  // The desktop sidebar replaces the bottom bar from `isScreenMedium` up (the
+  // sidebar shell in `(protected)/_layout.tsx` renders it).
+  const { isScreenMedium } = useDimension();
 
   const tabs = (
     <Tabs
@@ -35,7 +37,7 @@ export default function TabLayout() {
           marginTop: 5,
         },
         tabBarStyle: {
-          display: isDesktop ? 'none' : 'flex',
+          display: isScreenMedium ? 'none' : 'flex',
           height: 80,
           paddingTop: 4,
           paddingBottom: 20,
@@ -49,7 +51,7 @@ export default function TabLayout() {
           position: 'absolute',
         },
       }}
-      tabBar={!isDesktop ? props => <NewCustomTabBar {...props} /> : undefined}
+      tabBar={!isScreenMedium ? props => <NewCustomTabBar {...props} /> : undefined}
       backBehavior="history"
     >
       <Tabs.Screen

--- a/app/(protected)/(tabs)/index.tsx
+++ b/app/(protected)/(tabs)/index.tsx
@@ -260,9 +260,7 @@ function LegacyHome() {
 }
 
 export default function Home() {
-  const { isDesktop } = useDimension();
-  // qa/preview builds on mobile-web see the redesigned wallet screen; desktop
-  // web and production keep the existing design.
-  const showNewHome = !isDesktop;
-  return showNewHome ? <HomeScreenNew /> : <LegacyHome />;
+  // Desktop is the same redesigned wallet screen, stretched inside the sidebar
+  // shell — see `SidebarShell` in `(protected)/_layout.tsx`.
+  return <HomeScreenNew />;
 }

--- a/app/(protected)/(tabs)/rewards/benefits.tsx
+++ b/app/(protected)/(tabs)/rewards/benefits.tsx
@@ -14,10 +14,9 @@ import { useDimension } from '@/hooks/useDimension';
 import { useRewardsUserData, useTierBenefits } from '@/hooks/useRewards';
 
 export default function RewardsBenefits() {
-  // qa/preview builds see the redesigned tier-explore screen on mobile; desktop
-  // keeps the existing CompareTiersTable-based layout.
-  const { isDesktop } = useDimension();
-  return isDesktop ? <LegacyRewardsBenefits /> : <RewardsBenefitsScreenNew />;
+  // Desktop is the same redesigned tier-explore screen, stretched inside the
+  // sidebar shell — see `SidebarShell` in `(protected)/_layout.tsx`.
+  return <RewardsBenefitsScreenNew />;
 }
 
 function LegacyRewardsBenefits() {

--- a/app/(protected)/(tabs)/rewards/index.tsx
+++ b/app/(protected)/(tabs)/rewards/index.tsx
@@ -29,11 +29,9 @@ import { useRewardsWelcomePopupStore } from '@/store/useRewardsWelcomePopupStore
 import { useSpinWinModalStore } from '@/store/useSpinWinModalStore';
 
 export default function Rewards() {
-  // qa/preview builds see the redesigned rewards screen; production — and every
-  // desktop-web user — keep the existing design.
-  const { isDesktop } = useDimension();
-  const showNew = !isDesktop;
-  return showNew ? <RewardsScreenNew /> : <LegacyRewards />;
+  // Desktop is the same redesigned rewards screen, stretched inside the sidebar
+  // shell — see `SidebarShell` in `(protected)/_layout.tsx`.
+  return <RewardsScreenNew />;
 }
 
 function LegacyRewards() {

--- a/app/(protected)/(tabs)/savings.tsx
+++ b/app/(protected)/(tabs)/savings.tsx
@@ -43,11 +43,9 @@ import { useDepositStore } from '@/store/useDepositStore';
 import { useSavingStore } from '@/store/useSavingStore';
 
 export default function Savings() {
-  // qa/preview builds see the redesigned savings screen; production — and every
-  // desktop-web user — keep the existing design.
-  const { isDesktop } = useDimension();
-  const showNew = !isDesktop;
-  return showNew ? <SavingsScreenNew /> : <LegacySavings />;
+  // Desktop is the same redesigned savings screen, stretched inside the sidebar
+  // shell — see `SidebarShell` in `(protected)/_layout.tsx`.
+  return <SavingsScreenNew />;
 }
 
 function LegacySavings() {

--- a/app/(protected)/(tabs)/settings/index.tsx
+++ b/app/(protected)/(tabs)/settings/index.tsx
@@ -327,11 +327,8 @@ const DesktopSettings = () => {
 };
 
 export default function Settings() {
-  const { isDesktop } = useDimension();
-
-  if (isDesktop) {
-    return <DesktopSettings />;
-  }
-
+  // The sidebar's Profile item lands here, and desktop is the same redesigned
+  // profile screen, stretched inside the sidebar shell — see `SidebarShell` in
+  // `(protected)/_layout.tsx`.
   return <MobileSettings />;
 }

--- a/app/(protected)/_layout.tsx
+++ b/app/(protected)/_layout.tsx
@@ -12,6 +12,7 @@ import {
   BridgeTransferFiatCurrency,
 } from '@/components/BankTransfer/enums';
 import CardHeroOverlay from '@/components/Card/NewCardDetails/CardHeroOverlay';
+import { SidebarShell } from '@/components/Navbar/Sidebar';
 import { DEPOSIT_MODAL } from '@/constants/modals';
 import { path } from '@/constants/path';
 import { useActivitySSE } from '@/hooks/useActivitySSE';
@@ -182,75 +183,79 @@ export default function ProtectedLayout() {
 
   return (
     <View style={styles.root}>
-      <Stack
-        screenOptions={{
-          contentStyle: {
-            backgroundColor: '#0F0F10',
-          },
-          headerStyle: {
-            backgroundColor: '#0F0F10',
-          },
-          headerTintColor: '#fff',
-          headerTitleStyle: {
-            fontSize: 20,
-            fontWeight: 'bold',
-          },
-        }}
-      >
-        <Stack.Screen
-          name="(tabs)"
-          options={{
-            headerShown: false,
+      {/* The desktop sidebar is mounted here, above the navigator, so it lays out
+          once and stays put while the body beside it navigates or reloads. */}
+      <SidebarShell>
+        <Stack
+          screenOptions={{
+            contentStyle: {
+              backgroundColor: '#0F0F10',
+            },
+            headerStyle: {
+              backgroundColor: '#0F0F10',
+            },
+            headerTintColor: '#fff',
+            headerTitleStyle: {
+              fontSize: 20,
+              fontWeight: 'bold',
+            },
           }}
-        />
-        <Stack.Screen
-          name="quest-wallet"
-          options={{
-            headerShown: false,
-          }}
-        />
-        <Stack.Screen
-          name="coins/[id]"
-          options={{
-            headerShown: false,
-            animation: 'slide_from_right',
-          }}
-        />
-        <Stack.Screen
-          name="deposit"
-          options={{
-            headerShown: false,
-            animation: 'slide_from_right',
-          }}
-        />
-        <Stack.Screen
-          name="qr-scanner"
-          options={{
-            headerShown: false,
-            animation: 'slide_from_bottom',
-            presentation: 'fullScreenModal',
-          }}
-        />
-        <Stack.Screen
-          name="rescue-token"
-          options={{
-            headerShown: false,
-            animation: 'slide_from_right',
-          }}
-        />
-        <Stack.Screen
-          name="agent/index"
-          options={{
-            headerShown: false,
-          }}
-        />
-        <Stack.Screen
-          name="gooddollar/index"
-          options={{
-            headerShown: false,
-          }}
-        />
-      </Stack>
+        >
+          <Stack.Screen
+            name="(tabs)"
+            options={{
+              headerShown: false,
+            }}
+          />
+          <Stack.Screen
+            name="quest-wallet"
+            options={{
+              headerShown: false,
+            }}
+          />
+          <Stack.Screen
+            name="coins/[id]"
+            options={{
+              headerShown: false,
+              animation: 'slide_from_right',
+            }}
+          />
+          <Stack.Screen
+            name="deposit"
+            options={{
+              headerShown: false,
+              animation: 'slide_from_right',
+            }}
+          />
+          <Stack.Screen
+            name="qr-scanner"
+            options={{
+              headerShown: false,
+              animation: 'slide_from_bottom',
+              presentation: 'fullScreenModal',
+            }}
+          />
+          <Stack.Screen
+            name="rescue-token"
+            options={{
+              headerShown: false,
+              animation: 'slide_from_right',
+            }}
+          />
+          <Stack.Screen
+            name="agent/index"
+            options={{
+              headerShown: false,
+            }}
+          />
+          <Stack.Screen
+            name="gooddollar/index"
+            options={{
+              headerShown: false,
+            }}
+          />
+        </Stack>
+      </SidebarShell>
       {/* Root-level hero overlay for the card view-transition (redesigned
           screens only — stays dormant/null otherwise). Mounted above the whole
           navigator so the card can fly across the home → card/details change. */}

--- a/components/Card/NewCardDetails/CardDetailsPane.tsx
+++ b/components/Card/NewCardDetails/CardDetailsPane.tsx
@@ -19,6 +19,7 @@ import { getCardHeroDestination } from '@/components/Card/NewCardDetails/cardHer
 import CardLinksList from '@/components/Card/NewCardDetails/CardLinksList';
 import CardRevealSection from '@/components/Card/NewCardDetails/CardRevealSection';
 import { HERO_ENTER, HeroEnter } from '@/components/Card/NewCardDetails/heroMotion';
+import { usePageLeft } from '@/components/Navbar/Sidebar';
 import { useCardDetails } from '@/hooks/useCardDetails';
 import { useCardProvider } from '@/hooks/useCardProvider';
 import { useCardStatus } from '@/hooks/useCardStatus';
@@ -52,6 +53,8 @@ const CLOSE_SETTLE_MS = 640;
 const CardDetailsPane = () => {
   const insets = useSafeAreaInsets();
   const { width: windowWidth } = useWindowDimensions();
+  // On desktop this pane is a column beside the sidebar, not the whole window.
+  const pageLeft = usePageLeft();
   const isOpen = useCardPaneStore(state => state.isOpen);
   const originRect = useCardPaneStore(state => state.originRect);
   const closePane = useCardPaneStore(state => state.close);
@@ -120,13 +123,13 @@ const CardDetailsPane = () => {
   const close = useCallback(() => {
     if (originRect) {
       startFlight(
-        getCardHeroDestination({ windowWidth, topInset: insets.top }),
+        getCardHeroDestination({ windowWidth, topInset: insets.top, pageLeft }),
         originRect,
         cardDetails?.card_details?.last_4 ?? '',
       );
     }
     closePane();
-  }, [originRect, startFlight, windowWidth, insets.top, cardDetails, closePane]);
+  }, [originRect, startFlight, windowWidth, pageLeft, insets.top, cardDetails, closePane]);
 
   // Android's hardware back closes the pane, matching what the header's back button
   // does — without this it would leave the wallet screen entirely.

--- a/components/Card/NewCardDetails/cardHeroLayout.ts
+++ b/components/Card/NewCardDetails/cardHeroLayout.ts
@@ -40,20 +40,29 @@ interface DestinationArgs {
   windowWidth: number;
   /** Safe-area top inset of the destination screen. */
   topInset: number;
+  /**
+   * Left edge of the page the card lands on, in window coordinates. Zero on mobile,
+   * where the page spans the window; the sidebar's width on desktop, where the page
+   * is a column beside it (see `usePageLeft`).
+   */
+  pageLeft?: number;
 }
 
 /**
- * Where the card's artwork box comes to rest on the card-details screen. The card is
- * full-bleed — it spans the content container's full width, padding included — so
- * its width is the container's, capped by `max-w-lg` and centred.
+ * Where the card's artwork box comes to rest on the card-details screen, in window
+ * coordinates. The card is full-bleed — it spans the content container's full width,
+ * padding included — so its width is the container's, capped by `max-w-lg` and
+ * centred.
  */
 export const getCardHeroDestination = ({
   windowWidth,
   topInset,
+  pageLeft = 0,
 }: DestinationArgs): CardHeroRect => {
-  const width = Math.min(windowWidth, CONTENT_MAX_WIDTH);
+  const pageWidth = windowWidth - pageLeft;
+  const width = Math.min(pageWidth, CONTENT_MAX_WIDTH);
   return {
-    x: (windowWidth - width) / 2,
+    x: pageLeft + (pageWidth - width) / 2,
     y: topInset + HEADER_HEIGHT + CARD_TOP_GAP - width * CARD_TOP_SHADOW_RATIO,
     width,
     height: width / NEW_CARD_ASPECT_RATIO,

--- a/components/Home/NewHome/HomeWalletCard.tsx
+++ b/components/Home/NewHome/HomeWalletCard.tsx
@@ -5,6 +5,7 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { getCardHeroDestination } from '@/components/Card/NewCardDetails/cardHeroLayout';
 import NewCardArt from '@/components/Card/NewCardDetails/NewCardArt';
 import CardWaitingModal from '@/components/Home/CardWaitingModal';
+import { usePageLeft } from '@/components/Navbar/Sidebar';
 import { useHomeSetupSteps } from '@/hooks/useHomeSetupSteps';
 import { useCardHeroStore } from '@/store/useCardHeroStore';
 import { useCardPaneStore } from '@/store/useCardPaneStore';
@@ -35,6 +36,9 @@ const HomeWalletCard = ({ hasCard, last4, depositCompleted }: HomeWalletCardProp
   const ref = useRef<View>(null);
   const { width: windowWidth } = useWindowDimensions();
   const insets = useSafeAreaInsets();
+  // On desktop the pane the card flies to is a column beside the sidebar, not the
+  // whole window.
+  const pageLeft = usePageLeft();
   const [isVerificationOpen, setIsVerificationOpen] = useState(false);
   const { firstIncomplete } = useHomeSetupSteps(depositCompleted);
 
@@ -69,7 +73,11 @@ const HomeWalletCard = ({ hasCard, last4, depositCompleted }: HomeWalletCardProp
       const from = { x, y, width, height };
       // The destination is computed rather than reported by the pane, so the flight
       // starts on this frame instead of waiting on a layout pass.
-      start(from, getCardHeroDestination({ windowWidth, topInset: insets.top }), last4 ?? '');
+      start(
+        from,
+        getCardHeroDestination({ windowWidth, topInset: insets.top, pageLeft }),
+        last4 ?? '',
+      );
       openPane(from);
     });
   };

--- a/components/Navbar/Sidebar.tsx
+++ b/components/Navbar/Sidebar.tsx
@@ -1,0 +1,219 @@
+import { createContext, type ReactNode, useContext } from 'react';
+import { Pressable, useWindowDimensions, View } from 'react-native';
+import { Image } from 'expo-image';
+import { Href, router, usePathname } from 'expo-router';
+import { Bell, House, Sparkles, Zap } from 'lucide-react-native';
+
+import ProfileIcon from '@/assets/images/profile';
+import { Text } from '@/components/ui/text';
+import { path } from '@/constants/path';
+import { TRACKING_EVENTS } from '@/constants/tracking-events';
+import { useDimension } from '@/hooks/useDimension';
+import { track } from '@/lib/analytics';
+import { getAsset } from '@/lib/assets';
+import { cn } from '@/lib/utils';
+
+/** Figma 901:1180 — the sidebar is 18rem wide, inset 15px from the page edges. */
+const SIDEBAR_WIDTH = 288;
+const SIDEBAR_GUTTER = 15;
+/** How much of the window the sidebar takes: itself plus its gutters. */
+export const SIDEBAR_COLUMN_WIDTH = SIDEBAR_WIDTH + SIDEBAR_GUTTER * 2;
+
+/** Figma 901:1180 — the body column beside the sidebar. */
+export const SIDEBAR_BODY_MAX_WIDTH = 640;
+export const SIDEBAR_BODY_WIDTH = 'mx-auto w-full max-w-[40rem]';
+/** The body starts level with the design's "Wallet Balance" label, 65px down. */
+export const SIDEBAR_BODY_TOP_GUTTER = 64;
+
+const ICON_SLOT_SIZE = 24;
+const ICON_COLOR = '#FFFFFF';
+const ICON_STROKE_WIDTH = 1.8;
+
+type SidebarItem = {
+  label: string;
+  href: Href;
+  icon: ReactNode;
+  /**
+   * Route prefixes that keep this item highlighted. `/` only ever matches itself;
+   * everything else also matches its nested routes.
+   */
+  match: string[];
+};
+
+/**
+ * Wallet, Savings, Rewards and Activity — the mobile tab bar's three tabs plus the
+ * mobile header's bell, which has nowhere else to live on desktop.
+ */
+const NAV_ITEMS: SidebarItem[] = [
+  {
+    label: 'Wallet',
+    href: path.HOME,
+    icon: <House size={ICON_SLOT_SIZE} color={ICON_COLOR} strokeWidth={ICON_STROKE_WIDTH} />,
+    // The card lives on the wallet screen now (it opens as a pane), so its routes
+    // keep Wallet selected.
+    match: ['/', '/card', '/card-onboard'],
+  },
+  {
+    label: 'Savings',
+    href: path.SAVINGS,
+    icon: <Zap size={ICON_SLOT_SIZE} color={ICON_COLOR} strokeWidth={ICON_STROKE_WIDTH} />,
+    match: ['/savings'],
+  },
+  {
+    label: 'Rewards',
+    href: path.REWARDS,
+    icon: <Sparkles size={ICON_SLOT_SIZE} color={ICON_COLOR} strokeWidth={ICON_STROKE_WIDTH} />,
+    match: ['/rewards'],
+  },
+  {
+    label: 'Activity',
+    href: path.ACTIVITY,
+    icon: <Bell size={ICON_SLOT_SIZE} color={ICON_COLOR} strokeWidth={ICON_STROKE_WIDTH} />,
+    match: ['/activity'],
+  },
+];
+
+/** The mobile header's profile button, moved to the foot of the sidebar. */
+const PROFILE_ITEM: SidebarItem = {
+  label: 'Profile',
+  href: path.SETTINGS,
+  icon: <ProfileIcon width={16} height={20} />,
+  match: ['/settings'],
+};
+
+const isItemActive = (pathname: string, match: string[]) =>
+  match.some(prefix =>
+    prefix === '/' ? pathname === '/' : pathname === prefix || pathname.startsWith(`${prefix}/`),
+  );
+
+type SidebarLinkProps = {
+  item: SidebarItem;
+  isActive: boolean;
+};
+
+const SidebarLink = ({ item, isActive }: SidebarLinkProps) => (
+  <Pressable
+    accessibilityLabel={item.label}
+    accessibilityRole="link"
+    accessibilityState={{ selected: isActive }}
+    onPress={() => router.navigate(item.href)}
+    className={cn(
+      'h-[60px] flex-row items-center gap-[10px] rounded-full pl-[21px] transition-all',
+      isActive ? 'bg-[#2B2B2B]' : 'web:hover:bg-white/5',
+    )}
+  >
+    <View className="w-6 items-center">{item.icon}</View>
+    <Text className="text-[20px] font-medium leading-[22px] text-white">{item.label}</Text>
+  </Pressable>
+);
+
+/**
+ * Desktop sidebar (Figma 901:1180) — the `isScreenMedium` replacement for
+ * `<Navbar />` and for the mobile header's profile/activity buttons.
+ *
+ * `SidebarShell` mounts it once, above the navigator, so it lays out a single time
+ * and stays put while the body beside it navigates or reloads. It reads nothing
+ * asynchronous, so it has no loading state of its own.
+ */
+const Sidebar = () => {
+  const pathname = usePathname();
+
+  return (
+    <View style={{ width: SIDEBAR_COLUMN_WIDTH, padding: SIDEBAR_GUTTER }}>
+      <View className="flex-1 overflow-hidden rounded-[20px] bg-[#161616]">
+        <Pressable
+          accessibilityLabel="Solid"
+          accessibilityRole="link"
+          className="flex-row items-start gap-[7px] pl-[41px] pt-[50px]"
+          onPress={() => {
+            track(TRACKING_EVENTS.NAVBAR_LOGO_CLICKED, { source: 'sidebar' });
+            router.navigate(path.HOME);
+          }}
+        >
+          <Image
+            source={getAsset('images/solid-logo.png')}
+            alt="Solid logo"
+            contentFit="contain"
+            style={{ width: 22, height: 24, marginTop: 3 }}
+          />
+          <Image
+            source={getAsset('images/solid-4x.png')}
+            alt="Solid"
+            contentFit="contain"
+            style={{ width: 64, height: 25 }}
+          />
+        </Pressable>
+
+        <View className="mt-[54px] gap-[7px] px-[14px]">
+          {NAV_ITEMS.map(item => (
+            <SidebarLink
+              key={item.label}
+              item={item}
+              isActive={isItemActive(pathname, item.match)}
+            />
+          ))}
+        </View>
+
+        <View className="mt-auto px-[14px] pb-[32px]">
+          <SidebarLink item={PROFILE_ITEM} isActive={isItemActive(pathname, PROFILE_ITEM.match)} />
+        </View>
+      </View>
+    </View>
+  );
+};
+
+const SidebarShellContext = createContext(false);
+
+/**
+ * True while rendering inside the desktop sidebar shell. `PageLayout` uses it to
+ * drop the page's own navbar (the sidebar carries navigation) and to lay the body
+ * out as a centred 40rem column.
+ */
+export const useIsSidebarShell = () => useContext(SidebarShellContext);
+
+/**
+ * Left edge of the page column in window coordinates — 0 on mobile, past the
+ * sidebar on desktop. For geometry that has to be in window coordinates, such as
+ * the card hero flight.
+ */
+export const usePageLeft = () => {
+  const isSidebarShell = useIsSidebarShell();
+
+  return isSidebarShell ? SIDEBAR_COLUMN_WIDTH : 0;
+};
+
+/**
+ * Width of the column a page actually gets: the window on mobile, the 40rem body
+ * column on desktop. Full-bleed layouts that size themselves off the window
+ * (pagers, carousels) need this rather than `useWindowDimensions`.
+ */
+export const usePageWidth = () => {
+  const { width } = useWindowDimensions();
+  const pageLeft = usePageLeft();
+
+  return pageLeft ? Math.min(width - pageLeft, SIDEBAR_BODY_MAX_WIDTH) : width;
+};
+
+type SidebarShellProps = {
+  children: ReactNode;
+};
+
+/**
+ * Wraps the protected navigator so the sidebar sits beside it rather than inside
+ * it. `children` keeps its position in the tree at every width, so crossing the
+ * breakpoint never remounts the navigator.
+ */
+export const SidebarShell = ({ children }: SidebarShellProps) => {
+  const { isScreenMedium } = useDimension();
+
+  return (
+    <SidebarShellContext.Provider value={isScreenMedium}>
+      <View className="flex-1 flex-row bg-background">
+        {isScreenMedium && <Sidebar />}
+        <View className="flex-1">{children}</View>
+      </View>
+    </SidebarShellContext.Provider>
+  );
+};
+
+export default Sidebar;

--- a/components/PageLayout.tsx
+++ b/components/PageLayout.tsx
@@ -15,6 +15,7 @@ import { useDimension } from '@/hooks/useDimension';
 import Loading from './Loading';
 import Navbar from './Navbar';
 import NavbarMobile from './Navbar/NavbarMobile';
+import { SIDEBAR_BODY_TOP_GUTTER, SIDEBAR_BODY_WIDTH, useIsSidebarShell } from './Navbar/Sidebar';
 import WhatsNewButton from './Navbar/WhatsNewButton';
 import { useRegisterTabBarBlurTarget } from './tabBar/TabBarBlurContext';
 
@@ -176,6 +177,7 @@ export default function PageLayout({
   contentClassName = '',
 }: PageLayoutProps) {
   const { isScreenMedium, isDesktop } = useDimension();
+  const isSidebarShell = useIsSidebarShell();
   const pathname = usePathname();
   const insets = useSafeAreaInsets();
   const mobileBlurTargetRef = useRef<View>(null);
@@ -191,7 +193,10 @@ export default function PageLayout({
 
   // Determine what to show for navbar
   const shouldShowDesktopNavbar = showNavbar && (!desktopOnly || isLargeScreen);
-  const shouldShowMobileNavbar = showNavbar && !desktopOnly && !isLargeScreen;
+  // Inside the desktop sidebar shell the sidebar carries navigation — including the
+  // profile and activity buttons that sit in the mobile header — so no page renders
+  // a navbar of its own there.
+  const shouldShowMobileNavbar = showNavbar && !desktopOnly && !isLargeScreen && !isSidebarShell;
   const shouldOverlayMobileNavbar = shouldShowMobileNavbar && !customMobileHeader;
   const shouldShowScrollableWhatsNew =
     shouldOverlayMobileNavbar && mobileHeaderRightAction === 'default';
@@ -199,6 +204,10 @@ export default function PageLayout({
   const resolvedBlurTargetRef = blurTargetRef ?? mobileBlurTargetRef;
   const safeAreaEdges = shouldOverlayMobileNavbar ? edges.filter(edge => edge !== 'top') : edges;
   const mobileContentOffset = shouldOverlayMobileNavbar ? mobileNavbarOffset : 0;
+  // Headerless pages in the sidebar shell get the design's top gutter here, so the
+  // content clears the top of the window the way the mobile navbar's offset does.
+  const contentTopOffset =
+    mobileContentOffset || (isSidebarShell && !customMobileHeader ? SIDEBAR_BODY_TOP_GUTTER : 0);
 
   useRegisterTabBarBlurTarget(mobileBlurTargetRef, shouldOverlayMobileNavbar && !isLoading);
 
@@ -217,6 +226,10 @@ export default function PageLayout({
 
   // Render navbar/header content
   const renderNavbar = (isOverlay = false) => {
+    // Desktop sidebar shell: the sidebar stands in for the navbar. Screens that
+    // bring their own header (settings and friends) keep it.
+    if (isSidebarShell) return customMobileHeader ?? null;
+
     if (isLargeScreen) {
       // Desktop navbar/header
       return customDesktopHeader || (shouldShowDesktopNavbar && <Navbar />);
@@ -241,11 +254,32 @@ export default function PageLayout({
     );
   };
 
+  // In the sidebar shell the page is a centred 40rem column beside the sidebar. The
+  // top gutter goes on the header when there is one, and on the content otherwise
+  // (see contentTopOffset above).
+  const renderHeader = () => {
+    const header = renderNavbar();
+    if (!isSidebarShell || !header) return header;
+
+    return (
+      <View className={SIDEBAR_BODY_WIDTH} style={{ paddingTop: SIDEBAR_BODY_TOP_GUTTER }}>
+        {header}
+      </View>
+    );
+  };
+
+  const renderBody = (content: ReactNode, fill = false) =>
+    isSidebarShell ? (
+      <View className={`${SIDEBAR_BODY_WIDTH} ${fill ? 'flex-1' : ''}`}>{content}</View>
+    ) : (
+      content
+    );
+
   // Show loading state with navbar
   if (isLoading) {
     return (
       <SafeAreaView className={`flex-1 bg-background text-foreground ${className}`} edges={edges}>
-        {renderNavbar()}
+        {renderHeader()}
         <Loading />
       </SafeAreaView>
     );
@@ -256,9 +290,7 @@ export default function PageLayout({
     const scrollView = (
       <ScrollView
         className={`flex-1 ${contentClassName}`}
-        contentContainerStyle={
-          mobileContentOffset ? { paddingTop: mobileContentOffset } : undefined
-        }
+        contentContainerStyle={contentTopOffset ? { paddingTop: contentTopOffset } : undefined}
         scrollEnabled={scrollEnabled}
         contentInsetAdjustmentBehavior={shouldOverlayMobileNavbar ? 'never' : 'automatic'}
         onScroll={shouldOverlayMobileNavbar ? handleMobileScroll : undefined}
@@ -283,8 +315,12 @@ export default function PageLayout({
             <WhatsNewButton />
           </View>
         )}
-        {stickyHeader && <View className="z-10 bg-background">{stickyHeader}</View>}
-        {children}
+        {stickyHeader && (
+          <View className={`z-10 bg-background ${isSidebarShell ? SIDEBAR_BODY_WIDTH : ''}`}>
+            {stickyHeader}
+          </View>
+        )}
+        {renderBody(children)}
       </ScrollView>
     );
 
@@ -299,7 +335,7 @@ export default function PageLayout({
           </BlurTargetView>
         ) : (
           <>
-            {renderNavbar()}
+            {renderHeader()}
             {scrollView}
           </>
         )}
@@ -321,7 +357,7 @@ export default function PageLayout({
           <BlurTargetView ref={resolvedBlurTargetRef} style={styles.mobileBlurTarget}>
             <View
               className={`flex-1 ${contentClassName}`}
-              style={mobileContentOffset ? { paddingTop: mobileContentOffset } : undefined}
+              style={contentTopOffset ? { paddingTop: contentTopOffset } : undefined}
             >
               {shouldShowScrollableWhatsNew && (
                 <View
@@ -339,8 +375,13 @@ export default function PageLayout({
                   <WhatsNewButton />
                 </View>
               )}
-              {stickyHeader}
-              {children}
+              {renderBody(
+                <>
+                  {stickyHeader}
+                  {children}
+                </>,
+                true,
+              )}
             </View>
           </BlurTargetView>
           {shouldOverlayMobileNavbar && (
@@ -349,10 +390,18 @@ export default function PageLayout({
         </>
       ) : (
         <>
-          {renderNavbar()}
-          <View className={`flex-1 ${contentClassName}`}>
-            {stickyHeader}
-            {children}
+          {renderHeader()}
+          <View
+            className={`flex-1 ${contentClassName}`}
+            style={contentTopOffset ? { paddingTop: contentTopOffset } : undefined}
+          >
+            {renderBody(
+              <>
+                {stickyHeader}
+                {children}
+              </>,
+              true,
+            )}
           </View>
         </>
       )}

--- a/components/Rewards/NewRewards/RewardsBenefitsScreenNew.tsx
+++ b/components/Rewards/NewRewards/RewardsBenefitsScreenNew.tsx
@@ -1,5 +1,5 @@
 import { type RefObject, useEffect, useRef, useState } from 'react';
-import { Dimensions, LayoutChangeEvent, Platform, Pressable, StyleSheet, View } from 'react-native';
+import { LayoutChangeEvent, Platform, Pressable, StyleSheet, View } from 'react-native';
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 import Animated, {
   Easing,
@@ -20,6 +20,7 @@ import {
   CoreRocketPerkIcon,
   CoreTierSparkle,
 } from '@/assets/images/rewards-tiers/core-tier-icons';
+import { useIsSidebarShell, usePageWidth } from '@/components/Navbar/Sidebar';
 import PageLayout from '@/components/PageLayout';
 import { BackButton } from '@/components/ui/back-button';
 import { Text } from '@/components/ui/text';
@@ -722,7 +723,6 @@ const SLIDE_DURATION = 260;
 const SLIDE_EASING = Easing.out(Easing.cubic);
 const SWIPE_DISTANCE_THRESHOLD = 50;
 const SWIPE_VELOCITY_THRESHOLD = 400;
-const SCREEN_WIDTH = Dimensions.get('window').width;
 // Dampens the drag past the first/last tier so it feels like it's resisting.
 const RUBBER_BAND_FACTOR = 0.3;
 // bg-background (--background), used as the solid end of the top/bottom fades.
@@ -735,6 +735,8 @@ const FADE_EXTENT = 120;
 interface TierPageProps {
   tier: RewardsTier;
   isCurrentTier: boolean;
+  /** Width of the page column — the window on mobile, the body column on desktop. */
+  pageWidth: number;
 }
 
 /**
@@ -743,7 +745,7 @@ interface TierPageProps {
  * between real, already-rendered pages instead of faking it with a fade/slide
  * of a single swapped-out content block.
  */
-const TierPage = ({ tier, isCurrentTier }: TierPageProps) => {
+const TierPage = ({ tier, isCurrentTier, pageWidth }: TierPageProps) => {
   const insets = useSafeAreaInsets();
   const content = TIER_CONTENT[tier];
   const subtitle = isCurrentTier ? 'Your current tier' : content.unlockCopy;
@@ -752,7 +754,7 @@ const TierPage = ({ tier, isCurrentTier }: TierPageProps) => {
     return (
       <View
         style={{
-          width: SCREEN_WIDTH,
+          width: pageWidth,
           paddingTop: insets.top + HEADER_ROW_HEIGHT,
           paddingBottom: insets.bottom,
         }}
@@ -825,7 +827,7 @@ const TierPage = ({ tier, isCurrentTier }: TierPageProps) => {
   return (
     <View
       style={{
-        width: SCREEN_WIDTH,
+        width: pageWidth,
         paddingTop: insets.top + HEADER_ROW_HEIGHT,
         paddingBottom: insets.bottom,
       }}
@@ -920,26 +922,30 @@ export default function RewardsBenefitsScreenNew() {
   );
   const insets = useSafeAreaInsets();
   const tierBlurTargetRef = useRef<View>(null);
+  // The pager's pages are as wide as the column the page gets, which on desktop is
+  // the body column beside the sidebar rather than the whole window.
+  const pageWidth = usePageWidth();
+  const isSidebarShell = useIsSidebarShell();
   // Suspends the page's vertical ScrollView while a horizontal swipe is active,
   // so the two gestures (a plain RN ScrollView isn't gesture-handler-aware)
   // don't both react to the same touch and fight over the drag.
   const [isSwiping, setIsSwiping] = useState(false);
 
-  // Pixel offset of the 3-wide pager row. -index * SCREEN_WIDTH is "at rest" on
+  // Pixel offset of the 3-wide pager row. -index * pageWidth is "at rest" on
   // that tier; onUpdate adds the live drag delta so real, already-rendered
   // neighboring pages follow the finger instead of faking a swipe with a
   // fade/slide of a single swapped-out content block.
-  const translateX = useSharedValue(-TIERS.indexOf(selectedTier) * SCREEN_WIDTH);
+  const translateX = useSharedValue(-TIERS.indexOf(selectedTier) * pageWidth);
   const isDragging = useSharedValue(false);
 
   useEffect(() => {
     if (isDragging.value) return;
     const index = TIERS.indexOf(selectedTier);
-    translateX.value = withTiming(-index * SCREEN_WIDTH, {
+    translateX.value = withTiming(-index * pageWidth, {
       duration: SLIDE_DURATION,
       easing: SLIDE_EASING,
     });
-  }, [selectedTier, translateX, isDragging]);
+  }, [selectedTier, translateX, isDragging, pageWidth]);
 
   const rowStyle = useAnimatedStyle(() => ({
     transform: [{ translateX: translateX.value }],
@@ -1009,7 +1015,7 @@ export default function RewardsBenefitsScreenNew() {
       let dx = event.translationX;
       if (index === 0 && dx > 0) dx *= RUBBER_BAND_FACTOR;
       if (index === TIERS.length - 1 && dx < 0) dx *= RUBBER_BAND_FACTOR;
-      translateX.value = -index * SCREEN_WIDTH + dx;
+      translateX.value = -index * pageWidth + dx;
     })
     .onEnd(event => {
       'worklet';
@@ -1025,7 +1031,7 @@ export default function RewardsBenefitsScreenNew() {
       else if (isSwipeRight && index > 0) targetIndex = index - 1;
 
       translateX.value = withTiming(
-        -targetIndex * SCREEN_WIDTH,
+        -targetIndex * pageWidth,
         { duration: SLIDE_DURATION, easing: SLIDE_EASING },
         finished => {
           if (finished && targetIndex !== index) {
@@ -1049,11 +1055,20 @@ export default function RewardsBenefitsScreenNew() {
       scrollEnabled={!isSwiping}
     >
       <GestureDetector gesture={swipeGesture}>
-        <Animated.View style={[{ flexDirection: 'row' }, rowStyle]}>
-          {TIERS.map(tier => (
-            <TierPage key={tier} tier={tier} isCurrentTier={rewardsData?.currentTier === tier} />
-          ))}
-        </Animated.View>
+        {/* Desktop: the row is three columns wide, so clip the neighbouring tiers at
+            the column's edge — on mobile they simply hang off-screen. */}
+        <View style={isSidebarShell ? { width: pageWidth, overflow: 'hidden' } : undefined}>
+          <Animated.View style={[{ flexDirection: 'row' }, rowStyle]}>
+            {TIERS.map(tier => (
+              <TierPage
+                key={tier}
+                tier={tier}
+                isCurrentTier={rewardsData?.currentTier === tier}
+                pageWidth={pageWidth}
+              />
+            ))}
+          </Animated.View>
+        </View>
       </GestureDetector>
     </PageLayout>
   );


### PR DESCRIPTION
## Summary
Introduces a desktop sidebar navigation component and layout system that replaces the mobile navbar and bottom tab bar on medium+ screens. The sidebar is mounted above the navigator in the layout tree to persist across route changes, with pages rendered in a centered column beside it.

## Key Changes

- **New Sidebar Component** (`components/Navbar/Sidebar.tsx`):
  - Desktop sidebar with logo, main navigation (Wallet, Savings, Rewards, Activity), and profile link
  - `SidebarShell` wrapper that mounts the sidebar above the navigator
  - Context hooks (`useIsSidebarShell`, `usePageLeft`, `usePageWidth`) for pages to adapt to the sidebar layout
  - Exports layout constants for the 288px sidebar width and 640px max body column width

- **Layout Integration**:
  - Wrapped the protected navigator with `SidebarShell` in `app/(protected)/_layout.tsx`
  - Updated `PageLayout` to detect sidebar shell context and adjust navbar/header rendering accordingly
  - Pages in the sidebar shell render without their own navbar (sidebar carries navigation) and content is centered in a 40rem column
  - Added top gutter spacing for headerless pages to match design specs

- **Page Adaptations**:
  - Updated `RewardsBenefitsScreenNew` to use `usePageWidth()` instead of `Dimensions.get('window').width` for the tier pager
  - Updated card hero flight animation (`cardHeroLayout.ts`) to account for `pageLeft` offset in window coordinates
  - Updated `HomeWalletCard` to pass `pageLeft` to card hero destination calculation
  - Simplified screen selection logic in home, rewards, savings, and benefits screens to always show redesigned versions (sidebar shell handles desktop)

- **Navigation Updates**:
  - Changed tab bar visibility condition from `isDesktop` to `isScreenMedium` in `(tabs)/_layout.tsx`
  - Removed desktop-specific settings screen variant; profile now uses the same redesigned screen in sidebar shell

## Implementation Details

- The sidebar is positioned outside the navigator so it persists and lays out once, while the body beside it navigates independently
- Pages detect sidebar context via `useIsSidebarShell()` to conditionally render navbars and apply body column styling
- Geometry-dependent features (card hero flight, pagers) use `usePageWidth()` and `usePageLeft()` to account for the sidebar offset
- The design maintains the mobile-first responsive approach: sidebar only renders on `isScreenMedium` breakpoint and up

https://claude.ai/code/session_01Uim9wSonVD3vUgrGHLJ4YC