### PR TITLE
fix(desktop): let the tier and support popups take ResponsiveModal's …

### DIFF
--- a/components/Rewards/NewRewards/CashbackDetailsContent.tsx
+++ b/components/Rewards/NewRewards/CashbackDetailsContent.tsx
@@ -143,7 +143,7 @@ const CashbackDetailsContent = ({
   animationSession,
   isSheet = true,
 }: CashbackDetailsContentProps) => (
-  <View className={cn('items-center px-[34px]', isSheet && 'pt-[46px]')}>
+  <View className={cn('items-center', isSheet && 'px-[34px] pt-[46px]')}>
     <CashbackDiamondIcon key={animationSession} />
 
     <Text

--- a/components/Rewards/NewRewards/CashbackDetailsSheet.tsx
+++ b/components/Rewards/NewRewards/CashbackDetailsSheet.tsx
@@ -58,7 +58,6 @@ const CashbackDetailsSheet = ({
           contentKey="cashback-details"
           shouldAnimate={false}
           hideHeader
-          contentClassName="bg-[#1C1C1C]"
         >
           {content}
         </ResponsiveModal>

--- a/components/Rewards/NewRewards/TierPointsSheet.tsx
+++ b/components/Rewards/NewRewards/TierPointsSheet.tsx
@@ -59,7 +59,6 @@ const TierPointsSheet = ({ trigger, open: controlledOpen, onOpenChange }: TierPo
           contentKey="tier-points"
           shouldAnimate={false}
           hideHeader
-          contentClassName="bg-[#1C1C1C]"
         >
           {content}
         </ResponsiveModal>

--- a/components/Rewards/NewRewards/TierPointsSheetContent.tsx
+++ b/components/Rewards/NewRewards/TierPointsSheetContent.tsx
@@ -158,7 +158,7 @@ const TierPointsSheetContent = ({
   onClose,
   isSheet = true,
 }: TierPointsSheetContentProps) => (
-  <View className={cn('items-center px-[34px]', isSheet && 'pt-[46px]')}>
+  <View className={cn('items-center', isSheet && 'px-[34px] pt-[46px]')}>
     <AnimatedTierStar key={animationSession} />
 
     <Text

--- a/components/SupportDrawer/SupportDrawerProvider.tsx
+++ b/components/SupportDrawer/SupportDrawerProvider.tsx
@@ -37,7 +37,6 @@ const SupportDrawerProvider = () => {
           contentKey="support"
           shouldAnimate={false}
           hideHeader
-          contentClassName="bg-[#1c1c1c]"
         >
           <SupportDrawerContent isSheet={false} />
         </ResponsiveModal>


### PR DESCRIPTION
…styling

They were already rendering ResponsiveModal, but still passing the bottom sheet's own background (#1C1C1C) and horizontal padding (px-[34px]) through to it. Every other ResponsiveModal in the app uses the default bg-popup (#101010) and the modal's md:px-8, so these three read as a different kind of popup — lighter, and more inset — despite being the same component.

The desktop branches now pass no style overrides at all, and the sheet's padding joins its drag handle behind `isSheet`.


Claude-Session: https://claude.ai/code/session_01Uim9wSonVD3vUgrGHLJ4YC