### PR TITLE
fix(desktop): use ResponsiveModal for the sheets, not a restyled Dialog

### DIFF
--- a/components/Rewards/NewRewards/CashbackDetailsContent.tsx
+++ b/components/Rewards/NewRewards/CashbackDetailsContent.tsx
@@ -13,13 +13,18 @@ import Svg, { Defs, FeGaussianBlur, Filter, Path } from 'react-native-svg';
 
 import { Button } from '@/components/ui/button';
 import { Text } from '@/components/ui/text';
-import { formatNumber } from '@/lib/utils';
+import { cn, formatNumber } from '@/lib/utils';
 
 import type { CashbackDetailsData } from './CashbackDetailsSheet.types';
 
 interface CashbackDetailsContentProps extends CashbackDetailsData {
   onGetMoreCashback: () => void;
   animationSession: number;
+  /**
+   * Bottom-sheet presentation: adds the top padding that clears the sheet's drag
+   * handle. False inside a modal, which brings its own padding.
+   */
+  isSheet?: boolean;
 }
 
 const formatWholeDollars = (value: number) => `$${formatNumber(value || 0, 0, 0)}`;
@@ -136,8 +141,9 @@ const CashbackDetailsContent = ({
   allTimeCashback,
   onGetMoreCashback,
   animationSession,
+  isSheet = true,
 }: CashbackDetailsContentProps) => (
-  <View className="items-center px-[34px] pt-[46px]">
+  <View className={cn('items-center px-[34px]', isSheet && 'pt-[46px]')}>
     <CashbackDiamondIcon key={animationSession} />
 
     <Text

--- a/components/Rewards/NewRewards/CashbackDetailsSheet.tsx
+++ b/components/Rewards/NewRewards/CashbackDetailsSheet.tsx
@@ -1,17 +1,22 @@
 import { useState } from 'react';
 import { ScrollView, View } from 'react-native';
 
+import ResponsiveModal, { ModalState } from '@/components/ResponsiveModal';
 import { Dialog, DialogContent, DialogTrigger } from '@/components/ui/dialog';
 import { useDimension } from '@/hooks/useDimension';
-import { cn } from '@/lib/utils';
 
 import CashbackDetailsContent from './CashbackDetailsContent';
 
 import type { CashbackDetailsSheetProps } from './CashbackDetailsSheet.types';
 
-// Bottom sheet on phones, the standard centred modal from `md` up — the sheet
-// styling used to apply at every width, so on desktop it stretched across the
-// whole viewport with square top corners.
+const MODAL_STATE: ModalState = { name: 'cashback-details', number: 1 };
+const CLOSE_STATE: ModalState = { name: 'close', number: 0 };
+
+/**
+ * Cashback details: a bottom sheet on phones, the standard `ResponsiveModal` from
+ * `md` up — which brings the padding, close button and rounded corners a popup needs,
+ * and leaves the drag handle to the sheet it belongs to.
+ */
 const CashbackDetailsSheet = ({
   trigger,
   onGetMoreCashback,
@@ -32,29 +37,45 @@ const CashbackDetailsSheet = ({
     setOpen(nextOpen);
   };
 
+  const content = (
+    <CashbackDetailsContent
+      {...cashbackData}
+      animationSession={animationSession}
+      isSheet={!isScreenMedium}
+      onGetMoreCashback={handleGetMoreCashback}
+    />
+  );
+
+  if (isScreenMedium) {
+    return (
+      <View className="flex-1">
+        <ResponsiveModal
+          currentModal={MODAL_STATE}
+          previousModal={CLOSE_STATE}
+          isOpen={open}
+          onOpenChange={handleOpenChange}
+          trigger={trigger}
+          contentKey="cashback-details"
+          shouldAnimate={false}
+          hideHeader
+          contentClassName="bg-[#1C1C1C]"
+        >
+          {content}
+        </ResponsiveModal>
+      </View>
+    );
+  }
+
   return (
     <View className="flex-1">
       <Dialog open={open} onOpenChange={handleOpenChange}>
         <DialogTrigger asChild>{trigger}</DialogTrigger>
         <DialogContent
-          showCloseButton={isScreenMedium}
-          className={cn(
-            'overflow-hidden bg-[#1C1C1C] p-0',
-            isScreenMedium
-              ? 'max-h-[86vh] md:max-w-lg'
-              : 'fixed bottom-0 left-0 right-0 h-[76vh] max-w-none rounded-b-none rounded-t-[40px]',
-          )}
+          showCloseButton={false}
+          className="fixed bottom-0 left-0 right-0 h-[76vh] max-w-none overflow-hidden rounded-b-none rounded-t-[40px] bg-[#1C1C1C] p-0"
         >
-          {!isScreenMedium && (
-            <View className="absolute left-1/2 top-4 z-10 h-[5px] w-[73px] -translate-x-1/2 rounded-full bg-white/20" />
-          )}
-          <ScrollView showsVerticalScrollIndicator={false}>
-            <CashbackDetailsContent
-              {...cashbackData}
-              animationSession={animationSession}
-              onGetMoreCashback={handleGetMoreCashback}
-            />
-          </ScrollView>
+          <View className="absolute left-1/2 top-4 z-10 h-[5px] w-[73px] -translate-x-1/2 rounded-full bg-white/20" />
+          <ScrollView showsVerticalScrollIndicator={false}>{content}</ScrollView>
         </DialogContent>
       </Dialog>
     </View>

--- a/components/Rewards/NewRewards/TierPointsSheet.tsx
+++ b/components/Rewards/NewRewards/TierPointsSheet.tsx
@@ -1,15 +1,21 @@
 import { useEffect, useState } from 'react';
 import { ScrollView, View } from 'react-native';
 
+import ResponsiveModal, { ModalState } from '@/components/ResponsiveModal';
 import { Dialog, DialogContent, DialogTrigger } from '@/components/ui/dialog';
 import { useDimension } from '@/hooks/useDimension';
-import { cn } from '@/lib/utils';
 
 import TierPointsSheetContent from './TierPointsSheetContent';
 
 import type { TierPointsSheetProps } from './TierPointsSheet.types';
 
-// Bottom sheet on phones, the standard centred modal from `md` up.
+const MODAL_STATE: ModalState = { name: 'tier-points', number: 1 };
+const CLOSE_STATE: ModalState = { name: 'close', number: 0 };
+
+/**
+ * How points work: a bottom sheet on phones, the standard `ResponsiveModal` from
+ * `md` up.
+ */
 const TierPointsSheet = ({ trigger, open: controlledOpen, onOpenChange }: TierPointsSheetProps) => {
   const { isScreenMedium } = useDimension();
   const [uncontrolledOpen, setUncontrolledOpen] = useState(false);
@@ -33,28 +39,44 @@ const TierPointsSheet = ({ trigger, open: controlledOpen, onOpenChange }: TierPo
     onOpenChange?.(nextOpen);
   };
 
+  const content = (
+    <TierPointsSheetContent
+      animationSession={animationSession}
+      isSheet={!isScreenMedium}
+      onClose={() => handleOpenChange(false)}
+    />
+  );
+
+  if (isScreenMedium) {
+    return (
+      <View>
+        <ResponsiveModal
+          currentModal={MODAL_STATE}
+          previousModal={CLOSE_STATE}
+          isOpen={open}
+          onOpenChange={handleOpenChange}
+          trigger={trigger ?? null}
+          contentKey="tier-points"
+          shouldAnimate={false}
+          hideHeader
+          contentClassName="bg-[#1C1C1C]"
+        >
+          {content}
+        </ResponsiveModal>
+      </View>
+    );
+  }
+
   return (
     <View>
       <Dialog open={open} onOpenChange={handleOpenChange}>
         {trigger && <DialogTrigger asChild>{trigger}</DialogTrigger>}
         <DialogContent
-          showCloseButton={isScreenMedium}
-          className={cn(
-            'overflow-hidden bg-[#1C1C1C] p-0',
-            isScreenMedium
-              ? 'max-h-[86vh] md:max-w-lg'
-              : 'fixed bottom-0 left-1/2 h-[min(792px,calc(100vh-16px))] w-full max-w-[419px] -translate-x-1/2 rounded-b-none rounded-t-[40px]',
-          )}
+          showCloseButton={false}
+          className="fixed bottom-0 left-1/2 h-[min(792px,calc(100vh-16px))] w-full max-w-[419px] -translate-x-1/2 overflow-hidden rounded-b-none rounded-t-[40px] bg-[#1C1C1C] p-0"
         >
-          {!isScreenMedium && (
-            <View className="absolute left-1/2 top-4 z-10 h-[5px] w-[73px] -translate-x-1/2 rounded-full bg-white/20" />
-          )}
-          <ScrollView showsVerticalScrollIndicator={false}>
-            <TierPointsSheetContent
-              animationSession={animationSession}
-              onClose={() => handleOpenChange(false)}
-            />
-          </ScrollView>
+          <View className="absolute left-1/2 top-4 z-10 h-[5px] w-[73px] -translate-x-1/2 rounded-full bg-white/20" />
+          <ScrollView showsVerticalScrollIndicator={false}>{content}</ScrollView>
         </DialogContent>
       </Dialog>
     </View>

--- a/components/Rewards/NewRewards/TierPointsSheetContent.tsx
+++ b/components/Rewards/NewRewards/TierPointsSheetContent.tsx
@@ -12,6 +12,7 @@ import { Image } from 'expo-image';
 
 import { Button } from '@/components/ui/button';
 import { Text } from '@/components/ui/text';
+import { cn } from '@/lib/utils';
 
 const POINTS_STAR = require('@/assets/images/rewards-tiers/points-drawer-star.png');
 const POINTS_SAVE = require('@/assets/images/rewards-tiers/points-save.png');
@@ -22,6 +23,11 @@ const POINTS_SWAP = require('@/assets/images/rewards-tiers/points-swap.png');
 interface TierPointsSheetContentProps {
   animationSession: number;
   onClose: () => void;
+  /**
+   * Bottom-sheet presentation: adds the top padding that clears the sheet's drag
+   * handle. False inside a modal, which brings its own padding.
+   */
+  isSheet?: boolean;
 }
 
 interface PointsMethod {
@@ -147,8 +153,12 @@ const PointsCell = ({ method, bottom }: { method: PointsMethod; bottom?: boolean
   </View>
 );
 
-const TierPointsSheetContent = ({ animationSession, onClose }: TierPointsSheetContentProps) => (
-  <View className="items-center px-[34px] pt-[46px]">
+const TierPointsSheetContent = ({
+  animationSession,
+  onClose,
+  isSheet = true,
+}: TierPointsSheetContentProps) => (
+  <View className={cn('items-center px-[34px]', isSheet && 'pt-[46px]')}>
     <AnimatedTierStar key={animationSession} />
 
     <Text

--- a/components/SupportDrawer/SupportDrawerContent.tsx
+++ b/components/SupportDrawer/SupportDrawerContent.tsx
@@ -107,7 +107,15 @@ const SupportRow = ({ icon, label, onPress }: SupportRowProps) => (
 
 const Divider = () => <View className="h-px bg-white/10" />;
 
-const SupportDrawerContent = () => {
+interface SupportDrawerContentProps {
+  /**
+   * Bottom-sheet presentation: draws the drag handle and the top padding that
+   * clears it. False inside a modal, which supplies its own chrome and padding.
+   */
+  isSheet?: boolean;
+}
+
+const SupportDrawerContent = ({ isSheet = true }: SupportDrawerContentProps) => {
   const intercom = useIntercom();
   const chatMessage = useSupportDrawerStore(state => state.chatMessage);
 
@@ -136,12 +144,12 @@ const SupportDrawerContent = () => {
   );
 
   return (
-    <View style={styles.container}>
-      <View style={styles.handle} />
+    <View style={isSheet ? styles.container : undefined}>
+      {isSheet && <View style={styles.handle} />}
       <Text className="text-center text-[30px] font-semibold leading-[36px] text-white">
         Help & Support
       </Text>
-      <View style={styles.card}>
+      <View style={[styles.card, isSheet ? undefined : styles.cardInModal]}>
         <SupportRow icon={<ChatIcon />} label="Chat with us" onPress={handleChatPress} />
         <Divider />
         <SupportRow icon={<FaqIcon />} label="FAQ" onPress={() => openLink(FAQ_URL)} />
@@ -185,6 +193,8 @@ const styles = StyleSheet.create({
     borderRadius: 20,
     backgroundColor: '#2b2b2b',
   },
+  // The modal already supplies its own horizontal padding.
+  cardInModal: { marginHorizontal: 0, marginTop: 24 },
 });
 
 export default SupportDrawerContent;

--- a/components/SupportDrawer/SupportDrawerProvider.tsx
+++ b/components/SupportDrawer/SupportDrawerProvider.tsx
@@ -1,16 +1,19 @@
 import { useWindowDimensions, View } from 'react-native';
 
+import ResponsiveModal, { ModalState } from '@/components/ResponsiveModal';
 import { Dialog, DialogContent } from '@/components/ui/dialog';
 import { useDimension } from '@/hooks/useDimension';
-import { cn } from '@/lib/utils';
 import { closeSupportDrawer, useSupportDrawerStore } from '@/store/useSupportDrawerStore';
 
 import SupportDrawerContent from './SupportDrawerContent';
 
+const MODAL_STATE: ModalState = { name: 'support', number: 1 };
+const CLOSE_STATE: ModalState = { name: 'close', number: 0 };
+
 /**
- * Bottom sheet on phones, the standard centred modal from `md` up. The sheet
- * styling — and the translate that pinned it to the bottom of the viewport —
- * used to apply at every width.
+ * Help & Support: a bottom sheet on phones, the standard `ResponsiveModal` from `md`
+ * up. The sheet styling — the drag handle, and the translate that pinned the card to
+ * the bottom of the viewport — used to apply at every width.
  */
 const SupportDrawerProvider = () => {
   const isOpen = useSupportDrawerStore(state => state.isOpen);
@@ -18,25 +21,42 @@ const SupportDrawerProvider = () => {
   const { height, width } = useWindowDimensions();
   const sheetHeight = Math.min(522, height - 8);
 
+  const handleOpenChange = (open: boolean) => {
+    if (!open) closeSupportDrawer();
+  };
+
+  if (isScreenMedium) {
+    return (
+      <View>
+        <ResponsiveModal
+          currentModal={MODAL_STATE}
+          previousModal={CLOSE_STATE}
+          isOpen={isOpen}
+          onOpenChange={handleOpenChange}
+          trigger={null}
+          contentKey="support"
+          shouldAnimate={false}
+          hideHeader
+          contentClassName="bg-[#1c1c1c]"
+        >
+          <SupportDrawerContent isSheet={false} />
+        </ResponsiveModal>
+      </View>
+    );
+  }
+
   return (
     <View>
-      <Dialog open={isOpen} onOpenChange={open => !open && closeSupportDrawer()}>
+      <Dialog open={isOpen} onOpenChange={handleOpenChange}>
         <DialogContent
-          showCloseButton={isScreenMedium}
+          showCloseButton={false}
           overlayClassName="web:backdrop-blur-none"
-          className={cn(
-            'gap-0 overflow-hidden bg-[#1c1c1c] p-0',
-            isScreenMedium ? 'md:max-w-lg' : 'max-w-none rounded-b-none rounded-t-[40px]',
-          )}
-          style={
-            isScreenMedium
-              ? undefined
-              : {
-                  width: Math.min(419, width),
-                  height: sheetHeight,
-                  transform: [{ translateY: (height - sheetHeight) / 2 }],
-                }
-          }
+          className="max-w-none gap-0 overflow-hidden rounded-b-none rounded-t-[40px] bg-[#1c1c1c] p-0"
+          style={{
+            width: Math.min(419, width),
+            height: sheetHeight,
+            transform: [{ translateY: (height - sheetHeight) / 2 }],
+          }}
         >
           <SupportDrawerContent />
         </DialogContent>


### PR DESCRIPTION
The previous pass only swapped classNames on the raw Dialog, which left the sheets missing everything ResponsiveModal actually provides. They now render ResponsiveModal from `md` up and keep the bottom sheet below it.

That fixes the content touching the bottom edge: these sheets pass p-0 and relied on the sheet's own slack for breathing room, where ResponsiveModal's scroll container carries pb-4 md:pb-8.

The drag handle is sheet-only now. Cashback and tier-points draw it in their sheet branch; the support drawer's lives inside SupportDrawerContent, which is why it was still showing in the popup — it takes an `isSheet` prop, as do the other two contents, so the padding that exists to clear the handle goes with it. The support card also drops its 8% side margins in the modal, where the modal supplies the padding.


Claude-Session: https://claude.ai/code/session_01Uim9wSonVD3vUgrGHLJ4YC