### PR TITLE
feat(onboarding): static hero and pill buttons on desktop

### DIFF
--- a/components/Onboarding/DesktopHero.tsx
+++ b/components/Onboarding/DesktopHero.tsx
@@ -1,0 +1,46 @@
+import { View } from 'react-native';
+import { Image } from 'expo-image';
+
+import { Text } from '@/components/ui/text';
+import { useLandingPageApy } from '@/hooks/useLandingPageApy';
+import { getAsset } from '@/lib/assets';
+
+/**
+ * Left panel of the desktop onboarding split screen (Figma 907:1203) — the same
+ * full-bleed hero the redesigned mobile landing uses, sized for the panel.
+ *
+ * It replaced `DesktopCarousel` here: one static image and one headline, no slides,
+ * no pagination and no drag gesture. The carousel itself stays — the welcome
+ * (account-selection) screen still uses it.
+ *
+ * The headline steps up at `xl`; below that the panel is close to its 280px floor,
+ * where the desktop type size would wrap mid-word.
+ */
+export function DesktopHero() {
+  const { apy } = useLandingPageApy();
+  // Falls back to 8 while loading or when no APY is configured, so the copy never
+  // renders "0%" — same as the mobile landing.
+  const apyLabel = apy > 0 ? Number(apy.toFixed(1)) : 8;
+
+  return (
+    <View className="m-4 w-[28%] min-w-[280px] max-w-[540px] overflow-hidden rounded-2xl bg-[#111]">
+      <Image
+        source={getAsset('images/onboarding_hero_bg.png')}
+        alt=""
+        style={{ position: 'absolute', width: '100%', height: '100%' }}
+        contentFit="cover"
+      />
+
+      <View className="flex-1 justify-end px-8 pb-12 xl:px-10 xl:pb-14">
+        <Text className="text-[36px] font-medium leading-[36px] -tracking-[2px] text-white xl:text-[52px] xl:leading-[52px]">
+          Your Money{'\n'}Never Sleeps
+        </Text>
+
+        <Text className="mt-4 text-base leading-[1.2] text-white/70 xl:text-[20px]">
+          Earn up to {apyLabel}% return on your savings automatically, and spend globally with your
+          Solid card, all in one account.
+        </Text>
+      </View>
+    </View>
+  );
+}

--- a/components/Onboarding/LegacyOnboarding.tsx
+++ b/components/Onboarding/LegacyOnboarding.tsx
@@ -17,7 +17,7 @@ import { useShallow } from 'zustand/react/shallow';
 import LoginKeyIcon from '@/assets/images/login_key_icon';
 import {
   AnimatedGradientBackground,
-  DesktopCarousel,
+  DesktopHero,
   OnboardingPage,
   OnboardingPagination,
 } from '@/components/Onboarding';
@@ -119,11 +119,6 @@ export default function LegacyOnboarding() {
   const handleRecoverAccount = useCallback(() => {
     router.push(path.RECOVERY);
   }, [router]);
-
-  const handleHelpCenter = useCallback(() => {
-    // TODO: Add help center link
-    // Linking.openURL(HELP_CENTER_URL);
-  }, []);
 
   const filteredOnboardingData = ONBOARDING_DATA.filter(slide => slide?.platform !== false);
 
@@ -247,10 +242,8 @@ export default function LegacyOnboarding() {
   // Desktop Layout - Split Screen
   return (
     <View className="flex-1 flex-row bg-background">
-      {/* Left Section - Interactive Carousel */}
-      {/* TODO: lazy-loaded for FCP improvement */}
-      {/* <LazyDesktopCarousel onHelpCenterPress={handleHelpCenter} /> */}
-      <DesktopCarousel onHelpCenterPress={handleHelpCenter} />
+      {/* Left Section - Static hero */}
+      <DesktopHero />
 
       {/* Right Section - Auth Options (70%) */}
       <View className="relative flex-1">
@@ -290,7 +283,7 @@ export default function LegacyOnboarding() {
               {/* Create Account Button */}
               <Button
                 variant="brand"
-                className="h-14 w-full rounded-xl"
+                className="h-14 w-full rounded-full"
                 onPress={handleCreateAccount}
               >
                 <Text className="text-base font-bold">Create account</Text>
@@ -306,7 +299,7 @@ export default function LegacyOnboarding() {
               {/* Login Button */}
               <Button
                 variant="secondary"
-                className="h-14 w-full rounded-xl border-0"
+                className="h-14 w-full rounded-full border-0"
                 onPress={handleLoginPress}
                 disabled={isLoginPending}
               >

--- a/components/Onboarding/index.ts
+++ b/components/Onboarding/index.ts
@@ -1,4 +1,5 @@
 export { AnimatedGradientBackground } from './AnimatedGradientBackground';
 export { DesktopCarousel } from './DesktopCarousel';
+export { DesktopHero } from './DesktopHero';
 export { OnboardingPage } from './OnboardingPage';
 export { OnboardingPagination } from './OnboardingPagination';


### PR DESCRIPTION
Figma 907:1180 / 907:1203.

The left panel was an interactive carousel — three Lottie slides, gradient crossfades, pagination dots and a drag gesture. It's now a single static hero: the same image and headline the redesigned mobile landing uses (onboarding_hero_bg.png, "Your Money Never Sleeps", the APY-aware copy), so no new asset or wording. Panel width tracks the design's proportion, and the headline steps down below `xl`, where the panel nears its 280px floor.

Create account and Login become pills.

Everything else on the page is untouched — logo, "Welcome!", the headline and description, the OR divider, and the post-failure recovery prompt. DesktopCarousel itself stays: the welcome (account-selection) screen still uses it, and that page is unchanged.


Claude-Session: https://claude.ai/code/session_01Uim9wSonVD3vUgrGHLJ4YC