### PR TITLE
Add card country gate to home card CTAs

### DIFF
--- a/app/(protected)/(tabs)/card-onboard/country_selection.tsx
+++ b/app/(protected)/(tabs)/card-onboard/country_selection.tsx
@@ -36,8 +36,15 @@ export default function CountrySelection() {
   const router = useRouter();
   const { user } = useUser();
 
+  // Return to wherever the flow started — the redesigned home reaches this
+  // screen from its card CTAs, so a hard replace to /card would strand the user
+  // on a page the new UI no longer links to.
   const goBack = () => {
-    router.replace(path.CARD);
+    if (router.canGoBack()) {
+      router.back();
+    } else {
+      router.replace(path.CARD);
+    }
   };
 
   const [loading, setLoading] = useState(true);

--- a/components/Home/CardWaitingModal.tsx
+++ b/components/Home/CardWaitingModal.tsx
@@ -1,5 +1,12 @@
-import { useEffect } from 'react';
-import { ImageSourcePropType, Platform, Pressable, ScrollView, View } from 'react-native';
+import { useEffect, useState } from 'react';
+import {
+  ActivityIndicator,
+  ImageSourcePropType,
+  Platform,
+  Pressable,
+  ScrollView,
+  View,
+} from 'react-native';
 import Animated, {
   Easing,
   useAnimatedStyle,
@@ -10,13 +17,20 @@ import Animated, {
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { Image } from 'expo-image';
 import { LinearGradient } from 'expo-linear-gradient';
+import { useRouter } from 'expo-router';
 import { ArrowLeft } from 'lucide-react-native';
 
 import ResponsiveModal from '@/components/ResponsiveModal';
 import { Button } from '@/components/ui/button';
 import { Text } from '@/components/ui/text';
+import { path } from '@/constants/path';
+import { TRACKING_EVENTS } from '@/constants/tracking-events';
+import { useCardStatus } from '@/hooks/useCardStatus';
 import { HomeSetupStep } from '@/hooks/useHomeSetupSteps';
+import { track } from '@/lib/analytics';
 import { getAsset } from '@/lib/assets';
+import { resolveCardCountry } from '@/lib/cardCountryGate';
+import { hasCard, hasCardStatusWithRainApplication } from '@/lib/utils';
 
 interface CardWaitingModalProps {
   isOpen: boolean;
@@ -90,7 +104,14 @@ const BenefitCell = ({
  * original FinishSetupModal remains available.
  */
 const CardWaitingModal = ({ isOpen, onClose, firstIncomplete }: CardWaitingModalProps) => {
+  const router = useRouter();
   const insets = useSafeAreaInsets();
+  const [checkingCountry, setCheckingCountry] = useState(false);
+  const { data: cardStatus } = useCardStatus();
+  // Same escape hatch as `skipCountryCheck` in useActivateCard: someone holding
+  // a card, or already part-way through a Rain application, has cleared the
+  // country gate once and must not be bounced back out of the flow.
+  const skipCountryGate = hasCard(cardStatus) || hasCardStatusWithRainApplication(cardStatus);
   // On Android (edge-to-edge) the safe-area bottom inset can come back smaller
   // than the actual system nav bar inside the dialog portal, leaving the pinned
   // CTA sitting too close to the bottom edge. Floor it so the button always
@@ -131,9 +152,41 @@ const CardWaitingModal = ({ isOpen, onClose, firstIncomplete }: CardWaitingModal
     ],
   }));
 
-  const handleVerify = () => {
-    onClose();
-    firstIncomplete?.onPress?.();
+  // The country gate the old `/card` page's "Get your card" button ran (via
+  // `/card/activate`) before anything else. The step actions below jump straight
+  // into KYC / activation, so without this the country selection screen would
+  // never be shown and KYC would start with no country to route the provider on.
+  // The deposit step needs no card country, so it skips the gate.
+  const handleVerify = async () => {
+    if (checkingCountry) return;
+
+    track(TRACKING_EVENTS.CARD_GET_CARD_PRESSED, {
+      source: 'home_card_waiting_modal',
+      step: firstIncomplete?.key,
+    });
+
+    if (!firstIncomplete || firstIncomplete.key === 'deposit' || skipCountryGate) {
+      onClose();
+      firstIncomplete?.onPress?.();
+      return;
+    }
+
+    setCheckingCountry(true);
+    try {
+      const result = await resolveCardCountry('home_card_waiting_modal');
+
+      // Close before navigating — the destination shouldn't mount under an open
+      // modal (matches the previous close-then-act ordering).
+      onClose();
+
+      if (result === 'supported') {
+        firstIncomplete.onPress?.();
+      } else {
+        router.push(path.CARD_COUNTRY_SELECTION);
+      }
+    } finally {
+      setCheckingCountry(false);
+    }
   };
 
   return (
@@ -249,8 +302,13 @@ const CardWaitingModal = ({ isOpen, onClose, firstIncomplete }: CardWaitingModal
               variant="brand"
               className="h-[50px] w-full rounded-full border-0 active:opacity-90"
               onPress={handleVerify}
+              disabled={checkingCountry}
             >
-              <Text className="text-[16px] font-semibold text-black">Verify now</Text>
+              {checkingCountry ? (
+                <ActivityIndicator color="#000" />
+              ) : (
+                <Text className="text-[16px] font-semibold text-black">Verify now</Text>
+              )}
             </Button>
           </View>
         </LinearGradient>

--- a/hooks/useHomeSetupSteps.ts
+++ b/hooks/useHomeSetupSteps.ts
@@ -8,6 +8,8 @@ import { useCardSteps } from '@/hooks/useCardSteps';
 import { useDepositStore } from '@/store/useDepositStore';
 
 export interface HomeSetupStep {
+  /** Stable identifier — callers gate on this rather than matching on `title`. */
+  key: 'kyc' | 'card' | 'deposit';
   title: string;
   description: string;
   /** Short label used on the primary CTA button when this is the next step */
@@ -48,6 +50,7 @@ export function useHomeSetupSteps(depositCompleted: boolean): HomeSetupStepsResu
 
     const steps: HomeSetupStep[] = [
       {
+        key: 'kyc',
         title: 'Verify your identity',
         description: '3 min to unlock all features',
         cta: 'Verify your identity',
@@ -55,6 +58,7 @@ export function useHomeSetupSteps(depositCompleted: boolean): HomeSetupStepsResu
         onPress: kycStep?.onPress ?? (() => router.push(path.CARD)),
       },
       {
+        key: 'card',
         title: 'Get your free virtual card',
         description: 'Global payments, cashback and more',
         cta: 'Get your card',
@@ -62,6 +66,7 @@ export function useHomeSetupSteps(depositCompleted: boolean): HomeSetupStepsResu
         onPress: cardStep?.onPress ?? (() => router.push(path.CARD)),
       },
       {
+        key: 'deposit',
         title: 'Top up your balance',
         description: 'Via bank transfers or crypto',
         cta: 'Top up your balance',

--- a/lib/__tests__/cardCountryGate.test.ts
+++ b/lib/__tests__/cardCountryGate.test.ts
@@ -1,0 +1,112 @@
+/// <reference types="jest" />
+
+import { checkCardAccess, getClientIp, getCountryFromIp } from '@/lib/api';
+import { resolveCardCountry } from '@/lib/cardCountryGate';
+import { useCountryStore } from '@/store/useCountryStore';
+
+// The country store persists through MMKV, which has no native module under jest.
+jest.mock('@/lib/mmvkStorage', () => ({
+  __esModule: true,
+  default: () => ({
+    setItem: jest.fn(),
+    getItem: () => null,
+    removeItem: jest.fn(),
+  }),
+}));
+
+jest.mock('@/lib/analytics', () => ({ track: jest.fn() }));
+
+// Only `withRefreshToken` is used from @/lib/utils; stubbing it keeps the whole
+// wallet/viem dependency tree out of this test.
+jest.mock('@/lib/utils', () => ({
+  withRefreshToken: <T>(apiCall: () => Promise<T>) => apiCall(),
+}));
+
+jest.mock('@/lib/api', () => ({
+  getClientIp: jest.fn(),
+  getCountryFromIp: jest.fn(),
+  checkCardAccess: jest.fn(),
+}));
+
+const mockGetClientIp = getClientIp as jest.MockedFunction<typeof getClientIp>;
+const mockGetCountryFromIp = getCountryFromIp as jest.MockedFunction<typeof getCountryFromIp>;
+const mockCheckCardAccess = checkCardAccess as jest.MockedFunction<typeof checkCardAccess>;
+
+describe('resolveCardCountry', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useCountryStore.getState().clearCountryInfo();
+  });
+
+  it('proceeds without any lookup when the active country is already supported', async () => {
+    useCountryStore.getState().setCountryInfo({
+      countryCode: 'US',
+      countryName: 'United States',
+      isAvailable: true,
+    });
+
+    await expect(resolveCardCountry()).resolves.toBe('supported');
+    expect(mockGetClientIp).not.toHaveBeenCalled();
+    expect(mockCheckCardAccess).not.toHaveBeenCalled();
+  });
+
+  it('asks for a country when the IP cannot be resolved', async () => {
+    mockGetClientIp.mockResolvedValue(null);
+
+    await expect(resolveCardCountry()).resolves.toBe('needs_selection');
+    expect(mockGetCountryFromIp).not.toHaveBeenCalled();
+  });
+
+  it('proceeds when the detected country has card access, and caches it', async () => {
+    mockGetClientIp.mockResolvedValue('1.2.3.4');
+    mockGetCountryFromIp.mockResolvedValue({ countryCode: 'US', countryName: 'United States' });
+    mockCheckCardAccess.mockResolvedValue({ hasAccess: true, countryCode: 'US' });
+
+    await expect(resolveCardCountry()).resolves.toBe('supported');
+    expect(useCountryStore.getState().countryInfo).toMatchObject({
+      countryCode: 'US',
+      isAvailable: true,
+      source: 'ip',
+    });
+
+    // Second run is served from the store — no repeat lookups.
+    await expect(resolveCardCountry()).resolves.toBe('supported');
+    expect(mockCheckCardAccess).toHaveBeenCalledTimes(1);
+  });
+
+  it('asks for a country when the detected country has no card access', async () => {
+    mockGetClientIp.mockResolvedValue('1.2.3.4');
+    mockGetCountryFromIp.mockResolvedValue({ countryCode: 'RU', countryName: 'Russia' });
+    mockCheckCardAccess.mockResolvedValue({ hasAccess: false, countryCode: 'RU' });
+
+    await expect(resolveCardCountry()).resolves.toBe('needs_selection');
+    expect(useCountryStore.getState().countryInfo).toMatchObject({
+      countryCode: 'RU',
+      isAvailable: false,
+    });
+
+    // The cached "not available" answer is reused rather than re-checked.
+    await expect(resolveCardCountry()).resolves.toBe('needs_selection');
+    expect(mockCheckCardAccess).toHaveBeenCalledTimes(1);
+  });
+
+  it('asks for a country when country detection fails, and does not retry it', async () => {
+    mockGetClientIp.mockResolvedValue('1.2.3.4');
+    mockGetCountryFromIp.mockResolvedValue(null);
+
+    await expect(resolveCardCountry()).resolves.toBe('needs_selection');
+    expect(useCountryStore.getState().countryDetectionFailed).toBe(true);
+
+    await expect(resolveCardCountry()).resolves.toBe('needs_selection');
+    expect(mockGetCountryFromIp).toHaveBeenCalledTimes(1);
+  });
+
+  it('asks for a country when the access check throws', async () => {
+    mockGetClientIp.mockResolvedValue('1.2.3.4');
+    mockGetCountryFromIp.mockResolvedValue({ countryCode: 'US', countryName: 'United States' });
+    mockCheckCardAccess.mockRejectedValue(new Error('boom'));
+
+    await expect(resolveCardCountry()).resolves.toBe('needs_selection');
+    expect(useCountryStore.getState().countryDetectionFailed).toBe(true);
+  });
+});

--- a/lib/cardCountryGate.ts
+++ b/lib/cardCountryGate.ts
@@ -1,0 +1,152 @@
+import { TRACKING_EVENTS } from '@/constants/tracking-events';
+import { track } from '@/lib/analytics';
+import { checkCardAccess, getClientIp, getCountryFromIp } from '@/lib/api';
+import { withRefreshToken } from '@/lib/utils';
+import { useCountryStore } from '@/store/useCountryStore';
+
+/**
+ * Outcome of the card country gate.
+ *
+ * - `supported` — the country is known and the card is available there, so the
+ *   caller can continue straight into the card / KYC flow.
+ * - `needs_selection` — the country is unknown, undetectable or unsupported, so
+ *   the caller must send the user to the country selection screen
+ *   (`path.CARD_COUNTRY_SELECTION`) before anything else.
+ */
+export type CardCountryGateResult = 'supported' | 'needs_selection';
+
+/**
+ * Resolves the user's card country the same way `/card/activate` does on mount
+ * (see `useCountryCheck`), but imperatively — so an entry point that isn't a
+ * screen can run the same gate before it navigates.
+ *
+ * This is the logic behind the old `/card` page's "Get your card" button: it
+ * pushed to `/card/activate`, whose mount-time check funnels anyone whose
+ * country can't be confirmed into the country selection screen. The redesigned
+ * home CTAs open KYC directly, so they call this first to keep that step.
+ *
+ * Never throws — any failure means "we can't confirm the country", which hands
+ * the decision to the user on the selection screen.
+ *
+ * @param source analytics label for the entry point that ran the gate
+ */
+export const resolveCardCountry = async (source?: string): Promise<CardCountryGateResult> => {
+  const store = useCountryStore.getState();
+
+  track(TRACKING_EVENTS.CARD_COUNTRY_CHECK_STARTED, { source });
+
+  try {
+    // Already resolved — detected earlier, or picked by hand on the selection
+    // screen. Mirrors `validCountryInfo` in useCountryCheck.
+    if (store.countryInfo?.isAvailable) {
+      track(TRACKING_EVENTS.CARD_COUNTRY_AVAILABILITY_CHECKED, {
+        countryCode: store.countryInfo.countryCode,
+        countryName: store.countryInfo.countryName,
+        isAvailable: true,
+        source: 'cached_country_info',
+      });
+      return 'supported';
+    }
+
+    let ip = store.getCachedIp();
+
+    if (ip) {
+      track(TRACKING_EVENTS.CARD_COUNTRY_CHECK_IP_FETCHED, { ip, source: 'cache' });
+    } else {
+      ip = await getClientIp();
+
+      if (!ip) {
+        track(TRACKING_EVENTS.CARD_COUNTRY_CHECK_IP_FAILED, { reason: 'no_ip_returned' });
+        return 'needs_selection';
+      }
+
+      store.setCachedIp(ip);
+      track(TRACKING_EVENTS.CARD_COUNTRY_CHECK_IP_FETCHED, { ip });
+    }
+
+    const cachedInfo = store.getIpDetectedCountry(ip);
+
+    if (cachedInfo) {
+      // Keep the active country in sync with what this IP resolved to, so the
+      // selection screen opens on it and KYC provider routing sees it.
+      store.setCountryInfo(cachedInfo);
+
+      track(TRACKING_EVENTS.CARD_COUNTRY_AVAILABILITY_CHECKED, {
+        countryCode: cachedInfo.countryCode,
+        countryName: cachedInfo.countryName,
+        isAvailable: cachedInfo.isAvailable,
+        source: 'cached_ip_country',
+        ip,
+      });
+
+      return cachedInfo.isAvailable ? 'supported' : 'needs_selection';
+    }
+
+    // Detection already failed once — skip the retry and let the user pick.
+    if (store.countryDetectionFailed) {
+      track(TRACKING_EVENTS.CARD_KYC_COUNTRY_DETECTION_FAILED, {
+        reason: 'previous_detection_failed',
+        ip,
+      });
+      return 'needs_selection';
+    }
+
+    const countryData = await getCountryFromIp();
+
+    if (!countryData) {
+      store.setCountryDetectionFailed(true);
+      track(TRACKING_EVENTS.CARD_KYC_COUNTRY_DETECTION_FAILED, {
+        reason: 'no_country_data_from_ip',
+        ip,
+      });
+      return 'needs_selection';
+    }
+
+    const { countryCode, countryName } = countryData;
+    track(TRACKING_EVENTS.CARD_COUNTRY_CHECK_DETECTED, { countryCode, countryName, ip });
+
+    const accessCheck = await withRefreshToken(() => checkCardAccess(countryCode));
+
+    if (!accessCheck) {
+      store.setCountryDetectionFailed(true);
+      track(TRACKING_EVENTS.CARD_COUNTRY_CHECK_FAILED, {
+        reason: 'access_check_failed',
+        countryCode,
+        countryName,
+        ip,
+      });
+      return 'needs_selection';
+    }
+
+    store.setIpDetectedCountry(ip, {
+      countryCode,
+      countryName,
+      isAvailable: accessCheck.hasAccess,
+    });
+    store.setCountryDetectionFailed(false);
+
+    track(TRACKING_EVENTS.CARD_COUNTRY_AVAILABILITY_CHECKED, {
+      countryCode,
+      countryName,
+      isAvailable: accessCheck.hasAccess,
+      source: 'ip_detection',
+      ip,
+    });
+
+    if (accessCheck.hasAccess) {
+      track(TRACKING_EVENTS.CARD_KYC_COUNTRY_SUPPORTED, { countryCode, countryName, ip });
+      return 'supported';
+    }
+
+    track(TRACKING_EVENTS.CARD_KYC_COUNTRY_NOT_SUPPORTED, { countryCode, countryName, ip });
+    return 'needs_selection';
+  } catch (error) {
+    console.error('Error checking card country:', error);
+    useCountryStore.getState().setCountryDetectionFailed(true);
+    track(TRACKING_EVENTS.CARD_COUNTRY_CHECK_FAILED, {
+      reason: 'unexpected_error',
+      error: (error as Error)?.message,
+    });
+    return 'needs_selection';
+  }
+};


### PR DESCRIPTION
## Summary
Implements a country availability check for card-related CTAs on the home screen, ensuring users are routed through country selection before starting KYC if their country cannot be confirmed or doesn't support the card product.

## Key Changes
- **New `cardCountryGate` module** (`lib/cardCountryGate.ts`): Introduces `resolveCardCountry()` function that imperatively checks card availability by:
  - Checking cached country info first
  - Fetching client IP and detecting country via geolocation
  - Verifying card access for the detected country
  - Caching results to avoid repeated lookups
  - Gracefully handling failures by returning `'needs_selection'` to let users manually pick their country
  - Comprehensive tracking of each step in the flow

- **Updated `CardWaitingModal`** (`components/Home/CardWaitingModal.tsx`):
  - Integrated country gate check into the "Verify now" button handler
  - Added loading state with activity indicator during country resolution
  - Routes to country selection screen if country cannot be confirmed
  - Skips gate for users who already have a card or are in a Rain application (escape hatch)
  - Tracks CTA interactions with source and step context

- **Enhanced `HomeSetupStep` interface** (`hooks/useHomeSetupSteps.ts`):
  - Added stable `key` field (`'kyc' | 'card' | 'deposit'`) for reliable step identification
  - Allows callers to gate logic on step type rather than string matching

- **Improved country selection navigation** (`app/(protected)/(tabs)/card-onboard/country_selection.tsx`):
  - Changed back navigation to use router history when available
  - Falls back to `/card` only when no history exists
  - Prevents stranding users on deprecated pages when navigating from new home UI

## Implementation Details
- The gate never throws; any error defaults to `'needs_selection'` to hand control to the user
- IP detection results are cached per IP to avoid redundant API calls
- Failed detection is tracked to prevent retry loops
- Mirrors the original `/card` page's gate behavior (via `useCountryCheck`) but runs imperatively before navigation
- Comprehensive test coverage validates all success/failure paths and caching behavior

https://claude.ai/code/session_011uxkxK2ZwVdV5GGAkqrdN3