### PR TITLE
Add KYC verification progress tracking and home prompt nudges

### DIFF
--- a/components/Home/NewHome/HomePromptCard.tsx
+++ b/components/Home/NewHome/HomePromptCard.tsx
@@ -10,9 +10,16 @@ import CardWaitingModal from '@/components/Home/CardWaitingModal';
 import { Button } from '@/components/ui/button';
 import { Text } from '@/components/ui/text';
 import { DEPOSIT_MODAL } from '@/constants/modals';
+import { TRACKING_EVENTS } from '@/constants/tracking-events';
+import { useCardStatus } from '@/hooks/useCardStatus';
 import { useHomeSetupSteps } from '@/hooks/useHomeSetupSteps';
+import { track } from '@/lib/analytics';
 import { useDepositStore } from '@/store/useDepositStore';
-import { HomePromptKey, useHomePromptStore } from '@/store/useHomePromptStore';
+import {
+  HomePromptKey,
+  homePromptSnoozeDays,
+  useHomePromptStore,
+} from '@/store/useHomePromptStore';
 
 // Figma: Mona Sans / Bold 700 / 18px / line-height 100%.
 const TITLE_STYLE = { fontFamily: 'MonaSans_700Bold', fontSize: 18, lineHeight: 18 } as const;
@@ -54,21 +61,37 @@ interface HomePromptCardProps {
 
 /**
  * Next-step prompt card on the redesigned home screen. Which of the three
- * variants shows is decided by `useHomePrompt` from the user's state: no card
- * yet ("Finish verification"), card but no funds ("Fund your wallet"), or a
- * funded card that isn't in Apple Pay yet ("Add to Apple Pay").
+ * variants shows is decided by `useHomePrompt` from the user's state: an
+ * abandoned KYC ("Finish verification"), card but no funds ("Fund your
+ * wallet"), or a funded card that isn't in Apple Pay yet ("Add to Apple Pay").
  *
- * Each variant can be dismissed with the ✕; the dismissal is a snooze, so it
- * reappears a few days later (see `useHomePromptStore`). Separate from the
- * legacy HomeCardSetup so the public/legacy home is unaffected.
+ * Each variant can be dismissed with the ✕; the dismissal is a snooze persisted
+ * on the device, so it reappears once the variant's window is up — a week for
+ * verification (see `useHomePromptStore`). Separate from the legacy
+ * HomeCardSetup so the public/legacy home is unaffected.
  */
 const HomePromptCard = ({ promptKey, depositCompleted, className }: HomePromptCardProps) => {
   const [isWaitingOpen, setIsWaitingOpen] = useState(false);
   const [isWalletOpen, setIsWalletOpen] = useState(false);
   const { firstIncomplete } = useHomeSetupSteps(depositCompleted);
   const dismiss = useHomePromptStore(state => state.dismiss);
+  const { data: cardStatus } = useCardStatus();
 
   const { title, description, cta, icon } = CONTENT[promptKey];
+
+  const onPressDismiss = () => {
+    // Which prompt was closed, how long that buys, and where the user was in the
+    // funnel — enough to tell "snoozed a nudge they'd already acted on" from
+    // "gave up on verification" without an event per variant.
+    track(TRACKING_EVENTS.HOME_PROMPT_DISMISSED, {
+      prompt: promptKey,
+      snoozeDays: homePromptSnoozeDays(promptKey),
+      kycStatus: cardStatus?.kycStatus,
+      rainApplicationStatus: cardStatus?.rainApplicationStatus,
+      depositCompleted,
+    });
+    dismiss(promptKey);
+  };
 
   const onPressCta = () => {
     switch (promptKey) {
@@ -111,7 +134,7 @@ const HomePromptCard = ({ promptKey, depositCompleted, className }: HomePromptCa
           <Pressable
             accessibilityRole="button"
             accessibilityLabel={`Dismiss ${title}`}
-            onPress={() => dismiss(promptKey)}
+            onPress={onPressDismiss}
             hitSlop={16}
             className="absolute right-[10px] top-[11px]"
           >

--- a/components/kyc/useDiditSession.ts
+++ b/components/kyc/useDiditSession.ts
@@ -11,6 +11,7 @@ import { createDiditSession, getCardStatus, getDiditVerificationStatus } from '@
 import { KycStatus, RainApplicationStatus } from '@/lib/types';
 import { withRefreshToken } from '@/lib/utils';
 import { useKycStore } from '@/store/useKycStore';
+import { useUserStore } from '@/store/useUserStore';
 
 export type SessionState =
   | { phase: 'loading' }
@@ -165,6 +166,11 @@ export function useDiditSession() {
   }, [debugState, kycFlow, redirectBasedOnKycStatus]);
 
   const markStarted = useCallback(() => {
+    // Persisted so the home screen can tell "started verification and walked
+    // away" from "never started" — the two look identical on /cards/status for
+    // a while, and only the former should be nudged to finish.
+    const userId = useUserStore.getState().users.find(user => user.selected)?.userId;
+    if (userId) useKycStore.getState().markKycStarted(userId);
     setSession({ phase: 'started' });
   }, []);
 

--- a/constants/tracking-events.ts
+++ b/constants/tracking-events.ts
@@ -191,6 +191,9 @@ export const TRACKING_EVENTS = {
   // Feature Discovery Events
   TOOLTIP_OPENED: 'tooltip_opened',
 
+  // Home Prompt Card Events (verification / fund / Apple Pay nudges)
+  HOME_PROMPT_DISMISSED: 'home_prompt_dismissed',
+
   // Card Waitlist Events
   CARD_WAITLIST_STARTED: 'card_waitlist_started',
   CARD_WAITLIST_COMPLETED: 'card_waitlist_completed',

--- a/hooks/useHomePrompt.ts
+++ b/hooks/useHomePrompt.ts
@@ -1,7 +1,11 @@
 import { Platform } from 'react-native';
 
+import { useCardStatus } from '@/hooks/useCardStatus';
 import { useWalletEligibility } from '@/hooks/useWalletEligibility';
+import { shouldPromptToFinishKyc } from '@/lib/utils/kyc/verificationProgress';
 import { HomePromptKey, isHomePromptSnoozed, useHomePromptStore } from '@/store/useHomePromptStore';
+import { useKycStore } from '@/store/useKycStore';
+import { useUserStore } from '@/store/useUserStore';
 
 interface UseHomePromptParams {
   /** Whether the user already holds an active card. */
@@ -12,9 +16,16 @@ interface UseHomePromptParams {
 
 /**
  * Picks which prompt card (if any) the redesigned home screen should show, in
- * onboarding order: get verified → fund the wallet → add the card to Apple Pay.
+ * onboarding order: finish verification → fund the wallet → add the card to
+ * Apple Pay.
  *
- * Each variant can be dismissed independently and comes back after
+ * "Finish verification" is a nudge for an abandoned KYC, so it only shows to
+ * users who started verification and still have a step left. Users who never
+ * started aren't nagged here — the wallet card's own "Get your card" panel is
+ * their entry point — and users waiting on a decision (under review, Rain
+ * pending) aren't either, since there is nothing for them to finish.
+ *
+ * Each variant can be dismissed independently and comes back after its entry in
  * {@link HOME_PROMPT_SNOOZE_MS}; a snoozed variant hides the card rather than
  * falling through to a later step, since the earlier step is still the one the
  * user needs to do.
@@ -24,6 +35,9 @@ export function useHomePrompt({
   depositCompleted,
 }: UseHomePromptParams): HomePromptKey | null {
   const dismissedAt = useHomePromptStore(state => state.dismissedAt);
+  const userId = useUserStore(state => state.users.find(user => user.selected)?.userId);
+  const kycStartedAt = useKycStore(state => (userId ? state.kycStartedAt[userId] : undefined));
+  const { data: cardStatus } = useCardStatus();
 
   // Only iOS gets the Apple Pay prompt, and only once the card exists and is
   // funded — otherwise there's nothing to provision or nothing to spend.
@@ -32,7 +46,9 @@ export function useHomePrompt({
 
   let key: HomePromptKey | null = null;
   if (!hasCard) {
-    key = 'verification';
+    // No fall-through to the funding prompt: without a card the user's next
+    // step is the card, not a top-up, so no prompt beats the wrong prompt.
+    key = shouldPromptToFinishKyc(cardStatus, kycStartedAt ?? null) ? 'verification' : null;
   } else if (!depositCompleted) {
     key = 'fund';
   } else if (walletPromptPossible && eligibility && !eligibility.alreadyInAppleWallet) {

--- a/lib/utils/__tests__/verificationProgress.test.ts
+++ b/lib/utils/__tests__/verificationProgress.test.ts
@@ -1,0 +1,126 @@
+/// <reference types="jest" />
+
+import { CardStatusResponse, KycStatus, RainApplicationStatus } from '@/lib/types';
+import { shouldPromptToFinishKyc } from '@/lib/utils/kyc/verificationProgress';
+
+const STARTED_AT = 1_700_000_000_000;
+
+const cardStatus = (overrides: Partial<CardStatusResponse> = {}): CardStatusResponse => overrides;
+
+describe('shouldPromptToFinishKyc', () => {
+  it('stays hidden for a user who never started verification', () => {
+    expect(shouldPromptToFinishKyc(null, null)).toBe(false);
+    expect(shouldPromptToFinishKyc(cardStatus({ kycStatus: KycStatus.NOT_STARTED }), null)).toBe(
+      false,
+    );
+    expect(
+      shouldPromptToFinishKyc(
+        cardStatus({ rainApplicationStatus: RainApplicationStatus.NOT_STARTED }),
+        null,
+      ),
+    ).toBe(false);
+  });
+
+  it('shows for a user who opened the Didit SDK and walked away', () => {
+    // The backend has nothing to show yet — the local marker is the only signal.
+    expect(shouldPromptToFinishKyc(null, STARTED_AT)).toBe(true);
+    expect(
+      shouldPromptToFinishKyc(cardStatus({ kycStatus: KycStatus.NOT_STARTED }), STARTED_AT),
+    ).toBe(true);
+  });
+
+  it('shows while the user still has a step left, marker or not', () => {
+    expect(shouldPromptToFinishKyc(cardStatus({ kycStatus: KycStatus.INCOMPLETE }), null)).toBe(
+      true,
+    );
+    expect(
+      shouldPromptToFinishKyc(
+        cardStatus({ kycStatus: KycStatus.AWAITING_QUESTIONNAIRE }),
+        STARTED_AT,
+      ),
+    ).toBe(true);
+    expect(
+      shouldPromptToFinishKyc(
+        cardStatus({ rainApplicationStatus: RainApplicationStatus.NEEDS_VERIFICATION }),
+        null,
+      ),
+    ).toBe(true);
+    expect(
+      shouldPromptToFinishKyc(
+        cardStatus({ rainApplicationStatus: RainApplicationStatus.NEEDS_INFORMATION }),
+        null,
+      ),
+    ).toBe(true);
+  });
+
+  it('stays hidden once verification is finished', () => {
+    expect(shouldPromptToFinishKyc(cardStatus({ kycStatus: KycStatus.APPROVED }), STARTED_AT)).toBe(
+      false,
+    );
+    expect(
+      shouldPromptToFinishKyc(
+        cardStatus({
+          kycStatus: KycStatus.APPROVED,
+          rainApplicationStatus: RainApplicationStatus.APPROVED,
+        }),
+        STARTED_AT,
+      ),
+    ).toBe(false);
+  });
+
+  it('stays hidden while a decision is pending — there is nothing to finish', () => {
+    expect(
+      shouldPromptToFinishKyc(cardStatus({ kycStatus: KycStatus.UNDER_REVIEW }), STARTED_AT),
+    ).toBe(false);
+    expect(
+      shouldPromptToFinishKyc(
+        cardStatus({ rainApplicationStatus: RainApplicationStatus.PENDING }),
+        STARTED_AT,
+      ),
+    ).toBe(false);
+    expect(
+      shouldPromptToFinishKyc(
+        cardStatus({ rainApplicationStatus: RainApplicationStatus.MANUAL_REVIEW }),
+        STARTED_AT,
+      ),
+    ).toBe(false);
+  });
+
+  it('stays hidden on a final rejection — the CTA would be a dead end', () => {
+    expect(shouldPromptToFinishKyc(cardStatus({ kycStatus: KycStatus.REJECTED }), STARTED_AT)).toBe(
+      false,
+    );
+    expect(
+      shouldPromptToFinishKyc(cardStatus({ kycStatus: KycStatus.OFFBOARDED }), STARTED_AT),
+    ).toBe(false);
+    expect(
+      shouldPromptToFinishKyc(
+        cardStatus({ rainApplicationStatus: RainApplicationStatus.DENIED }),
+        STARTED_AT,
+      ),
+    ).toBe(false);
+  });
+
+  it('lets the Rain application status override an earlier Didit status', () => {
+    // Rain is the later stage of the same funnel: it needing the user beats a
+    // stale `under_review` from the Didit phase, and vice versa.
+    expect(
+      shouldPromptToFinishKyc(
+        cardStatus({
+          kycStatus: KycStatus.UNDER_REVIEW,
+          rainApplicationStatus: RainApplicationStatus.NEEDS_VERIFICATION,
+        }),
+        STARTED_AT,
+      ),
+    ).toBe(true);
+    expect(
+      shouldPromptToFinishKyc(
+        cardStatus({
+          kycStatus: KycStatus.INCOMPLETE,
+          rainApplicationStatus: RainApplicationStatus.MANUAL_REVIEW,
+        }),
+        STARTED_AT,
+      ),
+    ).toBe(false);
+  });
+});

--- a/lib/utils/kyc/verificationProgress.ts
+++ b/lib/utils/kyc/verificationProgress.ts
@@ -1,0 +1,87 @@
+import { CardStatusResponse, KycStatus, RainApplicationStatus } from '@/lib/types';
+
+/**
+ * Rain application states the user cannot act on: the application is either
+ * finished (approved), being decided (pending / manual review) or closed
+ * (denied / locked / canceled). Everything else — needsVerification,
+ * needsInformation, notStarted — is still waiting on the user.
+ */
+const SETTLED_RAIN_STATUSES: RainApplicationStatus[] = [
+  RainApplicationStatus.APPROVED,
+  RainApplicationStatus.PENDING,
+  RainApplicationStatus.MANUAL_REVIEW,
+  RainApplicationStatus.DENIED,
+  RainApplicationStatus.LOCKED,
+  RainApplicationStatus.CANCELED,
+];
+
+/**
+ * Backend KYC statuses (Didit's decision, before Rain is reached) the user
+ * cannot act on. `under_review` / `paused` are waiting on us, and `rejected` /
+ * `offboarded` are final — the card steps render no button for any of them
+ * (see `isStepButtonDisabled`), so nagging the user to "finish" would be a
+ * dead end.
+ */
+const SETTLED_KYC_STATUSES: KycStatus[] = [
+  KycStatus.APPROVED,
+  KycStatus.UNDER_REVIEW,
+  KycStatus.REJECTED,
+  KycStatus.PAUSED,
+  KycStatus.OFFBOARDED,
+];
+
+function isKnownRainStatus(status: unknown): status is RainApplicationStatus {
+  return Object.values(RainApplicationStatus).includes(status as RainApplicationStatus);
+}
+
+/**
+ * Whether the user has entered identity verification at all.
+ *
+ * `kycStartedAt` is the local marker written the moment the provider SDK opens
+ * (see `useDiditSession`). It matters because a user who opens Didit and walks
+ * away leaves no server-side trace for a while — `/cards/status` still reads
+ * `not_started` (or 404s into `null`) — yet they are exactly who we want to
+ * pull back in.
+ */
+export function hasStartedKyc(
+  cardStatus: CardStatusResponse | null | undefined,
+  kycStartedAt: number | null | undefined,
+): boolean {
+  if (kycStartedAt != null) return true;
+
+  const rainStatus = cardStatus?.rainApplicationStatus;
+  if (rainStatus && rainStatus !== RainApplicationStatus.NOT_STARTED) return true;
+
+  const kycStatus = cardStatus?.kycStatus;
+  return Boolean(kycStatus) && kycStatus !== KycStatus.NOT_STARTED;
+}
+
+/**
+ * Whether verification still has a step the user can take. Rain's application
+ * status wins whenever it is present — it is the later, more specific stage of
+ * the same funnel — and the backend `kycStatus` covers the Didit-only phase
+ * before Rain has seen the applicant.
+ */
+export function hasUnfinishedKyc(cardStatus: CardStatusResponse | null | undefined): boolean {
+  const rainStatus = cardStatus?.rainApplicationStatus;
+  if (isKnownRainStatus(rainStatus)) return !SETTLED_RAIN_STATUSES.includes(rainStatus);
+
+  const kycStatus = cardStatus?.kycStatus;
+  if (kycStatus) return !SETTLED_KYC_STATUSES.includes(kycStatus);
+
+  // No card record yet (`/cards/status` 404s until one exists), so nothing says
+  // the user is done.
+  return true;
+}
+
+/**
+ * Whether to nudge the user to finish verification: they started it and still
+ * have something to do. Deliberately not shown to users who never started —
+ * the wallet card's own "Get your card" panel is the entry point for those.
+ */
+export function shouldPromptToFinishKyc(
+  cardStatus: CardStatusResponse | null | undefined,
+  kycStartedAt: number | null | undefined,
+): boolean {
+  return hasStartedKyc(cardStatus, kycStartedAt) && hasUnfinishedKyc(cardStatus);
+}

--- a/store/__tests__/useHomePromptStore.test.ts
+++ b/store/__tests__/useHomePromptStore.test.ts
@@ -20,6 +20,8 @@ jest.mock('@/lib/mmvkStorage', () => {
   };
 });
 
+const DAY_MS = 24 * 60 * 60 * 1000;
+
 describe('home prompt snoozing', () => {
   afterEach(() => {
     useHomePromptStore.setState({ dismissedAt: {} });
@@ -31,15 +33,21 @@ describe('home prompt snoozing', () => {
 
   it('hides a prompt for the snooze window, then brings it back', () => {
     const now = 1_700_000_000_000;
+    const dismissedAt = { fund: now };
+    const window = HOME_PROMPT_SNOOZE_MS.fund;
+
+    expect(isHomePromptSnoozed(dismissedAt, 'fund', now + 1000)).toBe(true);
+    expect(isHomePromptSnoozed(dismissedAt, 'fund', now + window - 1)).toBe(true);
+    expect(isHomePromptSnoozed(dismissedAt, 'fund', now + window)).toBe(false);
+  });
+
+  it('brings the verification prompt back a week after it was closed', () => {
+    const now = 1_700_000_000_000;
     const dismissedAt = { verification: now };
 
-    expect(isHomePromptSnoozed(dismissedAt, 'verification', now + 1000)).toBe(true);
-    expect(isHomePromptSnoozed(dismissedAt, 'verification', now + HOME_PROMPT_SNOOZE_MS - 1)).toBe(
-      true,
-    );
-    expect(isHomePromptSnoozed(dismissedAt, 'verification', now + HOME_PROMPT_SNOOZE_MS)).toBe(
-      false,
-    );
+    expect(HOME_PROMPT_SNOOZE_MS.verification).toBe(7 * DAY_MS);
+    expect(isHomePromptSnoozed(dismissedAt, 'verification', now + 6 * DAY_MS)).toBe(true);
+    expect(isHomePromptSnoozed(dismissedAt, 'verification', now + 7 * DAY_MS)).toBe(false);
   });
 
   it('snoozes each variant independently', () => {

--- a/store/__tests__/useKycStore.test.ts
+++ b/store/__tests__/useKycStore.test.ts
@@ -1,0 +1,55 @@
+/// <reference types="jest" />
+
+import { useKycStore } from '@/store/useKycStore';
+
+// MMKV is a native module — back the persisted store with plain memory here.
+// (jest.mock is hoisted above the import by babel-jest.)
+jest.mock('@/lib/mmvkStorage', () => {
+  const memory = new Map<string, string>();
+  return {
+    __esModule: true,
+    default: () => ({
+      setItem: (key: string, value: string) => memory.set(key, value),
+      getItem: (key: string) => memory.get(key) ?? null,
+      removeItem: (key: string) => memory.delete(key),
+    }),
+  };
+});
+
+describe('kyc started marker', () => {
+  afterEach(() => {
+    useKycStore.setState({ kycStartedAt: {} });
+  });
+
+  it('records nothing until the user opens verification', () => {
+    expect(useKycStore.getState().kycStartedAt['user-1']).toBeUndefined();
+  });
+
+  it('keeps the first timestamp when verification is reopened', () => {
+    const { markKycStarted } = useKycStore.getState();
+
+    markKycStarted('user-1');
+    const first = useKycStore.getState().kycStartedAt['user-1'];
+    markKycStarted('user-1');
+
+    expect(first).toEqual(expect.any(Number));
+    expect(useKycStore.getState().kycStartedAt['user-1']).toBe(first);
+  });
+
+  it('does not leak the marker to another account on the same device', () => {
+    useKycStore.getState().markKycStarted('user-1');
+
+    expect(useKycStore.getState().kycStartedAt['user-2']).toBeUndefined();
+  });
+
+  it('clears one account without touching the others', () => {
+    const { markKycStarted, clearKycStartedAt } = useKycStore.getState();
+    markKycStarted('user-1');
+    markKycStarted('user-2');
+
+    clearKycStartedAt('user-1');
+
+    expect(useKycStore.getState().kycStartedAt['user-1']).toBeUndefined();
+    expect(useKycStore.getState().kycStartedAt['user-2']).toEqual(expect.any(Number));
+  });
+});

--- a/store/useHomePromptStore.ts
+++ b/store/useHomePromptStore.ts
@@ -6,12 +6,22 @@ import mmkvStorage from '@/lib/mmvkStorage';
 /** The home prompt-card variants a user can dismiss, one snooze timer each. */
 export type HomePromptKey = 'verification' | 'fund' | 'apple-pay';
 
+const DAY_MS = 24 * 60 * 60 * 1000;
+
 /**
- * How long a dismissed prompt stays hidden. Dismissing is a "not now", not a
- * "never" — the card comes back after three days so the user still gets nudged
- * through onboarding.
+ * How long a dismissed prompt stays hidden, per variant. Dismissing is a
+ * "not now", not a "never" — the card comes back later so the user still gets
+ * nudged through onboarding.
+ *
+ * Verification snoozes for a week rather than the three days the lighter
+ * prompts use: it's the step with real effort behind it (documents, a selfie),
+ * so coming back sooner reads as pestering.
  */
-export const HOME_PROMPT_SNOOZE_MS = 3 * 24 * 60 * 60 * 1000;
+export const HOME_PROMPT_SNOOZE_MS: Record<HomePromptKey, number> = {
+  verification: 7 * DAY_MS,
+  fund: 3 * DAY_MS,
+  'apple-pay': 3 * DAY_MS,
+};
 
 interface HomePromptState {
   /** Epoch ms of the last dismissal, per variant. */
@@ -35,6 +45,11 @@ export const useHomePromptStore = create<HomePromptState>()(
   ),
 );
 
+/** A variant's snooze window in days — for analytics payloads. */
+export function homePromptSnoozeDays(key: HomePromptKey): number {
+  return HOME_PROMPT_SNOOZE_MS[key] / DAY_MS;
+}
+
 /** Whether `key` was dismissed recently enough that it should stay hidden. */
 export function isHomePromptSnoozed(
   dismissedAt: HomePromptState['dismissedAt'],
@@ -44,5 +59,5 @@ export function isHomePromptSnoozed(
   const at = dismissedAt[key];
   // A timestamp in the future (clock moved back) would otherwise hide the card
   // for good, so treat anything outside the window as expired.
-  return at !== undefined && now >= at && now - at < HOME_PROMPT_SNOOZE_MS;
+  return at !== undefined && now >= at && now - at < HOME_PROMPT_SNOOZE_MS[key];
 }

--- a/store/useKycStore.ts
+++ b/store/useKycStore.ts
@@ -17,6 +17,17 @@ interface KycState {
   diditSessionId: string | null;
   setDiditSessionId: (sessionId: string) => void;
   clearDiditSessionId: () => void;
+  /**
+   * Epoch ms of the first time each user opened the verification SDK, keyed by
+   * userId. Local-only marker: a user who abandons Didit mid-flow leaves no
+   * server-side trace for a while, so this is what tells us they started at
+   * all. Keyed per user because the device is shared between accounts — a
+   * global flag would follow the next account that signs in, and would be lost
+   * on any re-login.
+   */
+  kycStartedAt: Record<string, number>;
+  markKycStarted: (userId: string) => void;
+  clearKycStartedAt: (userId: string) => void;
   /** Which product initiated KYC — drives post-KYC routing. */
   kycFlow: KycFlow | null;
   setKycFlow: (flow: KycFlow) => void;
@@ -31,12 +42,13 @@ const KYC_STORAGE_KEY = 'kyc-store';
 
 export const useKycStore = create<KycState>()(
   persist(
-    set => ({
+    (set, get) => ({
       kycLinkId: null,
       processingUntil: null,
       diditSessionId: null,
       kycFlow: null,
       kycProvider: null,
+      kycStartedAt: {},
 
       setKycLinkId: (kycLinkId: string) => {
         set({ kycLinkId });
@@ -60,6 +72,20 @@ export const useKycStore = create<KycState>()(
 
       clearDiditSessionId: () => {
         set({ diditSessionId: null });
+      },
+
+      markKycStarted: (userId: string) => {
+        // Keep the first timestamp: it dates the start of the attempt, and
+        // re-opening the SDK on a retry shouldn't reset that.
+        if (get().kycStartedAt[userId] != null) return;
+        set(state => ({ kycStartedAt: { ...state.kycStartedAt, [userId]: Date.now() } }));
+      },
+
+      clearKycStartedAt: (userId: string) => {
+        set(state => {
+          const { [userId]: _removed, ...rest } = state.kycStartedAt;
+          return { kycStartedAt: rest };
+        });
       },
 
       setKycFlow: (flow: KycFlow) => {


### PR DESCRIPTION
## Summary
This PR adds functionality to track when users start KYC verification and intelligently prompt them to finish if they abandon the process. It introduces a local marker system to detect abandoned verifications and a smart prompt card that appears on the home screen only when appropriate.

## Key Changes

- **KYC Progress Tracking**: Added `verificationProgress.ts` utilities to determine if a user has started KYC and whether they have unfinished steps
  - `hasStartedKyc()`: Checks both server status and local `kycStartedAt` marker
  - `hasUnfinishedKyc()`: Evaluates current KYC/Rain application status to see if user action is needed
  - `shouldPromptToFinishKyc()`: Combines both checks to decide if the nudge should show

- **KYC Store Enhancement**: Extended `useKycStore` with per-user KYC start tracking
  - Added `kycStartedAt` record keyed by userId to persist the first timestamp a user opened verification
  - `markKycStarted()`: Records the timestamp only on first open (idempotent)
  - `clearKycStartedAt()`: Clears marker per user without affecting other accounts on shared device

- **Home Prompt Improvements**: Made verification prompt smarter and less annoying
  - Changed snooze window from fixed 3 days to variant-specific: 7 days for verification, 3 days for fund/Apple Pay
  - Updated `useHomePrompt()` to use `shouldPromptToFinishKyc()` instead of always showing verification
  - Only shows verification prompt to users who actually started KYC and have steps remaining
  - Users waiting on decisions (under review, Rain pending) or who never started aren't nagged

- **Analytics**: Added `HOME_PROMPT_DISMISSED` event to track which prompts users close and their KYC status

- **Didit Session**: Integrated `markKycStarted()` call when the Didit SDK opens to establish the local marker

## Notable Implementation Details

- The local `kycStartedAt` marker is essential because users who open Didit and abandon mid-flow leave no server-side trace initially — `/cards/status` still shows `not_started` until they complete or the backend processes their partial submission
- Rain application status takes precedence over Didit KYC status since it's the later, more specific stage of the same funnel
- Per-user tracking prevents the marker from leaking between accounts on shared devices
- Snooze windows are now variant-specific to balance re-engagement (verification needs more time due to effort required) with user experience

https://claude.ai/code/session_01WLuXR9jnjy9vLe6XwW4K9e