### PR TITLE
feat(region): show the card pop-up straight off the IP, like virtual …

### DIFF
--- a/app/(protected)/(tabs)/card-onboard/country_selection.tsx
+++ b/app/(protected)/(tabs)/card-onboard/country_selection.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { ActivityIndicator, Modal, Pressable, ScrollView, TextInput, View } from 'react-native';
 import { useRouter } from 'expo-router';
 import { ChevronDown } from 'lucide-react-native';
@@ -12,7 +12,9 @@ import { Button } from '@/components/ui/button';
 import { Text } from '@/components/ui/text';
 import { COUNTRIES, Country } from '@/constants/countries';
 import { path } from '@/constants/path';
+import { useCardStatus } from '@/hooks/useCardStatus';
 import { checkProductAccess, resolveCountryAccess } from '@/lib/countryAccess';
+import { hasCard, hasCardStatusWithRainApplication } from '@/lib/utils';
 import { useCountryStore } from '@/store/useCountryStore';
 
 export default function CountrySelection() {
@@ -31,12 +33,25 @@ export default function CountrySelection() {
 
   // The selector renders immediately: it needs no network to be usable, and
   // gating it on the geo lookup meant a blank loading screen for as long as the
-  // lookup took. Detection only preselects a country once it lands.
+  // lookup took. Detection swaps in the pop-up if the card isn't issued where
+  // the user is, and otherwise just preselects their country.
   const [showCountrySelector, setShowCountrySelector] = useState(true);
   const [showDropdown, setShowDropdown] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');
   const [selectedCountry, setSelectedCountry] = useState<Country | null>(null);
   const [processing, setProcessing] = useState(false);
+  // Set as soon as the user touches the selector. Detection lands
+  // asynchronously, and yanking someone out of a country they're part-way
+  // through picking would be worse than not showing the pop-up at all.
+  const interacted = useRef(false);
+
+  // `isLoading`, not `isPending`: a disabled query (no selected user yet) stays
+  // pending forever, which would stall detection instead of merely delaying it.
+  const { data: cardStatus, isLoading: cardStatusLoading } = useCardStatus();
+  // Same escape hatch as `useActivateCard`: someone holding a card or part-way
+  // through a Rain application cleared the gate once. Their IP saying otherwise
+  // (travel, VPN) must not present them with a "no card in your region" wall.
+  const clearedGate = hasCard(cardStatus) || hasCardStatusWithRainApplication(cardStatus);
 
   const { countryInfo, setCountryInfo } = useCountryStore(
     useShallow(state => ({
@@ -45,11 +60,19 @@ export default function CountrySelection() {
     })),
   );
 
-  // Detect where the user is so the selector opens on their country. Picking by
-  // hand stays available even when detection succeeds, because the IP is only a
-  // guess at residence — so this never blocks the screen, and a failure just
-  // leaves the field empty.
+  // Where is the user, and is the card issued there? Answering by IP is the
+  // default so an unserved user reaches the pop-up without having to name their
+  // own country first — the same way the virtual account flow works. Picking by
+  // hand stays one tap away behind "Change country", because an IP is only a
+  // guess at residence and travellers will be guessed wrong.
+  //
+  // Never blocks the screen: the selector is already on screen, and a failed
+  // lookup simply leaves it there with an empty field.
   useEffect(() => {
+    // Wait for card status, or a card holder abroad would see the pop-up flash
+    // up before `clearedGate` resolves.
+    if (cardStatusLoading) return;
+
     let cancelled = false;
 
     const detect = async () => {
@@ -65,6 +88,10 @@ export default function CountrySelection() {
           setSelectedCountry(current => current ?? country);
           setSearchQuery(current => current || country.name);
         }
+
+        if (!access.isAvailable && !interacted.current && !clearedGate) {
+          setShowCountrySelector(false);
+        }
       } catch (error) {
         console.error('Error detecting country:', error);
       }
@@ -75,7 +102,7 @@ export default function CountrySelection() {
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [cardStatusLoading, clearedGate]);
 
   const filteredCountries = useMemo(() => {
     if (!searchQuery) return COUNTRIES;
@@ -84,16 +111,22 @@ export default function CountrySelection() {
     );
   }, [searchQuery]);
 
+  // "Change country" on the pop-up — the traveller's way back to picking by
+  // hand. Marks the screen as interacted so a late lookup can't bounce them
+  // straight back out to the pop-up.
   const handleChangeCountry = () => {
+    interacted.current = true;
     setShowCountrySelector(true);
   };
 
   const handleOpenDropdown = () => {
+    interacted.current = true;
     setSearchQuery('');
     setShowDropdown(true);
   };
 
   const handleCountrySelect = (country: Country) => {
+    interacted.current = true;
     setSelectedCountry(country);
     setSearchQuery(country.name);
     setShowDropdown(false);

--- a/lib/__tests__/countryAccess.test.ts
+++ b/lib/__tests__/countryAccess.test.ts
@@ -1,0 +1,127 @@
+/// <reference types="jest" />
+
+import { checkCardAccess, checkVaAccess } from '@/lib/api';
+import { resolveCountryAccess } from '@/lib/countryAccess';
+import { detectGeo } from '@/lib/geo';
+import { useCountryStore } from '@/store/useCountryStore';
+
+jest.mock('@/lib/mmvkStorage', () => ({
+  __esModule: true,
+  default: () => ({ setItem: jest.fn(), getItem: () => null, removeItem: jest.fn() }),
+}));
+jest.mock('@/lib/analytics', () => ({ track: jest.fn() }));
+jest.mock('@/lib/utils', () => ({
+  withRefreshToken: <T>(apiCall: () => Promise<T>) => apiCall(),
+}));
+jest.mock('@/lib/api', () => ({ checkCardAccess: jest.fn(), checkVaAccess: jest.fn() }));
+jest.mock('@/lib/geo', () => ({ detectGeo: jest.fn() }));
+
+const mockDetectGeo = detectGeo as jest.MockedFunction<typeof detectGeo>;
+const mockCheckCardAccess = checkCardAccess as jest.MockedFunction<typeof checkCardAccess>;
+const mockCheckVaAccess = checkVaAccess as jest.MockedFunction<typeof checkVaAccess>;
+
+const DAY = 24 * 60 * 60 * 1000;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  useCountryStore.getState().clearCountryInfo();
+});
+
+describe('stored country vs IP detection', () => {
+  it('new user: falls back to the IP, and the unserved answer reaches the caller', async () => {
+    mockDetectGeo.mockResolvedValue({ countryCode: 'PK', countryName: 'Pakistan' });
+    mockCheckCardAccess.mockResolvedValue({ hasAccess: false, countryCode: 'PK' });
+
+    await expect(resolveCountryAccess('card')).resolves.toMatchObject({
+      countryCode: 'PK',
+      isAvailable: false,
+      source: 'ip',
+    });
+  });
+
+  it('a hand-picked country wins over the IP, so a traveller keeps their choice', async () => {
+    useCountryStore.getState().setCountryInfo({
+      countryCode: 'GB',
+      countryName: 'United Kingdom',
+      isAvailable: true,
+      source: 'manual',
+    });
+    mockCheckCardAccess.mockResolvedValue({ hasAccess: true, countryCode: 'GB' });
+
+    await expect(resolveCountryAccess('card')).resolves.toMatchObject({
+      countryCode: 'GB',
+      isAvailable: true,
+      source: 'manual',
+    });
+    expect(mockDetectGeo).not.toHaveBeenCalled();
+  });
+
+  it('a hand-picked unserved country still resolves as unserved', async () => {
+    useCountryStore.getState().setCountryInfo({
+      countryCode: 'PK',
+      countryName: 'Pakistan',
+      isAvailable: false,
+      source: 'manual',
+    });
+    mockCheckCardAccess.mockResolvedValue({ hasAccess: false, countryCode: 'PK' });
+
+    await expect(resolveCountryAccess('card')).resolves.toMatchObject({ isAvailable: false });
+    expect(mockDetectGeo).not.toHaveBeenCalled();
+  });
+
+  it('an IP-detected country older than a day is re-detected', async () => {
+    useCountryStore.setState({
+      countryInfo: {
+        countryCode: 'GB',
+        countryName: 'United Kingdom',
+        isAvailable: true,
+        source: 'ip',
+      },
+      detectedAt: Date.now() - DAY - 1,
+    });
+    mockDetectGeo.mockResolvedValue({ countryCode: 'PK', countryName: 'Pakistan' });
+    mockCheckCardAccess.mockResolvedValue({ hasAccess: false, countryCode: 'PK' });
+
+    await expect(resolveCountryAccess('card')).resolves.toMatchObject({ countryCode: 'PK' });
+    expect(mockDetectGeo).toHaveBeenCalled();
+  });
+
+  it('availability is re-checked every time, so an opened market unsticks a stored "no"', async () => {
+    useCountryStore.getState().setCountryInfo({
+      countryCode: 'AR',
+      countryName: 'Argentina',
+      isAvailable: false,
+      source: 'manual',
+    });
+    mockCheckCardAccess.mockResolvedValue({ hasAccess: true, countryCode: 'AR' });
+
+    await expect(resolveCountryAccess('card')).resolves.toMatchObject({ isAvailable: true });
+  });
+});
+
+describe('per-product allow-lists', () => {
+  it('a country served for the card but not for virtual accounts answers differently', async () => {
+    mockDetectGeo.mockResolvedValue({ countryCode: 'BR', countryName: 'Brazil' });
+    mockCheckCardAccess.mockResolvedValue({ hasAccess: true, countryCode: 'BR' });
+    mockCheckVaAccess.mockResolvedValue({ hasAccess: false, countryCode: 'BR' });
+
+    await expect(resolveCountryAccess('card')).resolves.toMatchObject({ isAvailable: true });
+    await expect(resolveCountryAccess('virtual_account')).resolves.toMatchObject({
+      isAvailable: false,
+    });
+  });
+
+  it('a virtual account check never overwrites the stored card availability', async () => {
+    useCountryStore.getState().setCountryInfo({
+      countryCode: 'BR',
+      countryName: 'Brazil',
+      isAvailable: true,
+      source: 'manual',
+    });
+    mockCheckVaAccess.mockResolvedValue({ hasAccess: false, countryCode: 'BR' });
+
+    await resolveCountryAccess('virtual_account');
+
+    expect(useCountryStore.getState().countryInfo).toMatchObject({ isAvailable: true });
+  });
+});


### PR DESCRIPTION
…accounts

The card screen only reached the pop-up once the user had named their own country and pressed Ok — an odd thing to ask of someone we're about to tell we don't serve them. Virtual accounts already answer from the IP and show the pop-up directly; do the same here.

Detection now swaps the selector for the pop-up when the card isn't issued where the user is. "Change country" is the traveller's way back: an IP is a guess at residence, and a hand-picked country outranks it from then on (`resolveCountryAccess` only re-detects for IP-sourced countries, and only after a day).

Three guards, because the swap is asynchronous and can be wrong:
- Card holders and users part-way through a Rain application are exempt, the same escape hatch `useActivateCard` uses. Travelling with a card in your pocket must not raise a "no card in your region" wall.
- The swap waits on card status, so that exemption is known before it can fire. Gated on `isLoading` rather than `isPending`: the query is disabled until a user is selected, and a disabled query stays pending forever.
- Any interaction with the selector cancels the swap, so a late lookup can't yank someone out of a country they're part-way through picking.

Adds countryAccess tests pinning the stored-country-vs-IP precedence: hand-picked wins, IP-detected expires after a day, availability is re-checked every time so an opened market unsticks a stored "no", and a virtual account check never overwrites the stored card availability.


Claude-Session: https://claude.ai/code/session_01GNGUSbi3MwTYb5s1CrkDAy