### PR TITLE
fix(promotions-banner): fill the layout column instead of letterboxing

### DIFF
--- a/components/Home/NewHome/HomePromoBanners.tsx
+++ b/components/Home/NewHome/HomePromoBanners.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { Pressable, StyleSheet, View } from 'react-native';
 import { Image } from 'expo-image';
 
@@ -8,10 +9,15 @@ import { usePromotionsBannerPress, usePromotionsBanners } from '@/hooks/usePromo
 import { isDevFeatureEnabled } from '@/lib/config';
 
 import type { PromotionsBannerItem } from '@/lib/types';
+import type { ImageLoadEventData } from 'expo-image';
 
-// Matches the hardcoded Figma card (22024:1057) so an admin banner and the
-// fallback occupy the same space.
-const BANNER_HEIGHT = 98;
+// The hardcoded Figma card (22024:1057) is 387x98, the same 387pt mobile width
+// the wallet card above is drawn at. Banners are sized by ratio rather than by
+// that pixel height so they fill the layout column on every screen — a fixed
+// height would letterbox the artwork inside a wider desktop column instead of
+// growing with it, which is how the neighbouring sections behave too (see
+// GET_CARD_PANEL_ASPECT_RATIO in HomeWalletCard).
+const BANNER_ASPECT_RATIO = 387 / 98;
 const BANNER_RADIUS = 23;
 
 // The hardcoded 10% cashback promo is paused; keep the implementation ready for
@@ -29,6 +35,33 @@ const PromoSlot = ({ children }: { children: React.ReactNode }) => (
     <View className="px-4">{children}</View>
   </HeroExit>
 );
+
+/**
+ * One banner, always the full width of the layout column.
+ *
+ * Height follows the artwork's own ratio, adopted from the loaded image so an
+ * admin can upload any shape without it being cropped or letterboxed. Until
+ * that arrives the Figma ratio stands in, so a banner drawn to the design
+ * reserves exactly the right space and never shifts the page.
+ */
+const PromoImageBanner = ({ uri, onPress }: { uri: string; onPress: () => void }) => {
+  const [aspectRatio, setAspectRatio] = useState(BANNER_ASPECT_RATIO);
+
+  const onLoad = ({ source }: ImageLoadEventData) => {
+    if (source.width > 0 && source.height > 0) {
+      setAspectRatio(source.width / source.height);
+    }
+  };
+
+  return (
+    <Pressable onPress={onPress} style={[styles.card, { aspectRatio }]}>
+      {/* `cover` on a box that already matches the artwork's ratio fills it edge
+          to edge; it only ever trims a hair while the ratio is still the
+          placeholder, where `contain` would show bars instead. */}
+      <Image source={{ uri }} onLoad={onLoad} contentFit="cover" style={styles.image} />
+    </Pressable>
+  );
+};
 
 /**
  * The promo slot on the redesigned home screen.
@@ -59,24 +92,21 @@ const HomePromoBanners = () => {
   return (
     <PromoSlot>
       <View style={styles.stack}>
-        {banners.map((banner: PromotionsBannerItem, index) => (
-          <Pressable
-            key={`promo-${banner.slug}-${index}`}
-            onPress={getBannerPress(banner)}
-            style={styles.card}
-          >
-            <Image
-              source={{
-                uri:
-                  !isScreenMedium && banner.mobileImageURL
-                    ? banner.mobileImageURL
-                    : banner.imageURL,
-              }}
-              contentFit="contain"
-              style={styles.image}
+        {banners.map((banner: PromotionsBannerItem, index) => {
+          const uri =
+            !isScreenMedium && banner.mobileImageURL ? banner.mobileImageURL : banner.imageURL;
+
+          // Keyed by uri as well as position so crossing the mobile/desktop
+          // breakpoint starts the new artwork's ratio over rather than holding
+          // the previous image's until it loads.
+          return (
+            <PromoImageBanner
+              key={`promo-${banner.slug}-${index}-${uri}`}
+              uri={uri}
+              onPress={getBannerPress(banner)}
             />
-          </Pressable>
-        ))}
+          );
+        })}
       </View>
     </PromoSlot>
   );
@@ -88,7 +118,6 @@ const styles = StyleSheet.create({
   },
   card: {
     borderRadius: BANNER_RADIUS,
-    height: BANNER_HEIGHT,
     overflow: 'hidden',
     width: '100%',
   },


### PR DESCRIPTION
The banner was a fixed 98px-tall box with contentFit="contain", so the artwork rendered at its own ratio inside it and left bars either side — about 390px of a 608px column on desktop, well short of the wallet card above it. Height now comes from an aspect ratio instead, which is how the neighbouring sections already scale (see GET_CARD_PANEL_ASPECT_RATIO in HomeWalletCard), so the banner is full width at every size.

The ratio starts at the Figma card's 387x98 and is replaced by the loaded image's own, from expo-image's onLoad, so an admin can upload any shape and have it fill the width uncropped. A banner drawn to the design reserves exactly the right space up front and never shifts the page. contentFit is now cover, which on a box that matches the artwork fills it edge to edge and only trims a hair while the placeholder ratio is still in effect.

Measured in Chromium against the real parent chain (max-w-[40rem] column, px-4 slot), one component for web and native alike:

  viewport 1280 / 820  column 640  ->  banner 608 x 154  (was ~390 wide)
  viewport 390          column 390  ->  banner 358 x 90.7 (was 358 in a 98 box)
  a 1200x200 upload                 ->  banner 608 x 101.3, no crop

Note the paused HomeCashbackPromoBanner fallback still positions its text and artwork at fixed pixel offsets, so it will not scale into a desktop column if that promo is relaunched. Left alone here as parked code.


Claude-Session: https://claude.ai/code/session_01Dt7K7Ex711gkfnZHe4dzbA