### PR TITLE
fix(deposit): approve in the source token's real decimals (BNB Chain …

### DIFF
--- a/constants/__tests__/bridge.test.ts
+++ b/constants/__tests__/bridge.test.ts
@@ -1,0 +1,21 @@
+import { bsc, mainnet } from 'viem/chains';
+
+import { getBridgeTokenDecimals } from '@/constants/bridge';
+
+describe('getBridgeTokenDecimals', () => {
+  it('returns 18 for BNB Chain USDC/USDT (Binance-Peg tokens)', () => {
+    // The bug this guards against: hardcoding 6 here under-approved the pull by
+    // 1e12, stranding BSC deposits at the allowance step.
+    expect(getBridgeTokenDecimals(bsc.id, 'USDC')).toBe(18);
+    expect(getBridgeTokenDecimals(bsc.id, 'USDT')).toBe(18);
+  });
+
+  it('defaults to 6 for chains whose USDC omits an explicit decimals (Ethereum, etc.)', () => {
+    expect(getBridgeTokenDecimals(mainnet.id, 'USDC')).toBe(6);
+  });
+
+  it('defaults to 6 for an unknown token or unconfigured chain', () => {
+    expect(getBridgeTokenDecimals(bsc.id, 'NOPE')).toBe(6);
+    expect(getBridgeTokenDecimals(999999, 'USDC')).toBe(6);
+  });
+});

--- a/constants/bridge.ts
+++ b/constants/bridge.ts
@@ -214,6 +214,20 @@ export const getUsdcAddress = (chainId: number) => {
   return usdcAddress;
 };
 
+/**
+ * Decimals of a bridge source token, by token name, defaulting to 6.
+ *
+ * Most chains' USDC/USDT are 6 decimals (hence the default), but BNB Chain's
+ * Binance-Peg USDC/USDT are 18. Hardcoding 6 there under-approves the pull by
+ * 1e12, so the backend's transferFrom can never be covered and the deposit
+ * stalls at the allowance step. Always derive decimals from here.
+ */
+export const getBridgeTokenDecimals = (chainId: number, tokenName: string): number => {
+  const tokens = BRIDGE_TOKENS[chainId]?.tokens;
+  const token = tokens ? Object.values(tokens).find(t => t.name === tokenName) : undefined;
+  return token?.decimals ?? 6;
+};
+
 export const getBridgeChain = (chainId: number) => {
   return BRIDGE_TOKENS[chainId];
 };

--- a/hooks/useDepositFromEOA.ts
+++ b/hooks/useDepositFromEOA.ts
@@ -17,7 +17,7 @@ import { mainnet } from 'viem/chains';
 import { useBlockNumber, useChainId, useReadContract } from 'wagmi';
 import { readContract } from 'wagmi/actions';
 
-import { BRIDGE_TOKENS } from '@/constants/bridge';
+import { BRIDGE_TOKENS, getBridgeTokenDecimals } from '@/constants/bridge';
 import { ERRORS } from '@/constants/errors';
 import { TRACKING_EVENTS } from '@/constants/tracking-events';
 import { CROSS_CHAIN_DEPOSIT_METADATA_KEY } from '@/constants/transaction';
@@ -443,9 +443,7 @@ const useDepositFromEOA = (
       // Source token decimals (defaults to 6). Some chains' USDC is not 6
       // decimals (e.g. Binance-Peg USDC on BNB Chain is 18), so derive it from
       // the bridge config rather than hardcoding.
-      const srcDecimals =
-        Object.values(BRIDGE_TOKENS[srcChainId]?.tokens ?? {}).find(t => t.name === token)
-          ?.decimals ?? 6;
+      const srcDecimals = getBridgeTokenDecimals(srcChainId, token);
       const amountWei = parseUnits(amount, srcDecimals);
 
       let txHash: `0x${string}` | undefined;

--- a/hooks/useDepositFromSolidUsdc.ts
+++ b/hooks/useDepositFromSolidUsdc.ts
@@ -3,6 +3,7 @@ import { type Address, erc20Abi, parseUnits } from 'viem';
 import { base, mainnet } from 'viem/chains';
 import { useBlockNumber, useReadContract } from 'wagmi';
 
+import { getBridgeTokenDecimals } from '@/constants/bridge';
 import { CROSS_CHAIN_DEPOSIT_METADATA_KEY } from '@/constants/transaction';
 import { useActivityActions } from '@/hooks/useActivityActions';
 import { bridgeDeposit, createDeposit } from '@/lib/api';
@@ -147,7 +148,12 @@ const useDepositFromSolidUsdc = (
         isSponsor,
       });
 
-      const amountWei = parseUnits(amount, 6);
+      // Approve in the source token's real decimals. BNB Chain USDC/USDT are
+      // 18-decimal, so a hardcoded 6 under-approved by 1e12 and the backend's
+      // transferFrom could never be covered - the deposit stalled at the pull.
+      // The backend parses the same amount with these decimals, so they must match.
+      const srcDecimals = getBridgeTokenDecimals(srcChainId, token);
+      const amountWei = parseUnits(amount, srcDecimals);
       const spender = EXPO_PUBLIC_BRIDGE_AUTO_DEPOSIT_ADDRESS as Address;
 
       // Let the backend pull these funds out of the Safe on the source chain.


### PR DESCRIPTION
…USDC is 18)

Connect-wallet bridge deposits from BNB Chain stalled at the pull with "insufficient allowance". The Solid-wallet USDC path built the source-chain approval with a hardcoded 6 decimals, but BNB Chain's Binance-Peg USDC/USDT are 18-decimal tokens - so a 160 USDC deposit approved 160 * 1e6 base units while the backend's transferFrom needs 160 * 1e18. The approval fell short by 1e12 and no retry could ever cover it.

Derive decimals from the bridge-token config instead of hardcoding, via a new getBridgeTokenDecimals(chainId, tokenName) helper (defaults to 6, returns 18 for BNB Chain). useDepositFromEOA already derived this inline; both cross-chain deposit hooks now share the helper. The backend parses the same amount with these decimals, so approve and transferFrom now agree.

Adds unit tests for the helper.


Claude-Session: https://claude.ai/code/session_01EsHQSQecEw6FQST3KmvdJ7