### PR TITLE
style: 40px inset on every desktop popup, set in ResponsiveModal

### DIFF
--- a/components/ResponsiveModal.tsx
+++ b/components/ResponsiveModal.tsx
@@ -156,7 +156,11 @@ const ResponsiveModal = ({
       {trigger !== null && <DialogTrigger asChild>{trigger}</DialogTrigger>}
       <DialogContent
         className={cn(
-          'px-4 pb-0 pt-4 md:max-w-lg md:px-8 md:pb-0 md:pt-8',
+          // Desktop popups get a uniform 40px inset. Three of the four sides live
+          // here; the bottom stays 0 so the scroll viewport (and its bottom fade)
+          // reaches the card edge, and the matching 40px goes on the scroll
+          // content container below.
+          'px-4 pb-0 pt-4 md:max-w-lg md:px-10 md:pb-0 md:pt-10',
           !isScreenMedium ? 'mt-[5vh] w-screen max-w-full justify-start' : '',
           webFill && 'max-h-[90vh]',
           contentClassName, // Put last so overrides take effect
@@ -233,7 +237,7 @@ const ResponsiveModal = ({
                 >
                   <ScrollView
                     className="web:max-h-[80vh]"
-                    contentContainerClassName="pb-4 md:pb-8"
+                    contentContainerClassName="pb-4 md:pb-10"
                     contentContainerStyle={useFixedHeightLayout ? { flexGrow: 1 } : undefined}
                     style={useFixedHeightLayout ? { flex: 1 } : undefined}
                     showsVerticalScrollIndicator={false}


### PR DESCRIPTION
The card was on md:px-8/md:pt-8 (32px) with the matching bottom on the scroll content container. Bumped all three to 40px so it lands in one place and every popup picks it up.

The bottom stays off the card (md:pb-0) on purpose: the scroll viewport and its bottom fade have to reach the card edge, so the 40px goes on the scroll content container instead.


Claude-Session: https://claude.ai/code/session_01Uim9wSonVD3vUgrGHLJ4YC