### PR TITLE
fix(desktop): modals use the standard dialog, headers inside the column

### DIFF
--- a/components/Card/NewCardDetails/CardDetailsPane.tsx
+++ b/components/Card/NewCardDetails/CardDetailsPane.tsx
@@ -170,7 +170,9 @@ const CardDetailsPane = () => {
         !isVisible && styles.warm,
       ]}
     >
-      <View style={{ paddingTop: insets.top }}>
+      {/* Same column as the content below, so the back button doesn't drift out to
+          the edge of the desktop body area. */}
+      <View className="mx-auto w-full max-w-lg" style={{ paddingTop: insets.top }}>
         <CardDetailsHeader onBack={close} />
       </View>
       <ScrollView ref={scrollRef} showsVerticalScrollIndicator={false}>

--- a/components/Home/CardWaitingModal.tsx
+++ b/components/Home/CardWaitingModal.tsx
@@ -151,7 +151,7 @@ const CardWaitingModal = ({ isOpen, onClose, firstIncomplete }: CardWaitingModal
       disableScroll
       fillViewportHeight
       containerClassName="gap-0"
-      contentClassName="bg-[#111] px-0 pb-0 pt-0 md:px-0 md:pt-0"
+      contentClassName="overflow-hidden bg-[#111] px-0 pb-0 pt-0 md:px-0 md:pt-0"
     >
       <View className="flex-1">
         <ScrollView

--- a/components/Referral/ReferralProgramModalNew.tsx
+++ b/components/Referral/ReferralProgramModalNew.tsx
@@ -26,7 +26,7 @@ export default function ReferralProgramModalNew({ isOpen, onClose }: ReferralPro
       }}
       trigger={null}
       contentKey="referral-program-new"
-      contentClassName="bg-background px-0 pb-0 pt-0 md:max-w-lg md:px-0 md:pt-0"
+      contentClassName="overflow-hidden bg-background px-0 pb-0 pt-0 md:max-w-xl md:px-0 md:pt-0"
       shouldAnimate={false}
       hideHeader
       disableScroll

