### PR TITLE
Add KYC hand-off interstitial with retry logic and improved UX

### DIFF
--- a/app/(protected)/(tabs)/kyc.native.tsx
+++ b/app/(protected)/(tabs)/kyc.native.tsx
@@ -16,6 +16,7 @@ export default function KycNative() {
     session,
     initSession,
     markStarted,
+    retryRedirect,
     onVerificationComplete,
     onVerificationPending,
     onVerificationDeclined,
@@ -99,7 +100,9 @@ export default function KycNative() {
         <KycUnavailable message={session.message} onRetry={initSession} />
       )}
       {(session.phase === 'ready' || session.phase === 'started') && <KycNativeWaiting />}
-      {session.phase === 'completed' && <KycCompleted />}
+      {session.phase === 'completed' && (
+        <KycCompleted outcome={session.outcome} onContinue={retryRedirect} showBackButton />
+      )}
     </View>
   );
 }

--- a/app/(protected)/(tabs)/kyc.tsx
+++ b/app/(protected)/(tabs)/kyc.tsx
@@ -20,6 +20,7 @@ export default function KycWeb() {
     session,
     initSession,
     markStarted,
+    retryRedirect,
     onVerificationComplete,
     onVerificationPending,
     onVerificationDeclined,
@@ -171,7 +172,9 @@ export default function KycWeb() {
           />
         )}
 
-        {session.phase === 'completed' && <KycCompleted />}
+        {session.phase === 'completed' && (
+          <KycCompleted outcome={session.outcome} onContinue={retryRedirect} />
+        )}
       </View>
     </PageLayout>
   );

--- a/app/(protected)/(tabs)/sumsub-kyc.native.tsx
+++ b/app/(protected)/(tabs)/sumsub-kyc.native.tsx
@@ -27,6 +27,7 @@ export default function SumsubKycNative() {
     session,
     initSession,
     markStarted,
+    retryRedirect,
     fetchAccessToken,
     onVerificationComplete,
     onVerificationDeclined,
@@ -114,7 +115,9 @@ export default function SumsubKycNative() {
         <KycUnavailable message={session.message} onRetry={initSession} />
       )}
       {(session.phase === 'ready' || session.phase === 'started') && <KycNativeWaiting />}
-      {session.phase === 'completed' && <KycCompleted />}
+      {session.phase === 'completed' && (
+        <KycCompleted outcome={session.outcome} onContinue={retryRedirect} showBackButton />
+      )}
     </View>
   );
 }

--- a/app/(protected)/(tabs)/sumsub-kyc.tsx
+++ b/app/(protected)/(tabs)/sumsub-kyc.tsx
@@ -27,6 +27,7 @@ export default function SumsubKycWeb() {
     session,
     initSession,
     markStarted,
+    retryRedirect,
     fetchAccessToken,
     onVerificationComplete,
     onVerificationDeclined,
@@ -121,7 +122,9 @@ export default function SumsubKycWeb() {
           />
         )}
 
-        {session.phase === 'completed' && <KycCompleted />}
+        {session.phase === 'completed' && (
+          <KycCompleted outcome={session.outcome} onContinue={retryRedirect} />
+        )}
       </View>
     </PageLayout>
   );

--- a/components/kyc/KycStatusViews.tsx
+++ b/components/kyc/KycStatusViews.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { ActivityIndicator, View } from 'react-native';
 
 import { BackButton } from '@/components/ui/back-button';
@@ -67,13 +67,85 @@ export function KycUnavailable({
   );
 }
 
