### PR TITLE
fix: gate unreleased features (Stocks, GoodDollar, Spin & Win) out of…

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -51,7 +51,7 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
   ...config,
   name: 'Solid',
   slug: 'flash-frontend',
-  version: '1.0.12',
+  version: '2.0.0',
   orientation: 'portrait',
   icon: './assets/images/adaptive-icon.png',
   scheme: 'solid',

--- a/app/(protected)/(tabs)/_layout.tsx
+++ b/app/(protected)/(tabs)/_layout.tsx
@@ -15,6 +15,7 @@ import { TabBarBlurProvider } from '@/components/tabBar/TabBarBlurContext';
 import TabBarBackground from '@/components/ui/TabBarBackground';
 import { path } from '@/constants/path';
 import { useDimension } from '@/hooks/useDimension';
+import { isDevFeatureEnabled } from '@/lib/config';
 
 export default function TabLayout() {
   // The desktop sidebar replaces the bottom bar from `isScreenMedium` up (the
@@ -188,14 +189,19 @@ export default function TabLayout() {
           href: path.REWARDS,
         }}
       />
-      <Tabs.Screen
-        name="stocks"
-        options={{
-          title: 'Stocks',
-          headerShown: false,
-          href: path.STOCKS,
-        }}
-      />
+      {/* Stocks is an in-development feature: its tab/route is only registered on
+          qa/preview builds and hidden in production. The screen itself also
+          redirects in production as a deep-link safeguard. */}
+      {isDevFeatureEnabled && (
+        <Tabs.Screen
+          name="stocks"
+          options={{
+            title: 'Stocks',
+            headerShown: false,
+            href: path.STOCKS,
+          }}
+        />
+      )}
       <Tabs.Screen
         name="referral"
         options={{

--- a/app/(protected)/(tabs)/index.native.tsx
+++ b/app/(protected)/(tabs)/index.native.tsx
@@ -27,6 +27,7 @@ import { useTotalSavingsUSD } from '@/hooks/useTotalSavingsUSD';
 import useUser from '@/hooks/useUser';
 import { useVaultBalance } from '@/hooks/useVault';
 import { useWalletTokens } from '@/hooks/useWalletTokens';
+import { isDevFeatureEnabled } from '@/lib/config';
 import { useIntercom } from '@/lib/intercom';
 import { SavingMode } from '@/lib/types';
 import { formatBalanceUSD, hasCard } from '@/lib/utils';
@@ -178,7 +179,7 @@ function LegacyHome() {
 
         <View className="gap-3 px-4">
           <Text className="mb-2 text-lg font-semibold text-muted-foreground">Promotions</Text>
-          {spinStatus?.isAllowed && (
+          {isDevFeatureEnabled && spinStatus?.isAllowed && (
             <SpinWinCard
               currentStreak={spinStatus?.currentStreak ?? 0}
               spinAvailable={spinStatus?.spinAvailableToday ?? true}

--- a/app/(protected)/(tabs)/index.tsx
+++ b/app/(protected)/(tabs)/index.tsx
@@ -30,6 +30,7 @@ import { useTotalSavingsUSD } from '@/hooks/useTotalSavingsUSD';
 import useUser from '@/hooks/useUser';
 import { useVaultBalance } from '@/hooks/useVault';
 import { useWalletTokens } from '@/hooks/useWalletTokens';
+import { isDevFeatureEnabled } from '@/lib/config';
 import { useIntercom } from '@/lib/intercom';
 import { SavingMode } from '@/lib/types';
 import { fontSize, formatBalanceUSD, hasCard } from '@/lib/utils';
@@ -242,7 +243,7 @@ function LegacyHome() {
 
         <View className="gap-3 px-4 md:mt-10 md:px-0">
           <Text className="mb-2 text-lg font-semibold text-muted-foreground">For You</Text>
-          {Platform.OS !== 'web' && spinStatus?.isAllowed && (
+          {isDevFeatureEnabled && Platform.OS !== 'web' && spinStatus?.isAllowed && (
             <SpinWinCard
               currentStreak={spinStatus?.currentStreak ?? 0}
               spinAvailable={spinStatus?.spinAvailableToday ?? true}

--- a/app/(protected)/(tabs)/rewards/index.tsx
+++ b/app/(protected)/(tabs)/rewards/index.tsx
@@ -23,6 +23,7 @@ import { useDimension } from '@/hooks/useDimension';
 import { useOptInToRewards, useRewardsUserData } from '@/hooks/useRewards';
 import { useSpinStatus } from '@/hooks/useSpinWin';
 import { track } from '@/lib/analytics';
+import { isDevFeatureEnabled } from '@/lib/config';
 import { hasCard } from '@/lib/utils';
 import { useRewards } from '@/store/useRewardsStore';
 import { useRewardsWelcomePopupStore } from '@/store/useRewardsWelcomePopupStore';
@@ -174,7 +175,8 @@ function SpinWinButton() {
   const { data: spinStatus } = useSpinStatus();
   const openSpinWinModal = useSpinWinModalStore(state => state.setModal);
 
-  if (Platform.OS === 'web') return null;
+  // Spin & Win is an in-development feature: fully hidden in production.
+  if (!isDevFeatureEnabled || Platform.OS === 'web') return null;
 
   return (
     <Pressable

--- a/app/(protected)/(tabs)/stocks/index.tsx
+++ b/app/(protected)/(tabs)/stocks/index.tsx
@@ -1,5 +1,6 @@
 import React, { useRef, useState } from 'react';
 import { ScrollView, View } from 'react-native';
+import { Redirect } from 'expo-router';
 
 import PageLayout from '@/components/PageLayout';
 import BuyStockModal from '@/components/Stocks/BuyStockModal';
@@ -12,11 +13,23 @@ import StocksHoldingsList from '@/components/Stocks/StocksHoldingsList';
 import StocksPendingStrip from '@/components/Stocks/StocksPendingStrip';
 import StocksPortfolioCard from '@/components/Stocks/StocksPortfolioCard';
 import { Text } from '@/components/ui/text';
+import { path } from '@/constants/path';
 import { useDimension } from '@/hooks/useDimension';
 import { useXStockHoldings } from '@/hooks/useXStockHoldings';
 import { useXStockPrices } from '@/hooks/useXStockPrices';
+import { isProduction } from '@/lib/config';
 
+// Stocks is an in-development feature: not accessible in production builds.
+// Guards the deep-link/direct-navigation path (the tab/nav entries are gated too).
 export default function StocksPage() {
+  if (isProduction) {
+    return <Redirect href={path.HOME} />;
+  }
+
+  return <StocksPageContent />;
+}
+
+function StocksPageContent() {
   const { isScreenMedium } = useDimension();
   const scrollRef = useRef<ScrollView>(null);
 

--- a/app/(protected)/gooddollar/index.tsx
+++ b/app/(protected)/gooddollar/index.tsx
@@ -1,7 +1,17 @@
+import { Redirect } from 'expo-router';
+
 import GoodDollarClaim from '@/components/GoodDollar/GoodDollarClaim';
 import PageLayout from '@/components/PageLayout';
+import { path } from '@/constants/path';
+import { isProduction } from '@/lib/config';
 
 export default function GoodDollarScreen() {
+  // GoodDollar is an in-development feature: not accessible in production builds.
+  // Guards the deep-link/direct-navigation path (the nav entry is gated too).
+  if (isProduction) {
+    return <Redirect href={path.HOME} />;
+  }
+
   return (
     <PageLayout showNavbar scrollable>
       <GoodDollarClaim />

--- a/components/AccountCenter/AccountCenterDropdown.web.tsx
+++ b/components/AccountCenter/AccountCenterDropdown.web.tsx
@@ -8,6 +8,7 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import useUser from '@/hooks/useUser';
+import { isDevFeatureEnabled } from '@/lib/config';
 import { cn } from '@/lib/utils';
 
 import {
@@ -30,7 +31,7 @@ const AccountCenterDropdown = () => {
   const insets = useSafeAreaInsets();
   const { handleLogout } = useUser();
   // GoodDollar is in development: shown only on qa/preview builds, hidden in production.
-  const canSeeGoodDollar = true;
+  const canSeeGoodDollar = isDevFeatureEnabled;
 
   const contentInsets = {
     top: insets.top,

--- a/components/DeferredModalProviders.tsx
+++ b/components/DeferredModalProviders.tsx
@@ -15,6 +15,7 @@ import SupportDrawerProvider from '@/components/SupportDrawer/SupportDrawerProvi
 import SwapModalProvider from '@/components/Swap/SwapModalProvider';
 import UnstakeModalProvider from '@/components/Unstake/UnstakeModalProvider';
 import WithdrawModalProvider from '@/components/Withdraw/WithdrawModalProvider';
+import { isDevFeatureEnabled } from '@/lib/config';
 
 /**
  * Deferred modal providers component.
@@ -47,7 +48,9 @@ const DeferredModalProviders = () => {
     <>
       <DepositModalProvider />
       <SendModalProvider />
-      <SpinWinModalProvider />
+      {/* Spin & Win is an in-development feature: the modal (popup) machinery is
+          not mounted at all in production, so it can never be opened. */}
+      {isDevFeatureEnabled && <SpinWinModalProvider />}
       <SwapModalProvider />
       <WithdrawModalProvider />
       <StakeModalProvider />

--- a/components/Rewards/NewRewards/RewardsScreenNew.tsx
+++ b/components/Rewards/NewRewards/RewardsScreenNew.tsx
@@ -15,6 +15,7 @@ import { SPIN_WIN } from '@/constants/spinWinDesign';
 import { cardDetailsQueryOptions } from '@/hooks/cardDetailsQueryOptions';
 import { useOptInToRewards, useReferralSummary, useRewardsUserData } from '@/hooks/useRewards';
 import { useSpinStatus } from '@/hooks/useSpinWin';
+import { isDevFeatureEnabled } from '@/lib/config';
 import { RewardsTier } from '@/lib/types';
 import { useRewardsIntroStore } from '@/store/useRewardsIntroStore';
 import { useRewardsWelcomePopupStore } from '@/store/useRewardsWelcomePopupStore';
@@ -153,13 +154,14 @@ export default function RewardsScreenNew() {
             </Pressable>
           </View>
 
-          {/* The spin & win flow is a native-only modal — SpinWinModalProvider
-              force-closes itself on web — so the button stays native-only. It is
-              deliberately NOT gated on `spinStatus.isAllowed`: the provider
-              already closes itself when the backend says the user isn't
-              eligible, and gating here made the button vanish silently whenever
-              the status request hadn't resolved or failed. */}
-          {Platform.OS !== 'web' && (
+          {/* Spin & Win is an in-development feature: shown on qa/preview builds,
+              hidden in production. The flow is also a native-only modal
+              (SpinWinModalProvider force-closes on web). It is deliberately NOT
+              gated on `spinStatus.isAllowed`: the provider already closes itself
+              when the backend says the user isn't eligible, and gating here made
+              the button vanish silently whenever the status request hadn't
+              resolved or failed. */}
+          {isDevFeatureEnabled && Platform.OS !== 'web' && (
             <View className="px-4">
               <Pressable
                 onPress={() => openSpinWinModal(SPIN_WIN_MODAL.OPEN_HOME)}

--- a/components/SpinAndWin/SpinWinModalProvider.tsx
+++ b/components/SpinAndWin/SpinWinModalProvider.tsx
@@ -36,6 +36,7 @@ import { SPIN_WIN_MODAL } from '@/constants/modals';
 import { SPIN_WIN } from '@/constants/spinWinDesign';
 import { useCurrentGiveaway, useGiveawayCountdown, useGiveawayWinners } from '@/hooks/useGiveaway';
 import { usePerformSpin, useSpinStatus } from '@/hooks/useSpinWin';
+import { isProduction } from '@/lib/config';
 import { Faq } from '@/lib/types';
 import { useSpinWinModalStore } from '@/store/useSpinWinModalStore';
 import { useSpinWinStore } from '@/store/useSpinWinStore';
@@ -146,12 +147,18 @@ function SpinWinHomeScreen({ onClose, onSpin }: { onClose: () => void; onSpin: (
   const countdown = useGiveawayCountdown(giveaway?.giveawayDate);
 
   useEffect(() => {
-    if (!isStatusLoading && (Platform.OS === 'web' || spinStatus?.isAllowed === false)) {
+    // Spin & Win is native-only and an in-development feature (hidden in
+    // production); it also closes once the backend says the user isn't eligible.
+    if (
+      Platform.OS === 'web' ||
+      isProduction ||
+      (!isStatusLoading && spinStatus?.isAllowed === false)
+    ) {
       onClose();
     }
   }, [isStatusLoading, onClose, spinStatus?.isAllowed]);
 
-  const canSpin = true;
+  const canSpin = spinStatus?.spinAvailableToday && spinStatus?.isEligible;
 
   if (isStatusLoading) {
     return (

--- a/hooks/useGiveaway.ts
+++ b/hooks/useGiveaway.ts
@@ -3,6 +3,7 @@ import { useQuery } from '@tanstack/react-query';
 import { minutesToMilliseconds, secondsToMilliseconds } from 'date-fns';
 
 import { fetchCurrentGiveaway, fetchGiveawayWinners } from '@/lib/api/spin-win';
+import { isDevFeatureEnabled } from '@/lib/config';
 import { useSpinWinStore } from '@/store/useSpinWinStore';
 
 const SPIN_WIN = 'spin-win';
@@ -42,6 +43,8 @@ export const useCurrentGiveaway = () => {
       setGiveaway(data);
       return data;
     },
+    // Spin & Win is an in-development feature: no giveaway polling in production.
+    enabled: isDevFeatureEnabled,
     staleTime: secondsToMilliseconds(30),
     gcTime: minutesToMilliseconds(10),
     refetchInterval: query => getRefetchInterval(query.state.data?.giveawayDate),
@@ -54,6 +57,7 @@ export const useGiveawayWinners = () => {
   return useQuery({
     queryKey: [SPIN_WIN, 'giveaway', 'winners'],
     queryFn: fetchGiveawayWinners,
+    enabled: isDevFeatureEnabled,
     staleTime: minutesToMilliseconds(5),
     gcTime: minutesToMilliseconds(10),
   });

--- a/hooks/useNav.ts
+++ b/hooks/useNav.ts
@@ -1,6 +1,7 @@
 import { Href } from 'expo-router';
 
 import { path } from '@/constants/path';
+import { isDevFeatureEnabled } from '@/lib/config';
 
 type MenuItem = {
   label: string;
@@ -41,7 +42,15 @@ const useNav = () => {
     href: path.REWARDS,
   };
   // Agent lives in the account-center menu, not the navbar.
-  const menuItems: MenuItem[] = [home, savings, card, stocks, rewards, activity];
+  // Stocks is an in-development feature: shown on qa/preview builds, hidden in production.
+  const menuItems: MenuItem[] = [
+    home,
+    savings,
+    card,
+    ...(isDevFeatureEnabled ? [stocks] : []),
+    rewards,
+    activity,
+  ];
   return { menuItems };
 };
 

--- a/hooks/useSpinWin.ts
+++ b/hooks/useSpinWin.ts
@@ -3,6 +3,7 @@ import { secondsToMilliseconds } from 'date-fns';
 
 import useUser from '@/hooks/useUser';
 import { fetchSpinStatus, performSpin } from '@/lib/api/spin-win';
+import { isDevFeatureEnabled } from '@/lib/config';
 import { withRefreshToken } from '@/lib/utils';
 import { useSpinWinStore } from '@/store/useSpinWinStore';
 
@@ -21,7 +22,9 @@ export const useSpinStatus = () => {
       }
       return data;
     },
-    enabled: !!user?.userId,
+    // Spin & Win is an in-development feature: never query its status in
+    // production so no game data reaches the client there.
+    enabled: !!user?.userId && isDevFeatureEnabled,
     staleTime: secondsToMilliseconds(30),
     gcTime: secondsToMilliseconds(300),
   });

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "solid",
   "main": "index.js",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "scripts": {
     "start": "expo start",
     "start:clear": "expo start --clear",


### PR DESCRIPTION
… production

The change that promoted the mobile-first UI to production (commit "fix: dev gating") also stripped the isDevFeatureEnabled gates off Stocks and GoodDollar and hardcoded the Spin & Win eligibility check, so all three were reachable in production builds. Restore the intended gating and add deep-link safeguards.

- GoodDollar: restore `canSeeGoodDollar = isDevFeatureEnabled` in the web account-center dropdown (was hardcoded `true`, contradicting its own comment).
- Stocks: re-gate the navbar entry (useNav) and the tab/route registration (tabs/_layout) behind isDevFeatureEnabled.
- Spin & Win: gate the rewards-screen entry button behind isDevFeatureEnabled and force-close the modal provider in production; restore the real spin eligibility check (`spinAvailableToday && isEligible`), which had been hardcoded to `true`.
- Add production redirect guards to the /stocks and /gooddollar screens so the routes are not reachable via deep link / direct navigation.


Claude-Session: https://claude.ai/code/session_01CYtBKp4U91tbezURpRmxUo