### PR TITLE
fix(desktop): sidebar icons, card width, Add Funds cap

### DIFF
--- a/components/Card/NewCardDetails/CardRevealSection.tsx
+++ b/components/Card/NewCardDetails/CardRevealSection.tsx
@@ -8,10 +8,10 @@ import CardDetailsPanel, {
   REVEAL_DURATION,
 } from '@/components/Card/NewCardDetails/CardDetailsPanel';
 import {
+  CARD_BODY_BLEED_PERCENT,
   CARD_BOTTOM_SHADOW_RATIO,
   CARD_TOP_GAP,
   CARD_TOP_SHADOW_RATIO,
-  CONTENT_PADDING,
 } from '@/components/Card/NewCardDetails/cardHeroLayout';
 import CardHeroTarget from '@/components/Card/NewCardDetails/CardHeroTarget';
 import CardRevealFace from '@/components/Card/NewCardDetails/CardRevealFace';
@@ -197,9 +197,15 @@ const CardRevealSection = ({
 };
 
 const styles = StyleSheet.create({
-  // Full-bleed past the screen's px-4, matching the home card exactly — that
-  // identical size is what makes the hero transition read as one card.
-  slot: { marginHorizontal: -CONTENT_PADDING, marginTop: CARD_TOP_GAP, position: 'relative' },
+  // Out past the screen's px-4 and far enough to cancel the shadow the artwork bakes
+  // into each side, so the visible card spans the content column rather than sitting
+  // inside it. Matches the home card exactly — that identical size is what makes the
+  // hero transition read as one card.
+  slot: {
+    marginHorizontal: `${-CARD_BODY_BLEED_PERCENT}%`,
+    marginTop: CARD_TOP_GAP,
+    position: 'relative',
+  },
   // Cancelling the artwork's baked-in shadow makes this box exactly the card BODY, so
   // the gap above and the panel tucked in below are measured off the visible card.
   // RN resolves percentage margins against the parent's WIDTH, which is why these

--- a/components/Card/NewCardDetails/cardHeroLayout.ts
+++ b/components/Card/NewCardDetails/cardHeroLayout.ts
@@ -34,6 +34,20 @@ export const CARD_TOP_GAP = 48;
 export const CARD_TOP_SHADOW_RATIO = 0.04762;
 /** And 9.910% of the height, i.e. 6.388% of the width, below it. */
 export const CARD_BOTTOM_SHADOW_RATIO = 0.06388;
+/**
+ * The artwork bakes shadow into each side too — 48px of its 861px width. Left
+ * uncancelled it made the visible card noticeably narrower than the sections around
+ * it, and the wider the column the worse it got (39px short at 640px).
+ */
+export const CARD_SIDE_SHADOW_RATIO = 48 / 861;
+/** The visible card body's share of the artwork's width. */
+export const CARD_BODY_WIDTH_RATIO = 1 - CARD_SIDE_SHADOW_RATIO * 2;
+/**
+ * Negative horizontal margin that grows the artwork box until the visible card body
+ * spans the content column exactly — as a share of that column, so it goes in a
+ * style as `${-CARD_BODY_BLEED_PERCENT}%`.
+ */
+export const CARD_BODY_BLEED_PERCENT = (CARD_SIDE_SHADOW_RATIO / CARD_BODY_WIDTH_RATIO) * 100;
 
 interface DestinationArgs {
   /** Window width in dp. */
@@ -50,9 +64,9 @@ interface DestinationArgs {
 
 /**
  * Where the card's artwork box comes to rest on the card-details screen, in window
- * coordinates. The card is full-bleed — it spans the content container's full width,
- * padding included — so its width is the container's, capped by `max-w-lg` and
- * centred.
+ * coordinates. The visible card spans the content column — the container capped by
+ * `max-w-lg`, less its `px-4` — so the artwork box around it is wider still by the
+ * shadow it bakes into each side, and centred on the same column.
  */
 export const getCardHeroDestination = ({
   windowWidth,
@@ -60,7 +74,8 @@ export const getCardHeroDestination = ({
   pageLeft = 0,
 }: DestinationArgs): CardHeroRect => {
   const pageWidth = windowWidth - pageLeft;
-  const width = Math.min(pageWidth, CONTENT_MAX_WIDTH);
+  const containerWidth = Math.min(pageWidth, CONTENT_MAX_WIDTH);
+  const width = (containerWidth - CONTENT_PADDING * 2) / CARD_BODY_WIDTH_RATIO;
   return {
     x: pageLeft + (pageWidth - width) / 2,
     y: topInset + HEADER_HEIGHT + CARD_TOP_GAP - width * CARD_TOP_SHADOW_RATIO,

--- a/components/Home/NewHome/HomeScreenNew.tsx
+++ b/components/Home/NewHome/HomeScreenNew.tsx
@@ -160,9 +160,9 @@ export default function HomeScreenNew() {
           </View>
         )}
 
-        {/* The card is rendered full-bleed (no px-4): the PNG's baked-in drop
-            shadow (~4% each side) acts as the gutter, so the card BODY lines up
-            with the px-4 sections below instead of looking inset/narrower. */}
+        {/* HomeWalletCard brings its own px-4 and bleeds back out by the shadow the
+            PNG bakes into each side, so the visible card lines up with the sections
+            below rather than sitting inset. */}
         <View className="gap-3">
           <HomeWalletCard
             hasCard={userHasCard}

--- a/components/Home/NewHome/HomeWalletCard.tsx
+++ b/components/Home/NewHome/HomeWalletCard.tsx
@@ -2,7 +2,10 @@ import { useRef, useState } from 'react';
 import { Pressable, StyleSheet, useWindowDimensions, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
-import { getCardHeroDestination } from '@/components/Card/NewCardDetails/cardHeroLayout';
+import {
+  CARD_BODY_BLEED_PERCENT,
+  getCardHeroDestination,
+} from '@/components/Card/NewCardDetails/cardHeroLayout';
 import NewCardArt from '@/components/Card/NewCardDetails/NewCardArt';
 import CardWaitingModal from '@/components/Home/CardWaitingModal';
 import { usePageLeft } from '@/components/Navbar/Sidebar';
@@ -47,7 +50,9 @@ const HomeWalletCard = ({ hasCard, last4, depositCompleted }: HomeWalletCardProp
   if (!hasCard) {
     return (
       <>
-        <Pressable onPress={() => setIsVerificationOpen(true)}>{card}</Pressable>
+        <Pressable onPress={() => setIsVerificationOpen(true)} className="px-4">
+          <View style={styles.cardBox}>{card}</View>
+        </Pressable>
         <CardWaitingModal
           isOpen={isVerificationOpen}
           onClose={() => setIsVerificationOpen(false)}
@@ -86,17 +91,25 @@ const HomeWalletCard = ({ hasCard, last4, depositCompleted }: HomeWalletCardProp
     // Hidden for as long as the pane owns the card — while it flies, and while the
     // pane is open — so no copy is left behind under the (background-less) pane.
     <Pressable
-      ref={ref}
-      collapsable={false}
       onPress={handlePress}
+      className="px-4"
       style={heroActive || isPaneOpen ? styles.hidden : undefined}
     >
-      {card}
+      {/* The measured node is the artwork box, not this gutter — the hero flight's
+          `from` rect has to be the same box getCardHeroDestination predicts. */}
+      <View ref={ref} collapsable={false} style={styles.cardBox}>
+        {card}
+      </View>
     </Pressable>
   );
 };
 
 const styles = StyleSheet.create({
+  // The artwork bakes a drop shadow into each side, so a box the width of the content
+  // column draws a card visibly narrower than the sections around it. Sitting in the
+  // same px-4 gutter and bleeding back out by the shadow's share lines the visible
+  // card up with them exactly.
+  cardBox: { marginHorizontal: `${-CARD_BODY_BLEED_PERCENT}%` },
   hidden: { opacity: 0 },
 });
 

--- a/components/Home/NewHome/WalletActions.tsx
+++ b/components/Home/NewHome/WalletActions.tsx
@@ -19,7 +19,9 @@ const AddFundsTrigger = ({ fullWidth, ...props }: TriggerProps & { fullWidth: bo
     {...props}
     className={cn(
       'h-14 flex-row items-center justify-center rounded-full bg-white transition-all active:scale-95 active:opacity-80',
-      fullWidth ? 'w-full' : 'flex-1',
+      // On its own it stops at 24rem and centres, rather than stretching the full
+      // width of a desktop column.
+      fullWidth ? 'mx-auto w-full max-w-[24rem]' : 'flex-1',
     )}
   >
     <Text className="text-base font-bold text-black">Add Funds</Text>

--- a/components/Navbar/Sidebar.tsx
+++ b/components/Navbar/Sidebar.tsx
@@ -2,9 +2,11 @@ import { createContext, type ReactNode, useContext } from 'react';
 import { Pressable, useWindowDimensions, View } from 'react-native';
 import { Image } from 'expo-image';
 import { Href, router, usePathname } from 'expo-router';
-import { Bell, House, Sparkles, Zap } from 'lucide-react-native';
 
+import ActivityIcon from '@/assets/images/activity-nav-bar-icon';
+import HomeIcon from '@/assets/images/assets-nav-bar-icon';
 import ProfileIcon from '@/assets/images/profile';
+import SavingsIcon from '@/assets/images/savings-nav-bar-icon';
 import { Text } from '@/components/ui/text';
 import { path } from '@/constants/path';
 import { TRACKING_EVENTS } from '@/constants/tracking-events';
@@ -25,9 +27,15 @@ export const SIDEBAR_BODY_WIDTH = 'mx-auto w-full max-w-[40rem]';
 /** The body starts level with the design's "Wallet Balance" label, 65px down. */
 export const SIDEBAR_BODY_TOP_GUTTER = 64;
 
-const ICON_SLOT_SIZE = 24;
-const ICON_COLOR = '#FFFFFF';
-const ICON_STROKE_WIDTH = 1.8;
+// Not literal white: the nav icons fill their glyph when handed white (see
+// `isInactiveColor` in each) and the sidebar wants the design's outline.
+const ICON_COLOR = 'rgba(255, 255, 255, 0.92)';
+/**
+ * The rewards mark is artwork rather than a line icon, and it carries padding of its
+ * own, so it needs a bigger box than the 24px icons to read at the same weight —
+ * which is the size Figma 901:1302 gives it.
+ */
+const REWARDS_ICON = { width: 31, height: 26 } as const;
 
 type SidebarItem = {
   label: string;
@@ -48,7 +56,7 @@ const NAV_ITEMS: SidebarItem[] = [
   {
     label: 'Wallet',
     href: path.HOME,
-    icon: <House size={ICON_SLOT_SIZE} color={ICON_COLOR} strokeWidth={ICON_STROKE_WIDTH} />,
+    icon: <HomeIcon color={ICON_COLOR} />,
     // The card lives on the wallet screen now (it opens as a pane), so its routes
     // keep Wallet selected.
     match: ['/', '/card', '/card-onboard'],
@@ -56,19 +64,26 @@ const NAV_ITEMS: SidebarItem[] = [
   {
     label: 'Savings',
     href: path.SAVINGS,
-    icon: <Zap size={ICON_SLOT_SIZE} color={ICON_COLOR} strokeWidth={ICON_STROKE_WIDTH} />,
+    icon: <SavingsIcon color={ICON_COLOR} />,
     match: ['/savings'],
   },
   {
     label: 'Rewards',
     href: path.REWARDS,
-    icon: <Sparkles size={ICON_SLOT_SIZE} color={ICON_COLOR} strokeWidth={ICON_STROKE_WIDTH} />,
+    icon: (
+      <Image
+        source={getAsset('images/reward-tier-star.png')}
+        alt=""
+        style={REWARDS_ICON}
+        contentFit="contain"
+      />
+    ),
     match: ['/rewards'],
   },
   {
     label: 'Activity',
     href: path.ACTIVITY,
-    icon: <Bell size={ICON_SLOT_SIZE} color={ICON_COLOR} strokeWidth={ICON_STROKE_WIDTH} />,
+    icon: <ActivityIcon color={ICON_COLOR} />,
     match: ['/activity'],
   },
 ];


### PR DESCRIPTION
Sidebar icons are now the app's own: the home, flash and bell nav icons (asked for near-white rather than white — each fills its glyph when handed literal white) and reward-tier-star.png for Rewards, at the size Figma 901:1302 gives it since the artwork carries padding of its own.

The card artwork bakes a drop shadow into each side — 48px of its 861px width, so 5.575% a side, not the ~4% the code assumed. Drawing the box at the content column's width therefore drew a card 11% narrower than the sections around it, and the wider the column the worse it looked: 39px short of "Finish verification" at 640px. The card now sits in the same px-4 gutter as those sections and bleeds back out by the shadow's share, so the visible card body spans the column exactly. The same treatment goes on the card-details pane and into getCardHeroDestination, which keeps the home and pane boxes identical — the invariant the hero flight depends on (verified: scale 1.0 at 390 and 768, unchanged 0.79 asymmetry on desktop, where the pane is capped at max-w-lg).

Add Funds stops at 24rem and centres when it's the only action.


Claude-Session: https://claude.ai/code/session_01Uim9wSonVD3vUgrGHLJ4YC