-export function KycCompleted() {
+/**
+ * How the KYC screen is being left. The distinction is not cosmetic: a 409
+ * KYC_ALREADY_EXISTS ('existing') is not a pass, and reporting it as
+ * "Verification complete!" told users with an expired session and a rejected
+ * selfie that they were verified.
+ */
+export type KycHandoffOutcome = 'approved' | 'submitted' | 'declined' | 'existing';
+
+const HANDOFF_COPY: Record<KycHandoffOutcome, { title: string; body: string; tone: string }> = {
+  approved: {
+    title: 'Verification complete!',
+    body: 'Redirecting...',
+    tone: 'text-[#94F27F]',
+  },
+  submitted: {
+    title: 'Verification submitted',
+    body: 'Taking you to the next step...',
+    tone: 'text-[#94F27F]',
+  },
+  declined: {
+    title: 'Verification declined',
+    body: 'Taking you back so you can review the details...',
+    tone: 'text-red-400',
+  },
+  existing: {
+    title: 'Verification already on file',
+    body: 'We already have an identity check for you. Taking you back...',
+    tone: 'text-white',
+  },
+};
+
+/** How long to wait for the redirect before offering a manual way out. */
+const HANDOFF_FALLBACK_MS = 3000;
+
+/**
+ * Hand-off interstitial shown while the user is routed off the KYC screen.
+ *
+ * The manual button is the point: this screen used to render nothing but text,
+ * so a navigation that did not land stranded the user on "Redirecting..."
+ * indefinitely — with no button, and on native (which has no header) no back
+ * affordance either. Re-entering the flow then landed straight back here,
+ * because the tab screen stays mounted and its session state is never re-run.
+ */
+export function KycCompleted({
+  outcome = 'approved',
+  onContinue,
+  showBackButton = false,
+}: {
+  outcome?: KycHandoffOutcome;
+  /** Re-issues the redirect. Revealed once the automatic one looks stuck. */
+  onContinue?: () => void;
+  /** Render a back button at the top-left. Off on web, which has a page header. */
+  showBackButton?: boolean;
+}) {
+  const [showFallback, setShowFallback] = useState(false);
+  const { title, body, tone } = HANDOFF_COPY[outcome];
+
+  useEffect(() => {
+    if (!onContinue) return;
+    const timer = setTimeout(() => setShowFallback(true), HANDOFF_FALLBACK_MS);
+    return () => clearTimeout(timer);
+  }, [onContinue]);
+
   return (
-    <View className="flex-1 items-center justify-center py-20">
-      <Text className="text-center text-lg font-semibold text-[#94F27F]">
-        Verification complete!
-      </Text>
-      <Text className="mt-2 text-center text-[#ACACAC]">Redirecting...</Text>
+    <View className="flex-1">
+      {showBackButton && (
+        <View className="px-4 pt-2">
+          <BackButton />
+        </View>
+      )}
+      <View className="flex-1 items-center justify-center px-8 pb-20">
+        <Text className={`text-center text-lg font-semibold ${tone}`}>{title}</Text>
+        <Text className="mt-2 text-center text-[#ACACAC]">{body}</Text>
+        {showFallback && onContinue && (
+          <Button variant="brand" onPress={onContinue} className="mt-6 h-12 rounded-xl px-8">
+            <Text className="font-semibold text-primary-foreground">Continue</Text>
+          </Button>
+        )}
+      </View>
     </View>
   );
 }

--- a/components/kyc/index.ts
+++ b/components/kyc/index.ts
@@ -1,3 +1,4 @@
+export type { KycHandoffOutcome } from './KycStatusViews';
 export {
   KycCompleted,
   KycError,

--- a/components/kyc/useDiditSession.ts
+++ b/components/kyc/useDiditSession.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import Toast from 'react-native-toast-message';
-import { useLocalSearchParams, useRouter } from 'expo-router';
+import { useFocusEffect, useLocalSearchParams, useRouter } from 'expo-router';
 import { useQueryClient } from '@tanstack/react-query';
 
 import { path } from '@/constants/path';
@@ -12,15 +12,24 @@ import { KycStatus, RainApplicationStatus } from '@/lib/types';
 import { withRefreshToken } from '@/lib/utils';
 import { useKycStore } from '@/store/useKycStore';
 
+import type { KycHandoffOutcome } from '@/components/kyc/KycStatusViews';
+
 export type SessionState =
   | { phase: 'loading' }
   | { phase: 'error'; message: string }
   | { phase: 'unavailable'; message: string }
   | { phase: 'ready'; verificationUrl: string; sessionToken: string }
   | { phase: 'started' }
-  | { phase: 'completed' };
+  /**
+   * Hand-off: the user is being routed off /kyc. `destination` is retained so a
+   * navigation that does not land can be retried, and so the interstitial can
+   * offer a manual button instead of stranding the user on "Redirecting...".
+   */
+  | { phase: 'completed'; outcome: KycHandoffOutcome; destination?: string };
 
 const POLL_INTERVAL_MS = 5000;
+/** Re-issue the hand-off navigation once if we are still sitting on it. */
+const REDIRECT_RETRY_MS = 2500;
 
 export function useDiditSession() {
   const router = useRouter();
@@ -32,18 +41,13 @@ export function useDiditSession() {
   const [session, setSession] = useState<SessionState>({ phase: 'loading' });
   const sdkInitializedRef = useRef(false);
 
-  const redirectBasedOnKycStatus = useCallback(
-    async (kycStatus: KycStatus) => {
-      setSession({ phase: 'completed' });
-      queryClient.invalidateQueries({ queryKey: [CARD_STATUS_QUERY_KEY] });
-
+  /** Where this KYC outcome should land the user. No navigation, just the href. */
+  const resolveDestination = useCallback(
+    async (kycStatus: KycStatus): Promise<string> => {
       // VA flow: KYC is just a gate for opening the virtual account. Always
       // surface the pending submission page after KYC — the user re-enters
       // the VA flow via Deposit when their KYC + Rain status is approved.
-      if (kycFlow === 'va') {
-        router.replace(path.CARD_PENDING as any);
-        return;
-      }
+      if (kycFlow === 'va') return String(path.CARD_PENDING);
 
       if (kycStatus === KycStatus.APPROVED) {
         // Didit KYC approved: route by Rain status. Approved -> ready.
@@ -54,24 +58,66 @@ export function useDiditSession() {
         try {
           const cardStatusResponse = await withRefreshToken(() => getCardStatus());
           if (cardStatusResponse?.rainApplicationStatus === RainApplicationStatus.APPROVED) {
-            router.replace(path.CARD_READY as any);
-            return;
+            return String(path.CARD_READY);
           }
           if (cardStatusResponse?.kycStatus === KycStatus.UNDER_REVIEW) {
-            router.replace(path.CARD_PENDING as any);
-            return;
+            return String(path.CARD_PENDING);
           }
         } catch {
           // On error fall through to activate page as a safe default
         }
-        router.replace(path.CARD_ACTIVATE as any);
-      } else if (kycStatus === KycStatus.UNDER_REVIEW) {
-        router.replace(path.CARD_PENDING as any);
-      } else {
-        router.replace(`${String(path.CARD_ACTIVATE)}?kycStatus=${kycStatus}` as any);
+        return String(path.CARD_ACTIVATE);
       }
+      if (kycStatus === KycStatus.UNDER_REVIEW) return String(path.CARD_PENDING);
+      return `${String(path.CARD_ACTIVATE)}?kycStatus=${kycStatus}`;
     },
-    [kycFlow, queryClient, router],
+    [kycFlow],
+  );
+
+  const redirectBasedOnKycStatus = useCallback(
+    async (kycStatus: KycStatus, outcome?: KycHandoffOutcome) => {
+      const handoff =
+        outcome ?? (kycStatus === KycStatus.APPROVED ? 'approved' : ('submitted' as const));
+      // Render the hand-off before resolving the destination: that resolution
+      // can make a network call, and this screen must not sit blank while it
+      // runs (nor silently hang if the call never settles).
+      setSession({ phase: 'completed', outcome: handoff });
+      queryClient.invalidateQueries({ queryKey: [CARD_STATUS_QUERY_KEY] });
+
+      const destination = await resolveDestination(kycStatus);
+      setSession({ phase: 'completed', outcome: handoff, destination });
+      router.replace(destination as any);
+    },
+    [queryClient, resolveDestination, router],
+  );
+
+  /**
+   * Manual escape from the hand-off interstitial, wired to its Continue button.
+   * Falls back to the activate page when the destination never resolved. Read
+   * through a ref so this callback stays referentially stable — the
+   * interstitial keys its "looks stuck" timer on it, and a changing identity
+   * would keep restarting that timer.
+   */
+  const destinationRef = useRef<string | null>(null);
+  destinationRef.current =
+    session.phase === 'completed' ? (session.destination ?? null) : destinationRef.current;
+  const retryRedirect = useCallback(() => {
+    router.replace((destinationRef.current ?? String(path.CARD_ACTIVATE)) as any);
+  }, [router]);
+
+  /**
+   * One automatic retry, because the hand-off is only ever a pass-through: if we
+   * are still focused on it a beat after navigating, the navigation did not
+   * take. `useFocusEffect` cleans up on blur, so a redirect that *did* land can
+   * never be yanked back by a late retry.
+   */
+  useFocusEffect(
+    useCallback(() => {
+      if (session.phase !== 'completed' || !session.destination) return;
+      const destination = session.destination;
+      const timer = setTimeout(() => router.replace(destination as any), REDIRECT_RETRY_MS);
+      return () => clearTimeout(timer);
+    }, [router, session]),
   );
 
   const initSession = useCallback(async () => {
@@ -93,7 +139,10 @@ export function useDiditSession() {
         setSession({ phase: 'loading' });
         return;
       case 'completed':
-        setSession({ phase: 'completed' });
+        setSession({ phase: 'completed', outcome: 'approved' });
+        return;
+      case 'existing':
+        setSession({ phase: 'completed', outcome: 'existing' });
         return;
     }
 
@@ -127,19 +176,20 @@ export function useDiditSession() {
       // KYC_ALREADY_EXISTS (409): the user already has an established KYC
       // record (a provider consumer), so the backend refuses to create a new
       // Didit session rather than overwrite it — overwriting previously
-      // detached the user's existing card. This isn't a failure: they're
-      // already verified (or in review). Resolve their current status and route
-      // them to the right card screen instead of the red error/retry loop.
-      const isAlreadyVerified =
+      // detached the user's existing card. This is NOT a pass: the record may
+      // be expired, in review, or awaiting a resubmission. Resolve the real
+      // status, route on it, and label the hand-off 'existing' rather than
+      // claiming "Verification complete!" over a rejected selfie.
+      const hasExistingKyc =
         e?.code === 'KYC_ALREADY_EXISTS' || e?.status === 409 || e?.statusCode === 409;
-      if (isAlreadyVerified) {
+      if (hasExistingKyc) {
         try {
           const status = await withRefreshToken(() => getDiditVerificationStatus());
-          await redirectBasedOnKycStatus(status?.kycStatus ?? KycStatus.APPROVED);
+          await redirectBasedOnKycStatus(status?.kycStatus ?? KycStatus.APPROVED, 'existing');
         } catch {
-          // Status lookup failed — still treat as verified and let the card
-          // status page resolve the final destination.
-          await redirectBasedOnKycStatus(KycStatus.APPROVED);
+          // Status lookup failed — let the card status page resolve the final
+          // destination, still without claiming the check passed.
+          await redirectBasedOnKycStatus(KycStatus.APPROVED, 'existing');
         }
         return;
       }
@@ -203,7 +253,7 @@ export function useDiditSession() {
       text2: 'Review the details and try again with a valid document.',
       props: { badgeText: '' },
     });
-    redirectBasedOnKycStatus(KycStatus.REJECTED);
+    redirectBasedOnKycStatus(KycStatus.REJECTED, 'declined');
   }, [redirectBasedOnKycStatus]);
 
   /**
@@ -281,6 +331,7 @@ export function useDiditSession() {
     session,
     initSession,
     markStarted,
+    retryRedirect,
     onVerificationComplete,
     onVerificationPending,
     onVerificationDeclined,

--- a/components/kyc/useSumsubSession.ts
+++ b/components/kyc/useSumsubSession.ts
@@ -1,6 +1,6 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import Toast from 'react-native-toast-message';
-import { useLocalSearchParams, useRouter } from 'expo-router';
+import { useFocusEffect, useLocalSearchParams, useRouter } from 'expo-router';
 import { useQueryClient } from '@tanstack/react-query';
 
 import { path } from '@/constants/path';
@@ -10,6 +10,8 @@ import { track } from '@/lib/analytics';
 import { createSumsubSession, getSumsubVerificationStatus } from '@/lib/api';
 import { KycStatus } from '@/lib/types';
 import { withRefreshToken } from '@/lib/utils';
+
+import type { KycHandoffOutcome } from '@/components/kyc/KycStatusViews';
 
 /**
  * Session state machine for the Sumsub WebSDK. Unlike Didit (which hands back a
@@ -22,9 +24,16 @@ export type SumsubSessionState =
   | { phase: 'unavailable'; message: string }
   | { phase: 'ready'; accessToken: string; levelName: string }
   | { phase: 'started' }
-  | { phase: 'completed' };
+  /**
+   * Hand-off: the user is being routed off the Sumsub screen. `destination` is
+   * retained so a navigation that does not land can be retried, and so the
+   * interstitial can offer a manual button instead of stranding the user.
+   */
+  | { phase: 'completed'; outcome: KycHandoffOutcome; destination?: string };
 
 const POLL_INTERVAL_MS = 5000;
+/** Re-issue the hand-off navigation once if we are still sitting on it. */
+const REDIRECT_RETRY_MS = 2500;
 
 /**
  * Drives the Sumsub KYC flow for the Wirex (EU/EEA) jurisdiction. Mirrors
@@ -38,25 +47,57 @@ export function useSumsubSession() {
   const debugState = useLocalSearchParams<{ state?: string }>().state;
   const [session, setSession] = useState<SumsubSessionState>({ phase: 'loading' });
 
-  const redirectBasedOnKycStatus = useCallback(
-    async (kycStatus: KycStatus) => {
-      setSession({ phase: 'completed' });
-      queryClient.invalidateQueries({ queryKey: [CARD_STATUS_QUERY_KEY] });
+  /** Where this KYC outcome should land the user. No navigation, just the href. */
+  const resolveDestination = useCallback((kycStatus: KycStatus): string => {
+    // Wirex has no virtual-account flow — this is card KYC only. Sumsub GREEN
+    // hands off to Wirex, which then adjudicates. So:
+    //  - APPROVED (Wirex approved) → activate, where the user issues the card.
+    //  - UNDER_REVIEW (Sumsub passed, Wirex still deciding) → pending.
+    //  - anything else → activate with the status so step 1 renders correctly.
+    if (kycStatus === KycStatus.APPROVED) return String(path.CARD_ACTIVATE);
+    if (kycStatus === KycStatus.UNDER_REVIEW) return String(path.CARD_PENDING);
+    return `${String(path.CARD_ACTIVATE)}?kycStatus=${kycStatus}`;
+  }, []);
 
-      // Wirex has no virtual-account flow — this is card KYC only. Sumsub GREEN
-      // hands off to Wirex, which then adjudicates. So:
-      //  - APPROVED (Wirex approved) → activate, where the user issues the card.
-      //  - UNDER_REVIEW (Sumsub passed, Wirex still deciding) → pending.
-      //  - anything else → activate with the status so step 1 renders correctly.
-      if (kycStatus === KycStatus.APPROVED) {
-        router.replace(path.CARD_ACTIVATE as any);
-      } else if (kycStatus === KycStatus.UNDER_REVIEW) {
-        router.replace(path.CARD_PENDING as any);
-      } else {
-        router.replace(`${String(path.CARD_ACTIVATE)}?kycStatus=${kycStatus}` as any);
-      }
+  const redirectBasedOnKycStatus = useCallback(
+    async (kycStatus: KycStatus, outcome?: KycHandoffOutcome) => {
+      const handoff =
+        outcome ?? (kycStatus === KycStatus.APPROVED ? 'approved' : ('submitted' as const));
+      const destination = resolveDestination(kycStatus);
+      setSession({ phase: 'completed', outcome: handoff, destination });
+      queryClient.invalidateQueries({ queryKey: [CARD_STATUS_QUERY_KEY] });
+      router.replace(destination as any);
     },
-    [queryClient, router],
+    [queryClient, resolveDestination, router],
+  );
+
+  /**
+   * Manual escape from the hand-off interstitial, wired to its Continue button.
+   * Falls back to the activate page when the destination never resolved. Read
+   * through a ref so this callback stays referentially stable — the
+   * interstitial keys its "looks stuck" timer on it, and a changing identity
+   * would keep restarting that timer.
+   */
+  const destinationRef = useRef<string | null>(null);
+  destinationRef.current =
+    session.phase === 'completed' ? (session.destination ?? null) : destinationRef.current;
+  const retryRedirect = useCallback(() => {
+    router.replace((destinationRef.current ?? String(path.CARD_ACTIVATE)) as any);
+  }, [router]);
+
+  /**
+   * One automatic retry, because the hand-off is only ever a pass-through: if we
+   * are still focused on it a beat after navigating, the navigation did not
+   * take. `useFocusEffect` cleans up on blur, so a redirect that *did* land can
+   * never be yanked back by a late retry.
+   */
+  useFocusEffect(
+    useCallback(() => {
+      if (session.phase !== 'completed' || !session.destination) return;
+      const destination = session.destination;
+      const timer = setTimeout(() => router.replace(destination as any), REDIRECT_RETRY_MS);
+      return () => clearTimeout(timer);
+    }, [router, session]),
   );
 
   /** Fetch a fresh access token — also used as the WebSDK expiration handler. */
@@ -81,7 +122,10 @@ export function useSumsubSession() {
         setSession({ phase: 'loading' });
         return;
       case 'completed':
-        setSession({ phase: 'completed' });
+        setSession({ phase: 'completed', outcome: 'approved' });
+        return;
+      case 'existing':
+        setSession({ phase: 'completed', outcome: 'existing' });
         return;
     }
 
@@ -96,16 +140,18 @@ export function useSumsubSession() {
       }
       setSession({ phase: 'ready', accessToken: res.token, levelName: res.levelName });
     } catch (e: any) {
-      // Already verified (or registered with Wirex): resolve status and route on
-      // instead of showing an error/retry loop.
-      const isAlreadyVerified =
+      // An identity check is already on file (a provider consumer exists), so
+      // the backend refuses a new session. That is not a pass — the record may
+      // be in review or awaiting a resubmission — so route on the real status
+      // and label the hand-off 'existing' rather than claiming completion.
+      const hasExistingKyc =
         e?.code === 'KYC_ALREADY_EXISTS' || e?.status === 409 || e?.statusCode === 409;
-      if (isAlreadyVerified) {
+      if (hasExistingKyc) {
         try {
           const status = await withRefreshToken(() => getSumsubVerificationStatus());
-          await redirectBasedOnKycStatus(status?.kycStatus ?? KycStatus.UNDER_REVIEW);
+          await redirectBasedOnKycStatus(status?.kycStatus ?? KycStatus.UNDER_REVIEW, 'existing');
         } catch {
-          await redirectBasedOnKycStatus(KycStatus.UNDER_REVIEW);
+          await redirectBasedOnKycStatus(KycStatus.UNDER_REVIEW, 'existing');
         }
         return;
       }
@@ -159,7 +205,7 @@ export function useSumsubSession() {
       text2: 'Review the details and try again with a valid document.',
       props: { badgeText: '' },
     });
-    redirectBasedOnKycStatus(KycStatus.REJECTED);
+    redirectBasedOnKycStatus(KycStatus.REJECTED, 'declined');
   }, [redirectBasedOnKycStatus]);
 
   /**
@@ -243,6 +289,7 @@ export function useSumsubSession() {
     session,
     initSession,
     markStarted,
+    retryRedirect,
     fetchAccessToken,
     onVerificationComplete,
     onVerificationPending,

--- a/hooks/useCardSteps/__tests__/rainKycAction.test.ts
+++ b/hooks/useCardSteps/__tests__/rainKycAction.test.ts
@@ -1,0 +1,83 @@
+import { resolveRainKycAction } from '@/hooks/useCardSteps/rainKycAction';
+import { RainApplicationStatus } from '@/lib/types';
+
+const resolve = (input: Partial<Parameters<typeof resolveRainKycAction>[0]> = {}) =>
+  resolveRainKycAction({ hasUsableLink: false, ...input });
+
+describe('resolveRainKycAction', () => {
+  it('sends a resubmission to the Rain verification link', () => {
+    expect(
+      resolve({
+        rainApplicationStatus: RainApplicationStatus.NEEDS_INFORMATION,
+        hasUsableLink: true,
+      }),
+    ).toEqual({ type: 'external-link' });
+
+    expect(
+      resolve({
+        rainApplicationStatus: RainApplicationStatus.NEEDS_VERIFICATION,
+        hasUsableLink: true,
+      }),
+    ).toEqual({ type: 'external-link' });
+  });
+
+  it('reports an unavailable link rather than silently doing nothing', () => {
+    expect(
+      resolve({
+        rainApplicationStatus: RainApplicationStatus.NEEDS_INFORMATION,
+        hasUsableLink: false,
+      }),
+    ).toEqual({ type: 'link-unavailable' });
+  });
+
+  it('offers support for locked and canceled applications', () => {
+    expect(resolve({ rainApplicationStatus: RainApplicationStatus.LOCKED })).toEqual({
+      type: 'support',
+    });
+    expect(resolve({ rainApplicationStatus: RainApplicationStatus.CANCELED })).toEqual({
+      type: 'support',
+    });
+  });
+
+  it.each([
+    RainApplicationStatus.DENIED,
+    RainApplicationStatus.APPROVED,
+    RainApplicationStatus.PENDING,
+    RainApplicationStatus.MANUAL_REVIEW,
+  ])('offers no action for %s', status => {
+    expect(resolve({ rainApplicationStatus: status })).toEqual({ type: 'none' });
+  });
+
+  describe('when no Rain status is known', () => {
+    it('starts a fresh KYC only when no provider consumer exists', () => {
+      expect(resolve({ kycApplicationEstablished: false })).toEqual({ type: 'start-kyc' });
+      expect(
+        resolve({
+          rainApplicationStatus: RainApplicationStatus.NOT_STARTED,
+          kycApplicationEstablished: false,
+        }),
+      ).toEqual({ type: 'start-kyc' });
+    });
+
+    /**
+     * The field regression: an established Rain consumer means
+     * createDiditSession answers 409 KYC_ALREADY_EXISTS, and the user ends up
+     * stranded on the "Redirecting..." hand-off. Never restart KYC there.
+     */
+    it('never restarts KYC once a provider consumer exists', () => {
+      expect(resolve({ kycApplicationEstablished: true, hasUsableLink: true })).toEqual({
+        type: 'external-link',
+      });
+      expect(resolve({ kycApplicationEstablished: true, hasUsableLink: false })).toEqual({
+        type: 'link-unavailable',
+      });
+      expect(
+        resolve({
+          rainApplicationStatus: RainApplicationStatus.NOT_STARTED,
+          kycApplicationEstablished: true,
+          hasUsableLink: true,
+        }),
+      ).toEqual({ type: 'external-link' });
+    });
+  });
+});

--- a/hooks/useCardSteps/rainKycAction.ts
+++ b/hooks/useCardSteps/rainKycAction.ts
@@ -1,0 +1,73 @@
+import { RainApplicationStatus } from '@/lib/types';
+
+/**
+ * What the Rain KYC step button should do. Kept as a pure decision so the rules
+ * are testable without standing up the whole `useCardSteps` hook.
+ */
+export type RainKycAction =
+  /** LOCKED/CANCELED — a human has to unblock this. */
+  | { type: 'support' }
+  /** Send the user to Rain's hosted verification/resubmission page. */
+  | { type: 'external-link' }
+  /** No application yet — create a fresh provider session. */
+  | { type: 'start-kyc' }
+  /** An action is owed but we have no link to send them to. Tell them. */
+  | { type: 'link-unavailable' }
+  /** Terminal or in-flight state with nothing for the user to do. */
+  | { type: 'none' };
+
+export interface RainKycActionInput {
+  rainApplicationStatus?: RainApplicationStatus | null;
+  /** A verification link with both a url and at least one signed param. */
+  hasUsableLink: boolean;
+  /**
+   * Whether a provider (Rain) consumer already exists. When it does, creating a
+   * new Didit/Sumsub session is refused with 409 KYC_ALREADY_EXISTS, so
+   * 'start-kyc' is never a valid answer — resubmissions go through Rain's link.
+   */
+  kycApplicationEstablished?: boolean;
+}
+
+/**
+ * Rain KYC step decision.
+ *
+ * The case that mattered in the field: a user whose Rain application was
+ * `needsInformation` (BAD_SELFIE) but whose status never reached the client —
+ * masked by a stale bridge.xyz activation block — fell through to 'start-kyc',
+ * hit the guaranteed 409, and was stranded on the "Redirecting..." hand-off.
+ * A missing status is not evidence that nothing exists, so it can only mean
+ * 'start-kyc' when we positively know no consumer has been created.
+ */
+export function resolveRainKycAction({
+  rainApplicationStatus: status,
+  hasUsableLink,
+  kycApplicationEstablished,
+}: RainKycActionInput): RainKycAction {
+  // DENIED is final and renders no button at all. PENDING/MANUAL_REVIEW and
+  // APPROVED have no user action either.
+  if (
+    status === RainApplicationStatus.DENIED ||
+    status === RainApplicationStatus.APPROVED ||
+    status === RainApplicationStatus.PENDING ||
+    status === RainApplicationStatus.MANUAL_REVIEW
+  ) {
+    return { type: 'none' };
+  }
+
+  if (status === RainApplicationStatus.LOCKED || status === RainApplicationStatus.CANCELED) {
+    return { type: 'support' };
+  }
+
+  if (
+    status === RainApplicationStatus.NEEDS_VERIFICATION ||
+    status === RainApplicationStatus.NEEDS_INFORMATION
+  ) {
+    return hasUsableLink ? { type: 'external-link' } : { type: 'link-unavailable' };
+  }
+
+  // NOT_STARTED, or no status at all.
+  if (kycApplicationEstablished) {
+    return hasUsableLink ? { type: 'external-link' } : { type: 'link-unavailable' };
+  }
+  return { type: 'start-kyc' };
+}

--- a/hooks/useCardSteps/useCardSteps.ts
+++ b/hooks/useCardSteps/useCardSteps.ts
@@ -12,13 +12,7 @@ import { track } from '@/lib/analytics';
 import { getCustomerFromBridge, getKycLinkFromBridge, getProviderRouting } from '@/lib/api';
 import { EXPO_PUBLIC_CARD_ISSUER } from '@/lib/config';
 import { redirectToRainVerification } from '@/lib/rainVerification';
-import {
-  CardProvider,
-  CardStatusResponse,
-  KycProvider,
-  KycStatus,
-  RainApplicationStatus,
-} from '@/lib/types';
+import { CardProvider, CardStatusResponse, KycProvider, KycStatus } from '@/lib/types';
 import { hasMetSavingsDeposit, withRefreshToken } from '@/lib/utils';
 import { useCountryStore } from '@/store/useCountryStore';
 import { useDepositStore } from '@/store/useDepositStore';
@@ -35,6 +29,7 @@ import {
   showKycUnderReviewToast,
 } from './kycFlowHelpers';
 import { computeKycStatus, computeUiKycStatus, useProcessingWindow } from './kycStatusHelpers';
+import { resolveRainKycAction } from './rainKycAction';
 import { buildCardSteps, useCardActivation, useStepNavigation } from './stepHelpers';
 
 // Re-export types
@@ -66,9 +61,15 @@ export function useCardSteps(
       setKycProvider: state.setKycProvider,
     })),
   );
