### PR TITLE
Create externalAxios instance for third-party API calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ Key environment variables (see `.env.example`):
 - `EXPO_PUBLIC_AMPLITUDE_API_KEY`: Amplitude analytics
 - `EXPO_PUBLIC_INFO_GRAPH`: The Graph endpoint for project data
 - `EXPO_PUBLIC_ALGEBRA_INFO_GRAPH`: The Graph endpoint for DEX data
-- `EXPO_PUBLIC_COIN_GECKO_API_KEY`: CoinGecko API for price data
+- `EXPO_PUBLIC_COINGECKO_API_KEY`: CoinGecko Pro API key for price data (sent as `x-cg-pro-api-key`; the Pro endpoints 401 without it)
 - `EXPO_PUBLIC_THIRDWEB_CLIENT_ID`: ThirdWeb client configuration
 - `EXPO_PUBLIC_TURNKEY_API_BASE_URL`: Turnkey API endpoint
 - `EXPO_PUBLIC_TURNKEY_ORGANIZATION_ID`: Turnkey organization ID

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -186,29 +186,52 @@ axios.interceptors.request.use(config => {
   return config;
 });
 
+const captureAxiosError = (error: any) => {
+  const status = error.response?.status;
+  const url = error.config?.url;
+  const method = error.config?.method;
+
+  Sentry.captureException(error, {
+    tags: {
+      type: 'api_error',
+      status: status?.toString(),
+      method: method?.toUpperCase(),
+    },
+    extra: {
+      url,
+      responseData: error.response?.data,
+    },
+  });
+
+  return Promise.reject(error);
+};
+
 // Set up axios response interceptor to handle errors
-axios.interceptors.response.use(
-  response => response,
-  error => {
-    const status = error.response?.status;
-    const url = error.config?.url;
-    const method = error.config?.method;
+axios.interceptors.response.use(response => response, captureAxiosError);
 
-    Sentry.captureException(error, {
-      tags: {
-        type: 'api_error',
-        status: status?.toString(),
-        method: method?.toUpperCase(),
-      },
-      extra: {
-        url,
-        responseData: error.response?.data,
-      },
-    });
+/**
+ * Axios instance for third-party APIs (Alchemy Prices, CoinGecko).
+ *
+ * The global request interceptor above attaches the Solid backend Bearer JWT to
+ * every axios request on iOS/Android. Third-party hosts either reject that
+ * token or receive a credential they should never see:
+ *
+ *  - Alchemy treats an `Authorization: Bearer …` header as its own credential
+ *    and ignores the API key in the URL path, so the request 401s. Every price
+ *    lookup then resolves to 0 and balances render as $0.00 — on native only,
+ *    since `getJWTToken()` returns null on web and no header is attached there.
+ *  - CoinGecko authenticates via `x-cg-pro-api-key` and ignores the header, so
+ *    it still works, but the user's access token leaves the app for no reason.
+ *
+ * `axios.create()` starts with no interceptors, so this instance sends neither
+ * the JWT nor the platform headers. Error reporting is kept so failures against
+ * these hosts stay visible in Sentry.
+ *
+ * Same reasoning as the dedicated instance in `lib/alchemy.ts`.
+ */
+export const externalAxios = axios.create();
 
-    return Promise.reject(error);
-  },
-);
+externalAxios.interceptors.response.use(response => response, captureAxiosError);
 
 export const refreshToken = async () => {
   const refreshTokenValue = getRefreshToken();
@@ -384,7 +407,9 @@ export const fetchTokenTransfer = async ({
 };
 
 export const fetchTokenPriceUsd = async (token: string) => {
-  const response = await axios.get<TokenPriceUsd>(
+  // externalAxios (not the global axios): Alchemy 401s when the Solid JWT is
+  // attached, which zeroes out every price on native builds.
+  const response = await externalAxios.get<TokenPriceUsd>(
     `https://api.g.alchemy.com/prices/v1/${EXPO_PUBLIC_ALCHEMY_API_KEY}/tokens/by-symbol?symbols=${token}`,
   );
   return response?.data?.data[0]?.prices[0]?.value;
@@ -2735,7 +2760,7 @@ export const deleteDirectDepositSession = async (
 };
 
 export const searchCoin = async (query: string) => {
-  const response = await axios.get<SearchCoin>(
+  const response = await externalAxios.get<SearchCoin>(
     `https://pro-api.coingecko.com/api/v3/search?query=${query}`,
     {
       headers: {
@@ -2747,7 +2772,7 @@ export const searchCoin = async (query: string) => {
 };
 
 export const fetchCoinHistoricalChart = async (coinId: string, days: string = '1') => {
-  const response = await axios.get<CoinHistoricalChart>(
+  const response = await externalAxios.get<CoinHistoricalChart>(
     `https://pro-api.coingecko.com/api/v3/coins/${coinId}/market_chart?vs_currency=usd&days=${days}`,
     {
       headers: {
@@ -2763,7 +2788,7 @@ export const fetchCoinSimplePrice = async (
 ): Promise<Record<string, { usd?: number }>> => {
   if (coinIds.length === 0) return {};
   const ids = [...new Set(coinIds)].filter(Boolean).join(',');
-  const response = await axios.get<Record<string, { usd?: number }>>(
+  const response = await externalAxios.get<Record<string, { usd?: number }>>(
     `https://pro-api.coingecko.com/api/v3/simple/price?ids=${ids}&vs_currencies=usd`,
     {
       headers: {


### PR DESCRIPTION
## Summary
This PR refactors API error handling and introduces a dedicated axios instance for third-party API calls (Alchemy and CoinGecko) to prevent authentication conflicts on native platforms.

## Key Changes
- **Extracted error handling logic**: Created `captureAxiosError()` function to centralize Sentry error reporting for both the global and external axios instances
- **Created `externalAxios` instance**: A new axios instance without global interceptors that prevents the Solid backend JWT from being attached to third-party API requests
  - Solves a critical issue where Alchemy treats the JWT as its own credential and rejects requests with 401, causing all prices to resolve to 0 on native builds
  - Prevents unnecessary exposure of the user's access token to CoinGecko
  - Maintains error reporting by applying the same error interceptor
- **Updated API calls**: Migrated price-related functions to use `externalAxios`:
  - `fetchTokenPriceUsd()` (Alchemy)
  - `searchCoin()` (CoinGecko)
  - `fetchCoinHistoricalChart()` (CoinGecko)
  - `fetchCoinSimplePrice()` (CoinGecko)
- **Updated documentation**: Corrected environment variable name in README from `EXPO_PUBLIC_COIN_GECKO_API_KEY` to `EXPO_PUBLIC_COINGECKO_API_KEY` and clarified it's the Pro API key

## Implementation Details
The `externalAxios` instance is created with `axios.create()`, which starts with no interceptors, ensuring that neither the global JWT nor platform headers are attached. The same Sentry error capture logic is applied to maintain observability across all API failures.

https://claude.ai/code/session_01YYN3XTEu99ihRjRyUsvkTs