### PR TITLE
fix(region): don't gate the country selector on the geo lookup

### DIFF
--- a/app/(protected)/(tabs)/card-onboard/country_selection.tsx
+++ b/app/(protected)/(tabs)/card-onboard/country_selection.tsx
@@ -29,8 +29,10 @@ export default function CountrySelection() {
     }
   };
 
-  const [loading, setLoading] = useState(true);
-  const [showCountrySelector, setShowCountrySelector] = useState(false);
+  // The selector renders immediately: it needs no network to be usable, and
+  // gating it on the geo lookup meant a blank loading screen for as long as the
+  // lookup took. Detection only preselects a country once it lands.
+  const [showCountrySelector, setShowCountrySelector] = useState(true);
   const [showDropdown, setShowDropdown] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');
   const [selectedCountry, setSelectedCountry] = useState<Country | null>(null);
@@ -43,26 +45,29 @@ export default function CountrySelection() {
     })),
   );
 
-  // Detect where the user is so the selector opens on their country. The
-  // selector is always shown first — picking by hand stays available even when
-  // detection succeeds, because the IP is only a guess at residence.
+  // Detect where the user is so the selector opens on their country. Picking by
+  // hand stays available even when detection succeeds, because the IP is only a
+  // guess at residence — so this never blocks the screen, and a failure just
+  // leaves the field empty.
   useEffect(() => {
     let cancelled = false;
 
     const detect = async () => {
-      const access = await resolveCountryAccess('card', 'card_country_selection');
+      try {
+        const access = await resolveCountryAccess('card', 'card_country_selection');
 
-      if (cancelled) return;
+        if (cancelled || !access) return;
 
-      const country = access && COUNTRIES.find(c => c.code === access.countryCode);
+        const country = COUNTRIES.find(c => c.code === access.countryCode);
 
-      if (country) {
-        setSelectedCountry(country);
-        setSearchQuery(country.name);
+        // Don't stomp a country the user picked while detection was in flight.
+        if (country) {
+          setSelectedCountry(current => current ?? country);
+          setSearchQuery(current => current || country.name);
+        }
+      } catch (error) {
+        console.error('Error detecting country:', error);
       }
-
-      setShowCountrySelector(true);
-      setLoading(false);
     };
 
     void detect();
@@ -120,10 +125,6 @@ export default function CountrySelection() {
       setProcessing(false);
     }
   };
-
-  if (loading) {
-    return <LoadingView />;
-  }
 
   // Card isn't issued where they are — show what Solid still does for them
   // instead of a dead end, and record the country as a lead.
@@ -290,17 +291,5 @@ function CountrySelector({
         </Button>
       </View>
     </View>
-  );
-}
-
-// Loading View
-function LoadingView() {
-  return (
-    <PageLayout desktopOnly scrollable={false}>
-      <View className="flex-1 items-center justify-center">
-        <ActivityIndicator size="large" color="#94F27F" />
-        <Text className="mt-4 text-white/70">Loading...</Text>
-      </View>
-    </PageLayout>
   );
 }

--- a/lib/__tests__/geo.test.ts
+++ b/lib/__tests__/geo.test.ts
@@ -66,6 +66,23 @@ describe('detectGeo', () => {
     expect(mockFetch.mock.calls.length).toBeGreaterThan(3);
   });
 
+  it('gives up once the overall budget is spent instead of trying every provider', async () => {
+    // Each attempt "costs" 4s of wall clock, so the 8s budget runs out well
+    // before the provider list does — a caller is never blocked for the sum of
+    // every provider's timeout.
+    let now = 1_000_000;
+    const nowSpy = jest.spyOn(Date, 'now').mockImplementation(() => now);
+    mockFetch.mockImplementation(() => {
+      now += 4_000;
+      return Promise.resolve({ ok: false, json: () => Promise.resolve({}) });
+    });
+
+    await expect(detectGeo()).resolves.toBeNull();
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+
+    nowSpy.mockRestore();
+  });
+
   it('memoises the result and shares one in-flight request', async () => {
     mockFetch.mockResolvedValue(okJson({ ip: '1.1.1.1', country_code: 'US', country: 'USA' }));
 

--- a/lib/geo.ts
+++ b/lib/geo.ts
@@ -29,7 +29,14 @@ interface GeoProvider {
   parse: (data: Record<string, any>) => GeoLocation | null;
 }
 
-const REQUEST_TIMEOUT_MS = 5_000;
+const REQUEST_TIMEOUT_MS = 3_000;
+/**
+ * Ceiling on the whole fallback chain. Callers block a spinner — or a whole
+ * screen — on this, so trying every provider at its own timeout (which would
+ * add up to far longer than anyone will wait) is worse than giving up and
+ * letting them pick a country by hand.
+ */
+const TOTAL_BUDGET_MS = 8_000;
 const CACHE_TTL_MS = 30 * 60 * 1000;
 
 const isAlpha2 = (value: unknown): value is string =>
@@ -122,9 +129,9 @@ const PROVIDERS: GeoProvider[] = [
   },
 ];
 
-const fetchJson = async (url: string): Promise<Record<string, any> | null> => {
+const fetchJson = async (url: string, timeoutMs: number): Promise<Record<string, any> | null> => {
   const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
 
   try {
     const response = await fetch(url, {
@@ -144,8 +151,17 @@ let cached: { value: GeoLocation; at: number } | null = null;
 let inFlight: Promise<GeoLocation | null> | null = null;
 
 const lookup = async (): Promise<GeoLocation | null> => {
+  const deadline = Date.now() + TOTAL_BUDGET_MS;
+
   for (const provider of PROVIDERS) {
-    const data = await fetchJson(provider.url);
+    const remaining = deadline - Date.now();
+
+    if (remaining <= 0) {
+      console.warn('[geo] IP lookup budget exhausted');
+      return null;
+    }
+
+    const data = await fetchJson(provider.url, Math.min(REQUEST_TIMEOUT_MS, remaining));
     if (!data) continue;
 
     try {


### PR DESCRIPTION
The selector sat behind a full-screen loader until `resolveCountryAccess` resolved, and the new fallback chain could take far longer than the two calls it replaced: six providers at a 5s timeout each, tried in sequence, is up to 30s of blank screen when a network blocks them. The effect also had no try/finally, so any throw left `loading` true for good.

The selector needs no network to be usable — detection only preselects a country. Render it immediately and fill the field in when (if) detection lands, guarding against stomping a country the user picked meanwhile.

Also cap the lookup itself: 3s per provider and an 8s ceiling on the whole chain, since other callers block a button spinner on it.

Verified by rendering the screen with every provider hanging — the selector paints straight away instead of showing a loader.


Claude-Session: https://claude.ai/code/session_01GNGUSbi3MwTYb5s1CrkDAy