### PR TITLE
fix(rewards, card): tier band, tabs, card heights, tap blocking

### DIFF
--- a/components/Card/NewCardDetails/CardRevealSection.tsx
+++ b/components/Card/NewCardDetails/CardRevealSection.tsx
@@ -149,10 +149,21 @@ const CardRevealSection = ({
 
   return (
     <View style={styles.slot}>
-      {/* box-none: the artwork's transparent shadow overlaps the panel below, so the
-          wrapper must never be a touch target itself — but the copy buttons on the
-          revealed face still need to receive taps. */}
-      <View className="z-10" style={styles.cardBody} pointerEvents="box-none">
+      {/* box-none while the pane is open: the artwork's transparent shadow overlaps the
+          panel below, so the wrapper must never be a touch target itself — but the copy
+          buttons on the revealed face still need to receive taps.
+
+          It has to go back to 'none' when the pane closes. The pane stays mounted and
+          laid out (transparent, pointerEvents="none") so it can open instantly, and on
+          web `box-none` compiles to `pointer-events: none` on this view plus
+          `> * { pointer-events: auto }` — which handed hit-testing back to the invisible
+          card and left it swallowing taps aimed at the wallet's balance pill and action
+          buttons underneath. */}
+      <View
+        className="z-10"
+        style={styles.cardBody}
+        pointerEvents={isPaneOpen ? 'box-none' : 'none'}
+      >
         <CardHeroTarget>
           <View style={styles.cardStack}>
             <Animated.View style={frontStyle} pointerEvents="none">

--- a/components/Rewards/NewRewards/DailyBenefits.tsx
+++ b/components/Rewards/NewRewards/DailyBenefits.tsx
@@ -121,7 +121,7 @@ const BenefitCard = ({
       accessibilityRole={onPress ? 'button' : undefined}
       disabled={!onPress}
       onPress={onPress}
-      className="h-[136px] flex-1 items-center rounded-twice bg-card pt-[21px] transition-all active:scale-95 active:opacity-80"
+      className="h-[136px] w-full items-center rounded-twice bg-card pt-[21px] transition-all active:scale-95 active:opacity-80"
     >
       <Icon />
       <Text
@@ -154,14 +154,23 @@ const DailyBenefits = ({
   return (
     <View className="gap-[15px] px-4">
       <Text className="text-base font-normal text-white/50">Your tier benefits</Text>
+      {/* Every card sits in its own flex-1 column and sets its own height. The
+          cashback one is wrapped by CashbackDetailsSheet's own flex-1 View, so when
+          the cards themselves carried the flex the cashback card ended up flexing
+          along its column's vertical axis instead — which is what left it shorter
+          than the other two. */}
       <View className="flex-row gap-[15px]">
         <CashbackDetailsSheet
           trigger={<BenefitCard benefit={cashbackBenefit} />}
           {...cashbackData}
           onGetMoreCashback={onGetMoreCashback}
         />
-        <BenefitCard benefit={referralsBenefit} onPress={onReferralsPress} />
-        <BenefitCard benefit={supportBenefit} onPress={onSupportPress} />
+        <View className="flex-1">
+          <BenefitCard benefit={referralsBenefit} onPress={onReferralsPress} />
+        </View>
+        <View className="flex-1">
+          <BenefitCard benefit={supportBenefit} onPress={onSupportPress} />
+        </View>
       </View>
     </View>
   );

--- a/components/Rewards/NewRewards/RewardsBenefitsScreenNew.tsx
+++ b/components/Rewards/NewRewards/RewardsBenefitsScreenNew.tsx
@@ -1,5 +1,5 @@
-import { type RefObject, useEffect, useRef, useState } from 'react';
-import { LayoutChangeEvent, Platform, Pressable, StyleSheet, View } from 'react-native';
+import { useEffect, useRef, useState } from 'react';
+import { LayoutChangeEvent, Pressable, StyleSheet, View } from 'react-native';
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 import Animated, {
   Easing,
@@ -9,7 +9,6 @@ import Animated, {
 } from 'react-native-reanimated';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { scheduleOnRN } from 'react-native-worklets';
-import { BlurView } from 'expo-blur';
 import { Image } from 'expo-image';
 import { LinearGradient } from 'expo-linear-gradient';
 import { router } from 'expo-router';
@@ -30,6 +29,7 @@ import { type AssetPath, getAsset } from '@/lib/assets';
 import { RewardsTier } from '@/lib/types';
 
 import TierPointsSheet from './TierPointsSheet';
+import TierStatsBand from './TierStatsBand';
 
 const TIERS = [RewardsTier.CORE, RewardsTier.PRIME, RewardsTier.ULTRA];
 
@@ -58,9 +58,6 @@ const TIER_HERO_SIZES: Record<RewardsTier, number> = {
 
 const TIER_HERO_GLOW_ASSET: AssetPath = 'images/rewards-tiers/glow.svg';
 
-const CORE_SUMMARY = require('@/assets/images/rewards-tiers/core-summary.png');
-const PRIME_SUMMARY = require('@/assets/images/rewards-tiers/prime-summary.png');
-const ULTRA_SUMMARY = require('@/assets/images/rewards-tiers/ultra-summary.png');
 const PRIME_TIER_SPARKLE = require('@/assets/images/rewards-tiers/prime-tier-sparkle.png');
 const ULTRA_TIER_SPARKLE = require('@/assets/images/rewards-tiers/ultra-tier-sparkle.png');
 const TIER_INFO = require('@/assets/images/rewards-tiers/tier-info.png');
@@ -259,23 +256,30 @@ const TIER_CONTENT: Record<RewardsTier, TierContent> = {
 interface TierSwitcherProps {
   selected: RewardsTier;
   onSelect: (tier: RewardsTier) => void;
-  blurTarget: RefObject<View | null>;
 }
 
 type SegmentLayout = { x: number; width: number };
 
-const TierSwitcher = ({ selected, onSelect, blurTarget }: TierSwitcherProps) => {
+const TIER_TAB_STYLE = { fontFamily: 'MonaSans_500Medium', fontSize: 15, lineHeight: 18 } as const;
+
+/**
+ * Segmented tier control. The selected tab is a filled pill that slides from the
+ * previous tab to the tapped one; the track itself is transparent, so the tabs read
+ * as buttons over the page rather than as a black bar.
+ */
+const TierSwitcher = ({ selected, onSelect }: TierSwitcherProps) => {
   const layouts = useRef<Partial<Record<RewardsTier, SegmentLayout>>>({});
   const indicatorX = useSharedValue(0);
   const indicatorWidth = useSharedValue(0);
 
+  // The pill covers its tab exactly — it used to be inset by 8px, which read as a
+  // stray highlight rather than a selected button.
   const handleLayout = (tier: RewardsTier) => (event: LayoutChangeEvent) => {
     const { x, width } = event.nativeEvent.layout;
-    const indicatorLayout = { x: x + 1, width: width - 8 };
-    layouts.current[tier] = indicatorLayout;
+    layouts.current[tier] = { x, width };
     if (tier === selected) {
-      indicatorX.value = indicatorLayout.x;
-      indicatorWidth.value = indicatorLayout.width;
+      indicatorX.value = x;
+      indicatorWidth.value = width;
     }
   };
 
@@ -290,37 +294,21 @@ const TierSwitcher = ({ selected, onSelect, blurTarget }: TierSwitcherProps) => 
     transform: [{ translateX: indicatorX.value }],
     width: indicatorWidth.value,
   }));
-  const blurViewProps =
-    Platform.OS === 'android'
-      ? {
-          blurMethod: 'dimezisBlurView' as const,
-          blurReductionFactor: 3.2,
-          blurTarget,
-        }
-      : {};
 
   return (
     <View
-      className="h-[33px] w-[248px] flex-row items-center self-center overflow-hidden rounded-full p-1"
+      className="h-11 flex-row items-center self-center rounded-full p-1"
       style={{
-        borderColor: 'rgba(255,255,255,0.08)',
+        borderColor: 'rgba(255,255,255,0.12)',
         borderWidth: StyleSheet.hairlineWidth,
-        transform: [{ translateY: 9 }],
       }}
     >
-      <BlurView
-        {...blurViewProps}
-        intensity={80}
-        pointerEvents="none"
-        style={StyleSheet.absoluteFill}
-        tint="systemChromeMaterialDark"
-      />
-      <View
-        pointerEvents="none"
-        style={[StyleSheet.absoluteFillObject, { backgroundColor: 'rgba(0,0,0,0.56)' }]}
-      />
+      {/* left-0 anchors the pill to the track's own origin, so translateX can be the
+          tab's measured x. Without it the pill starts at its static position — one
+          padding-width in — and lands offset from the tab it is meant to cover. */}
       <Animated.View
-        className="absolute bottom-1 top-1 rounded-full bg-white/15"
+        className="absolute bottom-1 left-0 top-1 rounded-full bg-white/15"
+        pointerEvents="none"
         style={indicatorStyle}
       />
       {TIERS.map(tier => (
@@ -328,16 +316,9 @@ const TierSwitcher = ({ selected, onSelect, blurTarget }: TierSwitcherProps) => 
           key={tier}
           onPress={() => onSelect(tier)}
           onLayout={handleLayout(tier)}
-          className="flex-1 items-center justify-center"
+          className="h-9 items-center justify-center rounded-full px-6 transition-all active:opacity-70"
         >
-          <Text
-            className="text-white"
-            style={{
-              fontFamily: 'MonaSans_500Medium',
-              fontSize: 14,
-              lineHeight: 17,
-            }}
-          >
+          <Text className="text-white" style={TIER_TAB_STYLE}>
             {TIER_LABELS[tier]}
           </Text>
         </Pressable>
@@ -421,14 +402,7 @@ const CoreSummaryAndPerks = () => {
 
   return (
     <View className="mx-4 mt-[45px]">
-      <View className="h-[137px] overflow-hidden rounded-twice">
-        <Image
-          source={CORE_SUMMARY}
-          style={StyleSheet.absoluteFillObject}
-          contentFit="fill"
-          accessibilityLabel="3% cashback. 24/7 fast support."
-        />
-      </View>
+      <TierStatsBand stats={content.stats} />
 
       <View className="-mt-[41px] h-[270px] overflow-hidden rounded-twice bg-[#1C1C1C]">
         {content.perks.map((perk, index) => (
@@ -569,19 +543,11 @@ const PremiumPerkIcon = ({ index }: { index: number }) => {
 
 const PremiumSummaryAndPerks = ({ tier }: { tier: RewardsTier.PRIME | RewardsTier.ULTRA }) => {
   const content = TIER_CONTENT[tier];
-  const summary = tier === RewardsTier.PRIME ? PRIME_SUMMARY : ULTRA_SUMMARY;
   const discount = tier === RewardsTier.PRIME ? '25%' : '50%';
 
   return (
     <View className="mx-4 mt-[59px]">
-      <View className="h-[137px] overflow-hidden rounded-twice">
-        <Image
-          source={summary}
-          style={StyleSheet.absoluteFillObject}
-          contentFit="fill"
-          accessibilityLabel={content.stats.map(stat => `${stat.value} ${stat.label}`).join('. ')}
-        />
-      </View>
+      <TierStatsBand stats={content.stats} />
 
       <View className="-mt-[42px] h-[270px] overflow-hidden rounded-twice bg-[#1C1C1C]">
         {content.perks.map((perk, index) => (
@@ -921,7 +887,6 @@ export default function RewardsBenefitsScreenNew() {
     () => rewardsData?.currentTier ?? RewardsTier.CORE,
   );
   const insets = useSafeAreaInsets();
-  const tierBlurTargetRef = useRef<View>(null);
   // The pager's pages are as wide as the column the page gets, which on desktop is
   // the body column beside the sidebar rather than the whole window.
   const pageWidth = usePageWidth();
@@ -975,11 +940,7 @@ export default function RewardsBenefitsScreenNew() {
           <View className="absolute left-4 top-4">
             <BackButton variant="header" onPress={() => router.push(path.REWARDS)} />
           </View>
-          <TierSwitcher
-            selected={selectedTier}
-            onSelect={setSelectedTier}
-            blurTarget={tierBlurTargetRef}
-          />
+          <TierSwitcher selected={selectedTier} onSelect={setSelectedTier} />
         </View>
       </LinearGradient>
 
@@ -1051,7 +1012,6 @@ export default function RewardsBenefitsScreenNew() {
       showNavbar={false}
       edges={['left', 'right']}
       additionalContent={overlays}
-      blurTargetRef={tierBlurTargetRef}
       scrollEnabled={!isSwiping}
     >
       <GestureDetector gesture={swipeGesture}>

--- a/components/Rewards/NewRewards/TierStatsBand.tsx
+++ b/components/Rewards/NewRewards/TierStatsBand.tsx
@@ -1,0 +1,106 @@
+import { StyleSheet, View } from 'react-native';
+import Svg, { Defs, Path, Pattern, Rect } from 'react-native-svg';
+import { LinearGradient } from 'expo-linear-gradient';
+
+import { Text } from '@/components/ui/text';
+
+/** Total height of the band. Its foot is tucked behind the perks card below. */
+export const TIER_STATS_BAND_HEIGHT = 137;
+/** How much of that foot the perks card covers. */
+export const TIER_STATS_BAND_TUCK = 41;
+/** The part that stays on screen — the stats sit here so nothing is tucked away. */
+const VISIBLE_HEIGHT = TIER_STATS_BAND_HEIGHT - TIER_STATS_BAND_TUCK;
+
+const BAND_GRADIENT = ['rgba(148, 242, 127, 0.15)', 'rgba(148, 242, 127, 0.05)'] as const;
+const DIVIDER_COLOR = 'rgba(255, 255, 255, 0.1)';
+
+// One tile of the wave texture: two half-period-offset rows, so tiling weaves them.
+const WAVE_TILE = { width: 40, height: 26 };
+const WAVE_COLOR = 'rgba(255, 255, 255, 0.08)';
+
+/** Measured off the design's band: 26px value over a 16px label. */
+const VALUE_STYLE = { fontFamily: 'MonaSans_600SemiBold', fontSize: 26, lineHeight: 30 } as const;
+const LABEL_STYLE = { fontFamily: 'MonaSans_400Regular', fontSize: 16, lineHeight: 19 } as const;
+
+export interface TierStat {
+  label: string;
+  /** Empty for a label-only column, e.g. Core's "24/7 Fast support". */
+  value: string;
+}
+
+/**
+ * Tiled wave texture, drawn rather than shipped as a bitmap so it never stretches
+ * with the band. Swap in an exported asset here if the design's own texture is
+ * needed — `<Image resizeMode="repeat">` keeps the same tiling behaviour.
+ */
+const WaveTexture = () => (
+  <Svg width="100%" height="100%" style={StyleSheet.absoluteFillObject} pointerEvents="none">
+    <Defs>
+      <Pattern
+        id="tierStatsWaves"
+        x="0"
+        y="0"
+        width={WAVE_TILE.width}
+        height={WAVE_TILE.height}
+        patternUnits="userSpaceOnUse"
+      >
+        <Path d="M0 6.5 Q 10 0 20 6.5 T 40 6.5" stroke={WAVE_COLOR} strokeWidth={1} fill="none" />
+        <Path
+          d="M0 19.5 Q 10 26 20 19.5 T 40 19.5"
+          stroke={WAVE_COLOR}
+          strokeWidth={1}
+          fill="none"
+        />
+      </Pattern>
+    </Defs>
+    <Rect x="0" y="0" width="100%" height="100%" fill="url(#tierStatsWaves)" />
+  </Svg>
+);
+
+/**
+ * The green headline stats above each tier's perks card — two columns for Core, three
+ * for Prime and Ultra, split by hairline dividers.
+ *
+ * This used to be a flat PNG per tier drawn with `contentFit="fill"`, which stretched
+ * its baked-in text horizontally as soon as the band was wider than the 385px it was
+ * exported at — badly so on desktop. Everything here is laid out instead, so it holds
+ * at any width, and the copy comes from the tier's own `stats`.
+ */
+const TierStatsBand = ({ stats }: { stats: readonly TierStat[] }) => (
+  <View
+    className="overflow-hidden rounded-t-twice"
+    style={{ height: TIER_STATS_BAND_HEIGHT }}
+    pointerEvents="none"
+  >
+    <LinearGradient colors={BAND_GRADIENT} style={StyleSheet.absoluteFill} />
+    <WaveTexture />
+
+    <View className="flex-row" style={{ height: VISIBLE_HEIGHT }}>
+      {stats.map((stat, index) => (
+        <View className="flex-1 flex-row" key={stat.label}>
+          {index > 0 && <View style={styles.divider} />}
+          <View className="flex-1 items-center justify-center px-2">
+            {!!stat.value && (
+              <Text className="text-center text-brand" style={VALUE_STYLE}>
+                {stat.value}
+              </Text>
+            )}
+            <Text className="text-center text-white" style={LABEL_STYLE}>
+              {stat.label}
+            </Text>
+          </View>
+        </View>
+      ))}
+    </View>
+  </View>
+);
+
+const styles = StyleSheet.create({
+  divider: {
+    backgroundColor: DIVIDER_COLOR,
+    marginVertical: 10,
+    width: StyleSheet.hairlineWidth,
+  },
+});
+
+export default TierStatsBand;


### PR DESCRIPTION
Tap blocking on the wallet screen. The card-details pane stays mounted and laid out so it can open instantly — transparent, zIndex 60, pointerEvents "none". But the card wrapper inside it asked for "box-none", which react-native-web compiles to `pointer-events: none` on the element plus `> * { pointer-events: auto }`. That handed hit-testing straight back to the invisible card, which sits over the balance pill and the Add Funds / Swap / Send row, so taps there hit a card nobody could see. It is "box-none" only while the pane is open now.

Tier stats band. Was one flat PNG per tier drawn with contentFit="fill", so its baked-in text stretched horizontally past the 385px it was exported at — badly on desktop. Rebuilt as layout: green gradient, hairline dividers, a tiled SVG wave texture that cannot stretch, 1.25rem top corners, and the stats read from the tier's own `stats` (2 columns for Core, 3 for the rest — same copy the images carried). Geometry is unchanged: 137 tall, stats in the visible 96 with the rest tucked behind the perks card.

Tier tabs. 44px track with real 36px buttons sized by their own padding instead of a 33px bar pinned to 248px, no black fill or blur behind the track, and the pill now covers the selected tab exactly (it was inset 8px and offset by the track's padding) as it slides between tabs.

Cashback benefit card. CashbackDetailsSheet wraps its trigger in a flex-1 View, so the card's own flex-1 was flexing along that column's vertical axis and losing its height. Each card now sits in its own flex-1 column and sets its own height, leaving all three equal.


Claude-Session: https://claude.ai/code/session_01Uim9wSonVD3vUgrGHLJ4YC