-  // Consider Rain when API returns rainApplicationStatus (provider may be omitted)
+  // Consider Rain when the API returns rainApplicationStatus (provider may be
+  // omitted). An external verification link is Rain-only too, so treat it as
+  // the same evidence: if the response carries a resubmission link, the Rain
+  // step handler must be wired even when the status field is missing —
+  // otherwise the step falls back to restarting Didit and the link is
+  // unreachable.
   const cardIssuer =
-    cardStatusResponse?.rainApplicationStatus != null
+    cardStatusResponse?.rainApplicationStatus != null ||
+    cardStatusResponse?.applicationExternalVerificationLink != null
       ? CardProvider.RAIN
       : (cardStatusResponse?.provider ?? EXPO_PUBLIC_CARD_ISSUER ?? null);
   const countryStore = useCountryStore(
@@ -250,42 +251,53 @@ export function useCardSteps(
   const handleRainKYCPress = useCallback(() => {
     const status = cardStatusResponse?.rainApplicationStatus;
     const link = cardStatusResponse?.applicationExternalVerificationLink;
+    // Rain signs the link's params, so a link without them is not openable.
+    const usableLink = link?.url && Object.keys(link.params ?? {}).length > 0 ? link : null;
 
-    // DENIED is a final decision with no action — it renders no button, so it is not
-    // handled here. LOCKED/CANCELED still offer a "Contact support" button.
-    if (status === RainApplicationStatus.LOCKED || status === RainApplicationStatus.CANCELED) {
-      openSupportDrawer();
-      return;
-    }
-    if (
-      status === RainApplicationStatus.NEEDS_VERIFICATION ||
-      status === RainApplicationStatus.NEEDS_INFORMATION
-    ) {
-      if (link?.url && Object.keys(link.params ?? {}).length > 0) {
-        redirectToRainVerification(link);
-      } else {
-        Toast.show({
-          type: 'error',
-          text1: 'Verification link unavailable',
-          text2: 'Unable to open verification. Please try again later or contact support.',
-          props: { badgeText: '' },
-        });
-        track(TRACKING_EVENTS.CARD_KYC_FLOW_TRIGGERED, {
-          action: 'verification_link_missing',
-          rainApplicationStatus: status,
-          hasLink: Boolean(link),
-          hasUrl: Boolean(link?.url),
-          hasParams: Boolean(link?.params && Object.keys(link.params).length > 0),
-        });
-      }
-      return;
-    }
-    if (status === RainApplicationStatus.NOT_STARTED || !status) {
-      handleProceedToKyc();
+    const reportUnavailableLink = () => {
+      Toast.show({
+        type: 'error',
+        text1: 'Verification link unavailable',
+        text2: 'Unable to open verification. Please try again later or contact support.',
+        props: { badgeText: '' },
+      });
+      track(TRACKING_EVENTS.CARD_KYC_FLOW_TRIGGERED, {
+        action: 'verification_link_missing',
+        rainApplicationStatus: status,
+        kycApplicationEstablished: cardStatusResponse?.kycApplicationEstablished,
+        hasLink: Boolean(link),
+        hasUrl: Boolean(link?.url),
+        hasParams: Boolean(link?.params && Object.keys(link.params).length > 0),
+      });
+    };
+
+    const action = resolveRainKycAction({
+      rainApplicationStatus: status,
+      hasUsableLink: Boolean(usableLink),
+      kycApplicationEstablished: cardStatusResponse?.kycApplicationEstablished,
+    });
+
+    switch (action.type) {
+      case 'support':
+        openSupportDrawer();
+        return;
+      case 'external-link':
+        // resolveRainKycAction only returns this when hasUsableLink was true.
+        if (usableLink) redirectToRainVerification(usableLink);
+        return;
+      case 'start-kyc':
+        handleProceedToKyc();
+        return;
+      case 'link-unavailable':
+        reportUnavailableLink();
+        return;
+      case 'none':
+        return;
     }
   }, [
     cardStatusResponse?.rainApplicationStatus,
     cardStatusResponse?.applicationExternalVerificationLink,
+    cardStatusResponse?.kycApplicationEstablished,
     handleProceedToKyc,
   ]);
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -499,6 +499,13 @@ export interface CardStatusResponse {
   kycWarnings?: KycWarning[];
   /** Rain KYC: application status from Rain */
   rainApplicationStatus?: RainApplicationStatus;
+  /**
+   * True once a provider (Rain) consumer exists for this user. Creating a new
+   * Didit/Sumsub session in that state is refused with 409 KYC_ALREADY_EXISTS,
+   * so never offer a "start KYC" action when this is set — a resubmission has
+   * to go through `applicationExternalVerificationLink` instead.
+   */
+  kycApplicationEstablished?: boolean;
   /** Rain: link for needsVerification redirect */
   applicationExternalVerificationLink?: { url: string; params: Record<string, string> };
   /**


### PR DESCRIPTION
## Summary
This PR improves the KYC flow by adding a hand-off interstitial screen that displays while users are being redirected after verification, with automatic retry logic and a manual fallback button to prevent users from being stranded on a "Redirecting..." screen.

## Key Changes

- **Hand-off interstitial screen**: Added `KycCompleted` component that displays contextual messaging based on the verification outcome ('approved', 'submitted', 'declined', or 'existing'), replacing the previous minimal "Verification complete!" message.

- **Automatic retry logic**: Implemented `useFocusEffect` hook to automatically retry navigation after 2.5 seconds if the user is still on the hand-off screen, preventing navigation failures from stranding users.

- **Manual escape hatch**: Added a "Continue" button that appears after 3 seconds if the automatic redirect hasn't landed, allowing users to manually retry the navigation.

- **Refactored destination resolution**: Extracted destination logic into separate `resolveDestination` functions in both `useDiditSession` and `useSumsubSession` to decouple navigation from status resolution, allowing the interstitial to render while network calls complete.

- **Improved outcome tracking**: Enhanced session state to include `outcome` (the type of verification result) and `destination` (the target URL), enabling better UX messaging and retry capabilities.

- **Rain KYC action logic**: Created new `resolveRainKycAction` utility with comprehensive test coverage to determine the correct action for Rain KYC resubmissions, fixing a field regression where users with established KYC consumers were incorrectly offered "start KYC" actions.

- **Better handling of existing KYC**: Changed terminology from "isAlreadyVerified" to "hasExistingKyc" and labeled such hand-offs as 'existing' rather than 'approved', preventing false success messaging for users with expired or rejected sessions.

- **Enhanced CardStatusResponse**: Added `kycApplicationEstablished` field to track whether a provider consumer exists, preventing invalid KYC restart attempts.

## Notable Implementation Details

- The hand-off interstitial uses `useFocusEffect` to ensure retry timers are cleaned up when the screen loses focus, preventing late retries from interrupting successful navigations.
- Destination refs are used to keep the retry callback referentially stable, preventing timer resets when session state updates.
- The `KycHandoffOutcome` type distinguishes between different exit scenarios to provide accurate user messaging.
- Rain KYC action resolution is now testable and handles the case where a provider consumer exists but status is unknown (preventing the 409 KYC_ALREADY_EXISTS stranding issue).

https://claude.ai/code/session_01Er6yjCvPrAfJd9LA22bwYY