### PR TITLE
fix: close button on the tier/support popups, stop routing to /card

### DIFF
--- a/components/Rewards/NewRewards/CashbackDetailsSheet.tsx
+++ b/components/Rewards/NewRewards/CashbackDetailsSheet.tsx
@@ -57,7 +57,6 @@ const CashbackDetailsSheet = ({
           trigger={trigger}
           contentKey="cashback-details"
           shouldAnimate={false}
-          hideHeader
         >
           {content}
         </ResponsiveModal>

--- a/components/Rewards/NewRewards/TierPointsSheet.tsx
+++ b/components/Rewards/NewRewards/TierPointsSheet.tsx
@@ -58,7 +58,6 @@ const TierPointsSheet = ({ trigger, open: controlledOpen, onOpenChange }: TierPo
           trigger={trigger ?? null}
           contentKey="tier-points"
           shouldAnimate={false}
-          hideHeader
         >
           {content}
         </ResponsiveModal>

--- a/components/SupportDrawer/SupportDrawerProvider.tsx
+++ b/components/SupportDrawer/SupportDrawerProvider.tsx
@@ -36,7 +36,6 @@ const SupportDrawerProvider = () => {
           trigger={null}
           contentKey="support"
           shouldAnimate={false}
-          hideHeader
         >
           <SupportDrawerContent isSheet={false} />
         </ResponsiveModal>

--- a/hooks/useHomeSetupSteps.ts
+++ b/hooks/useHomeSetupSteps.ts
@@ -45,6 +45,11 @@ export function useHomeSetupSteps(depositCompleted: boolean): HomeSetupStepsResu
     const cardStep = cardSteps.find(step => step.key === 'activate');
 
     const openDeposit = () => useDepositStore.getState().setModal(DEPOSIT_MODAL.OPEN_OPTIONS);
+    // Card onboarding starts at country selection (same entry ReserveCardButton and
+    // useCountryCheck use). These steps used to fall back to `/card`, the deprecated
+    // waitlist page — and they fall back often: `activate` has no onPress until KYC
+    // is complete, and `kyc` has none while its button is disabled.
+    const startCardOnboarding = () => router.push(path.CARD_COUNTRY_SELECTION);
 
     const steps: HomeSetupStep[] = [
       {
@@ -52,14 +57,15 @@ export function useHomeSetupSteps(depositCompleted: boolean): HomeSetupStepsResu
         description: '3 min to unlock all features',
         cta: 'Verify your identity',
         completed: Boolean(kycStep?.completed),
-        onPress: kycStep?.onPress ?? (() => router.push(path.CARD)),
+        onPress: kycStep?.onPress ?? startCardOnboarding,
       },
       {
         title: 'Get your free virtual card',
         description: 'Global payments, cashback and more',
         cta: 'Get your card',
         completed: Boolean(cardStep?.completed),
-        onPress: cardStep?.onPress ?? (() => router.push(path.CARD)),
+        // No activate action means KYC isn't done yet, so send them to that instead.
+        onPress: cardStep?.onPress ?? kycStep?.onPress ?? startCardOnboarding,
       },
       {
         title: 'Top up your balance',


### PR DESCRIPTION
hideHeader renders nothing at all — the close-only header row is what ResponsiveModal shows when you *don't* hide the header. Dropping it from the cashback, tier-points and support popups gives them the same close button every other modal has.

"Verify now" landed on /card, the deprecated waitlist page, because useHomeSetupSteps fell back to it whenever a card step had no action — which is the common case: `activate` has no onPress until KYC is complete, and `kyc` has none while its button is disabled. The steps now fall back to country selection, the entry ReserveCardButton and useCountryCheck already use, and the card step tries the KYC action first since that is what is actually blocking it.


Claude-Session: https://claude.ai/code/session_01Uim9wSonVD3vUgrGHLJ4YC