--- a/components/ResponsiveModal.tsx
+++ b/components/ResponsiveModal.tsx
@@ -156,7 +156,7 @@ const ResponsiveModal = ({
       {trigger !== null && <DialogTrigger asChild>{trigger}</DialogTrigger>}
       <DialogContent
         className={cn(
-          'px-4 pb-0 pt-4 md:max-w-md md:px-8 md:pb-0 md:pt-8',
+          'px-4 pb-0 pt-4 md:max-w-lg md:px-8 md:pb-0 md:pt-8',
           !isScreenMedium ? 'mt-[5vh] w-screen max-w-full justify-start' : '',
           webFill && 'max-h-[90vh]',
           contentClassName, // Put last so overrides take effect

--- a/components/Rewards/NewRewards/CashbackDetailsSheet.tsx
+++ b/components/Rewards/NewRewards/CashbackDetailsSheet.tsx
@@ -2,16 +2,22 @@ import { useState } from 'react';
 import { ScrollView, View } from 'react-native';
 
 import { Dialog, DialogContent, DialogTrigger } from '@/components/ui/dialog';
+import { useDimension } from '@/hooks/useDimension';
+import { cn } from '@/lib/utils';
 
 import CashbackDetailsContent from './CashbackDetailsContent';
 
 import type { CashbackDetailsSheetProps } from './CashbackDetailsSheet.types';
 
+// Bottom sheet on phones, the standard centred modal from `md` up — the sheet
+// styling used to apply at every width, so on desktop it stretched across the
+// whole viewport with square top corners.
 const CashbackDetailsSheet = ({
   trigger,
   onGetMoreCashback,
   ...cashbackData
 }: CashbackDetailsSheetProps) => {
+  const { isScreenMedium } = useDimension();
   const [open, setOpen] = useState(false);
   const [animationSession, setAnimationSession] = useState(0);
 
@@ -31,10 +37,17 @@ const CashbackDetailsSheet = ({
       <Dialog open={open} onOpenChange={handleOpenChange}>
         <DialogTrigger asChild>{trigger}</DialogTrigger>
         <DialogContent
-          showCloseButton={false}
-          className="fixed bottom-0 left-0 right-0 h-[76vh] max-w-none overflow-hidden rounded-b-none rounded-t-[40px] bg-[#1C1C1C] p-0"
+          showCloseButton={isScreenMedium}
+          className={cn(
+            'overflow-hidden bg-[#1C1C1C] p-0',
+            isScreenMedium
+              ? 'max-h-[86vh] md:max-w-lg'
+              : 'fixed bottom-0 left-0 right-0 h-[76vh] max-w-none rounded-b-none rounded-t-[40px]',
+          )}
         >
-          <View className="absolute left-1/2 top-4 z-10 h-[5px] w-[73px] -translate-x-1/2 rounded-full bg-white/20" />
+          {!isScreenMedium && (
+            <View className="absolute left-1/2 top-4 z-10 h-[5px] w-[73px] -translate-x-1/2 rounded-full bg-white/20" />
+          )}
           <ScrollView showsVerticalScrollIndicator={false}>
             <CashbackDetailsContent
               {...cashbackData}

--- a/components/Rewards/NewRewards/RewardsBenefitsScreenNew.tsx
+++ b/components/Rewards/NewRewards/RewardsBenefitsScreenNew.tsx
@@ -19,7 +19,7 @@ import {
   CoreRocketPerkIcon,
   CoreTierSparkle,
 } from '@/assets/images/rewards-tiers/core-tier-icons';
-import { useIsSidebarShell, usePageWidth } from '@/components/Navbar/Sidebar';
+import { SIDEBAR_BODY_WIDTH, useIsSidebarShell, usePageWidth } from '@/components/Navbar/Sidebar';
 import PageLayout from '@/components/PageLayout';
 import { BackButton } from '@/components/ui/back-button';
 import { Text } from '@/components/ui/text';
@@ -594,6 +594,8 @@ const PremiumFeesCard = ({ tier }: { tier: RewardsTier.PRIME | RewardsTier.ULTRA
  * CompareTiersTable-based screen.
  */
 const HEADER_ROW_HEIGHT = 56;
+/** Figma leaves 20px above the tier tabs. */
+const HEADER_TOP_SPACING = 20;
 const SLIDE_DURATION = 260;
 const SLIDE_EASING = Easing.out(Easing.cubic);
 const SWIPE_DISTANCE_THRESHOLD = 50;
@@ -802,15 +804,18 @@ export default function RewardsBenefitsScreenNew() {
           top: 0,
           left: 0,
           right: 0,
-          height: insets.top + HEADER_ROW_HEIGHT + FADE_EXTENT,
+          height: insets.top + HEADER_TOP_SPACING + HEADER_ROW_HEIGHT + FADE_EXTENT,
           zIndex: 10,
         }}
       >
+        {/* Constrained to the page column so the back button lines up with the
+            content rather than floating out at the edge of the desktop body. */}
         <View
-          className="relative flex-row items-center justify-center px-4"
-          style={{ height: HEADER_ROW_HEIGHT, marginTop: insets.top }}
+          className={`relative flex-row items-center justify-center px-4 ${SIDEBAR_BODY_WIDTH}`}
+          style={{ height: HEADER_ROW_HEIGHT, marginTop: insets.top + HEADER_TOP_SPACING }}
         >
-          <View className="absolute left-4 top-4">
+          {/* Stretched top-to-bottom so it centres on the tabs beside it. */}
+          <View className="absolute bottom-0 left-4 top-0 justify-center">
             <BackButton variant="header" onPress={() => router.push(path.REWARDS)} />
           </View>
           <TierSwitcher

--- a/components/Rewards/NewRewards/TierPointsSheet.tsx
+++ b/components/Rewards/NewRewards/TierPointsSheet.tsx
@@ -2,12 +2,16 @@ import { useEffect, useState } from 'react';
 import { ScrollView, View } from 'react-native';
 
 import { Dialog, DialogContent, DialogTrigger } from '@/components/ui/dialog';
+import { useDimension } from '@/hooks/useDimension';
+import { cn } from '@/lib/utils';
 
 import TierPointsSheetContent from './TierPointsSheetContent';
 
 import type { TierPointsSheetProps } from './TierPointsSheet.types';
 
+// Bottom sheet on phones, the standard centred modal from `md` up.
 const TierPointsSheet = ({ trigger, open: controlledOpen, onOpenChange }: TierPointsSheetProps) => {
+  const { isScreenMedium } = useDimension();
   const [uncontrolledOpen, setUncontrolledOpen] = useState(false);
   const [animationSession, setAnimationSession] = useState(0);
   const open = controlledOpen ?? uncontrolledOpen;
@@ -34,10 +38,17 @@ const TierPointsSheet = ({ trigger, open: controlledOpen, onOpenChange }: TierPo
       <Dialog open={open} onOpenChange={handleOpenChange}>
         {trigger && <DialogTrigger asChild>{trigger}</DialogTrigger>}
         <DialogContent
-          showCloseButton={false}
-          className="fixed bottom-0 left-1/2 h-[min(792px,calc(100vh-16px))] w-full max-w-[419px] -translate-x-1/2 overflow-hidden rounded-b-none rounded-t-[40px] bg-[#1C1C1C] p-0"
+          showCloseButton={isScreenMedium}
+          className={cn(
+            'overflow-hidden bg-[#1C1C1C] p-0',
+            isScreenMedium
+              ? 'max-h-[86vh] md:max-w-lg'
+              : 'fixed bottom-0 left-1/2 h-[min(792px,calc(100vh-16px))] w-full max-w-[419px] -translate-x-1/2 rounded-b-none rounded-t-[40px]',
+          )}
         >
-          <View className="absolute left-1/2 top-4 z-10 h-[5px] w-[73px] -translate-x-1/2 rounded-full bg-white/20" />
+          {!isScreenMedium && (
+            <View className="absolute left-1/2 top-4 z-10 h-[5px] w-[73px] -translate-x-1/2 rounded-full bg-white/20" />
+          )}
           <ScrollView showsVerticalScrollIndicator={false}>
             <TierPointsSheetContent
               animationSession={animationSession}

--- a/components/SupportDrawer/SupportDrawerProvider.tsx
+++ b/components/SupportDrawer/SupportDrawerProvider.tsx
@@ -1,12 +1,20 @@
 import { useWindowDimensions, View } from 'react-native';
 
 import { Dialog, DialogContent } from '@/components/ui/dialog';
+import { useDimension } from '@/hooks/useDimension';
+import { cn } from '@/lib/utils';
 import { closeSupportDrawer, useSupportDrawerStore } from '@/store/useSupportDrawerStore';
 
 import SupportDrawerContent from './SupportDrawerContent';
 
+/**
+ * Bottom sheet on phones, the standard centred modal from `md` up. The sheet
+ * styling — and the translate that pinned it to the bottom of the viewport —
+ * used to apply at every width.
+ */
 const SupportDrawerProvider = () => {
   const isOpen = useSupportDrawerStore(state => state.isOpen);
+  const { isScreenMedium } = useDimension();
   const { height, width } = useWindowDimensions();
   const sheetHeight = Math.min(522, height - 8);
 
@@ -14,14 +22,21 @@ const SupportDrawerProvider = () => {
     <View>
       <Dialog open={isOpen} onOpenChange={open => !open && closeSupportDrawer()}>
         <DialogContent
-          showCloseButton={false}
+          showCloseButton={isScreenMedium}
           overlayClassName="web:backdrop-blur-none"
-          className="max-w-none gap-0 overflow-hidden rounded-b-none rounded-t-[40px] bg-[#1c1c1c] p-0"
-          style={{
-            width: Math.min(419, width),
-            height: sheetHeight,
-            transform: [{ translateY: (height - sheetHeight) / 2 }],
-          }}
+          className={cn(
+            'gap-0 overflow-hidden bg-[#1c1c1c] p-0',
+            isScreenMedium ? 'md:max-w-lg' : 'max-w-none rounded-b-none rounded-t-[40px]',
+          )}
+          style={
+            isScreenMedium
+              ? undefined
+              : {
+                  width: Math.min(419, width),
+                  height: sheetHeight,
+                  transform: [{ translateY: (height - sheetHeight) / 2 }],
+                }
+          }
         >
           <SupportDrawerContent />
         </DialogContent>


### PR DESCRIPTION
Popups. Three sheets — cashback details, tier points and the support drawer — hard-coded their bottom-sheet styling at every width, so on desktop they stretched across the whole viewport with square top corners. They now switch to the standard centred dialog (rounded, capped width, close button) from `md` up and keep the sheet, handle and all, below it. ResponsiveModal's desktop cap goes from max-w-md to max-w-lg so every popup built on it is a little wider; the referral popup goes to max-w-xl.

Rounded corners on the referral and card-waiting popups: both pass px-0 so their content runs to the card's edge, where nothing clipped it to the radius. They clip now. Scoped to those two rather than ResponsiveModal itself — a blanket overflow-hidden would clip dropdowns that legitimately overflow other modals.

Headers. Two back buttons render in `additionalContent`, which PageLayout does not constrain to the page column, so on desktop they drifted out to the edge of the body area: the rewards-benefits header row and the card-details pane's. Both are now bounded by the same column as the content under them. Everything else draws its back button inside `children`, which the column already covers.

The tier tabs sit 20px below the top, and the back button beside them is stretched top-to-bottom so the two line up.


Claude-Session: https://claude.ai/code/session_01Uim9wSonVD3vUgrGHLJ4YC