### PR TITLE
fix(card): stop stranding users on a card that is still being issued

### DIFF
--- a/app/(protected)/(tabs)/card-onboard/country_selection.tsx
+++ b/app/(protected)/(tabs)/card-onboard/country_selection.tsx
@@ -14,7 +14,7 @@ import { COUNTRIES, Country } from '@/constants/countries';
 import { path } from '@/constants/path';
 import { useCardStatus } from '@/hooks/useCardStatus';
 import { checkProductAccess, resolveCountryAccess } from '@/lib/countryAccess';
-import { hasCard, hasCardStatusWithRainApplication } from '@/lib/utils';
+import { hasCard, hasCardStatusWithRainApplication, hasPendingCard } from '@/lib/utils';
 import { useCountryStore } from '@/store/useCountryStore';
 
 export default function CountrySelection() {
@@ -48,10 +48,14 @@ export default function CountrySelection() {
   // `isLoading`, not `isPending`: a disabled query (no selected user yet) stays
   // pending forever, which would stall detection instead of merely delaying it.
   const { data: cardStatus, isLoading: cardStatusLoading } = useCardStatus();
-  // Same escape hatch as `useActivateCard`: someone holding a card or part-way
-  // through a Rain application cleared the gate once. Their IP saying otherwise
-  // (travel, VPN) must not present them with a "no card in your region" wall.
-  const clearedGate = hasCard(cardStatus) || hasCardStatusWithRainApplication(cardStatus);
+  // Same escape hatch as `useActivateCard`: someone holding a card, waiting on one
+  // being issued, or part-way through a Rain application cleared the gate once.
+  // Their IP saying otherwise (travel, VPN) must not present them with a "no card
+  // in your region" wall.
+  const clearedGate =
+    hasCard(cardStatus) ||
+    hasPendingCard(cardStatus) ||
+    hasCardStatusWithRainApplication(cardStatus);
 
   const { countryInfo, setCountryInfo } = useCountryStore(
     useShallow(state => ({

--- a/app/(protected)/(tabs)/card/index.tsx
+++ b/app/(protected)/(tabs)/card/index.tsx
@@ -4,7 +4,12 @@ import { Redirect } from 'expo-router';
 import PageLayout from '@/components/PageLayout';
 import { path } from '@/constants/path';
 import { useCardStatus } from '@/hooks/useCardStatus';
-import { getActiveCardRoute, hasCard, hasCardStatusWithRainApplication } from '@/lib/utils';
+import {
+  getActiveCardRoute,
+  hasCard,
+  hasCardStatusWithRainApplication,
+  hasPendingCard,
+} from '@/lib/utils';
 
 /**
  * `/card` is deprecated as a destination — it used to render the standalone card
@@ -26,6 +31,13 @@ export default function Card() {
   // to card details.
   if (hasCard(cardStatus)) {
     return <Redirect href={getActiveCardRoute(cardStatus)} />;
+  }
+
+  // A card is ordered but the issuer hasn't opened it yet. The issuance flow
+  // renders the "on its way" state and polls until it does; country selection
+  // would restart onboarding this user already completed.
+  if (hasPendingCard(cardStatus)) {
+    return <Redirect href={path.CARD_ACTIVATE} />;
   }
 
   // A Rain application is already in flight (KYC submitted, card pending) —

--- a/app/(protected)/(tabs)/card/ready.tsx
+++ b/app/(protected)/(tabs)/card/ready.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useState } from 'react';
 import { Linking, Pressable, View } from 'react-native';
 import Toast from 'react-native-toast-message';
-import { useRouter } from 'expo-router';
+import { Redirect, useRouter } from 'expo-router';
 import { useQueryClient } from '@tanstack/react-query';
 
 import { CardStatusPage } from '@/components/Card/CardStatusPage';
@@ -9,10 +9,11 @@ import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Text } from '@/components/ui/text';
 import { Underline } from '@/components/ui/underline';
+import { path } from '@/constants/path';
 import { CARD_STATUS_QUERY_KEY, useCardStatus } from '@/hooks/useCardStatus';
 import { createCard, submitCardConsents } from '@/lib/api';
 import { CardStatus } from '@/lib/types';
-import { getActiveCardRoute, withRefreshToken } from '@/lib/utils';
+import { getActiveCardRoute, hasCard, hasPendingCard, withRefreshToken } from '@/lib/utils';
 import { useCardWelcomePopupStore } from '@/store/useCardWelcomePopupStore';
 import { useCountryStore } from '@/store/useCountryStore';
 
@@ -88,6 +89,17 @@ export default function CardReady() {
 
   const toggle = (key: ConsentKey) => setConsents(prev => ({ ...prev, [key]: !prev[key] }));
 
+  // This screen creates the card, and the backend allows exactly one per
+  // provider. Re-entering it with a card already in flight (browser back, a deep
+  // link, a stale tab) leaves the only button here guaranteed to fail with "card
+  // already exists", so route to where that card actually lives instead.
+  if (!activating && hasCard(cardStatusResponse)) {
+    return <Redirect href={getActiveCardRoute(cardStatusResponse)} />;
+  }
+  if (!activating && hasPendingCard(cardStatusResponse)) {
+    return <Redirect href={path.CARD_ACTIVATE} />;
+  }
+
   const handleActivateCard = async () => {
     if (!allAccepted) return;
 
@@ -107,19 +119,30 @@ export default function CardReady() {
 
       queryClient.invalidateQueries({ queryKey: [CARD_STATUS_QUERY_KEY] });
 
+      // Show the welcome popup whenever the card lands, including when it opens a
+      // moment later on the issuance flow.
+      setShouldShowWelcomePopup(true);
+
       if (card.status !== CardStatus.PENDING) {
-        setShouldShowWelcomePopup(true);
         // BD users land on the issuance flow to complete the minimum-deposit
         // step before reaching card details; everyone else goes to details.
         router.replace(getActiveCardRoute(cardStatusResponse));
-      } else {
-        Toast.show({
-          type: 'success',
-          text1: 'Card activation in progress',
-          text2: 'Your card is being set up. Please wait.',
-          props: { badgeText: '' },
-        });
+        return;
       }
+
+      // The card exists but the issuer hasn't opened it yet. Leaving the user on
+      // this screen was a dead end: the consents are already submitted and the
+      // card is already created, so the only button here now fails with "card
+      // already exists", and nothing on the page ever notices the card going
+      // live. The issuance flow shows the "on its way" state, polls card status,
+      // and forwards to the card details page the moment it opens.
+      Toast.show({
+        type: 'success',
+        text1: 'Card creation in progress',
+        text2: "We're finishing up your card — this page will update itself.",
+        props: { badgeText: '' },
+      });
+      router.replace(path.CARD_ACTIVATE);
     } catch (error) {
       console.error('Error activating card:', error);
       Toast.show({

--- a/components/Home/CardWaitingModal.tsx
+++ b/components/Home/CardWaitingModal.tsx
@@ -31,7 +31,7 @@ import { HomeSetupStep } from '@/hooks/useHomeSetupSteps';
 import { track } from '@/lib/analytics';
 import { getAsset } from '@/lib/assets';
 import { resolveCardCountry } from '@/lib/cardCountryGate';
-import { hasCard, hasCardStatusWithRainApplication } from '@/lib/utils';
+import { hasCard, hasCardStatusWithRainApplication, hasPendingCard } from '@/lib/utils';
 
 interface CardWaitingModalProps {
   isOpen: boolean;
@@ -204,9 +204,13 @@ const CardWaitingModal = ({ isOpen, onClose, firstIncomplete }: CardWaitingModal
   const [checkingCountry, setCheckingCountry] = useState(false);
   const { data: cardStatus } = useCardStatus();
   // Same escape hatch as `skipCountryCheck` in useActivateCard: someone holding
-  // a card, or already part-way through a Rain application, has cleared the
-  // country gate once and must not be bounced back out of the flow.
-  const skipCountryGate = hasCard(cardStatus) || hasCardStatusWithRainApplication(cardStatus);
+  // a card, waiting on one being issued, or already part-way through a Rain
+  // application has cleared the country gate once and must not be bounced back
+  // out of the flow.
+  const skipCountryGate =
+    hasCard(cardStatus) ||
+    hasPendingCard(cardStatus) ||
+    hasCardStatusWithRainApplication(cardStatus);
   // On Android (edge-to-edge) the safe-area bottom inset can come back smaller
   // than the actual system nav bar inside the dialog portal, leaving the pinned
   // CTA sitting too close to the bottom edge. Floor it so the button always

--- a/hooks/useActivateCard.ts
+++ b/hooks/useActivateCard.ts
@@ -9,7 +9,7 @@ import { useCardSteps } from '@/hooks/useCardSteps';
 import { useCountryCheck } from '@/hooks/useCountryCheck';
 import { track } from '@/lib/analytics';
 import { CardStatus, KycStatus } from '@/lib/types';
-import { hasCard, hasCardStatusWithRainApplication } from '@/lib/utils';
+import { hasCard, hasCardStatusWithRainApplication, hasPendingCard } from '@/lib/utils';
 
 export function useActivateCard() {
   const router = useRouter();
@@ -40,7 +40,15 @@ export function useActivateCard() {
   // has confirmed country, or has Rain application status (already in KYC flow).
   const userHasCard = hasCard(cardStatusResponse);
   const hasRainApplicationStatus = hasCardStatusWithRainApplication(cardStatusResponse);
-  const skipCountryCheck = countryConfirmed === 'true' || userHasCard || hasRainApplicationStatus;
+  // A card already ordered clears the gate too — this screen is where a pending
+  // card waits, and re-running an IP check on someone mid-issuance would bounce a
+  // traveller (or anyone behind a VPN) into country selection and restart the
+  // onboarding they just finished.
+  const skipCountryCheck =
+    countryConfirmed === 'true' ||
+    userHasCard ||
+    hasPendingCard(cardStatusResponse) ||
+    hasRainApplicationStatus;
   const { checkingCountry } = useCountryCheck({ skip: skipCountryCheck });
   const isCheckingCountry = !skipCountryCheck && checkingCountry;
 

--- a/lib/utils/__tests__/cardStatusRouting.test.ts
+++ b/lib/utils/__tests__/cardStatusRouting.test.ts
@@ -1,0 +1,83 @@
+/// <reference types="jest" />
+import { CardProvider, CardStatus, type CardStatusResponse } from '@/lib/types';
+import { hasCard, hasPendingCard } from '@/lib/utils/cardStatusRouting';
+
+const cardStatus = (overrides: Partial<CardStatusResponse> = {}): CardStatusResponse =>
+  ({ ...overrides }) as CardStatusResponse;
+
+/**
+ * `hasCard` and `hasPendingCard` decide where a user in the card flow is sent, so
+ * the boundary between them is what keeps a mid-issuance user out of onboarding.
+ *
+ * A Wirex virtual card is `pending` between issuance and the issuer opening it —
+ * a card that exists but is not yet usable. `hasCard` (usable) must stay false
+ * there, while `hasPendingCard` (exists) must be true, or the routing sends the
+ * user back to country selection and restarts onboarding they already finished.
+ */
+describe('card status routing predicates', () => {
+  describe('hasPendingCard', () => {
+    it('is true for a Wirex card awaiting issuance', () => {
+      expect(
+        hasPendingCard(cardStatus({ status: CardStatus.PENDING, provider: CardProvider.WIREX })),
+      ).toBe(true);
+    });
+
+    it('is true for a pending card with no provider reported', () => {
+      // /cards/status has historically omitted the provider; a pending card is
+      // still a card, so routing must not depend on that field being present.
+      expect(hasPendingCard(cardStatus({ status: CardStatus.PENDING }))).toBe(true);
+    });
+
+    it('is false for the deprecated Bridge provider', () => {
+      expect(
+        hasPendingCard(cardStatus({ status: CardStatus.PENDING, provider: CardProvider.BRIDGE })),
+      ).toBe(false);
+    });
+
+    it.each([CardStatus.ACTIVE, CardStatus.FROZEN, CardStatus.INACTIVE])(
+      'is false once the card reaches %s',
+      status => {
+        expect(hasPendingCard(cardStatus({ status, provider: CardProvider.WIREX }))).toBe(false);
+      },
+    );
+
+    it('is false with no card at all', () => {
+      expect(hasPendingCard(cardStatus())).toBe(false);
+      expect(hasPendingCard(null)).toBe(false);
+      expect(hasPendingCard(undefined)).toBe(false);
+    });
+  });
+
+  describe('hasCard stays "usable card only"', () => {
+    it('does not count a pending card as usable', () => {
+      const pending = cardStatus({
+        status: CardStatus.PENDING,
+        provider: CardProvider.WIREX,
+      });
+
+      expect(hasCard(pending)).toBe(false);
+      expect(hasPendingCard(pending)).toBe(true);
+    });
+
+    it('counts an active Wirex card', () => {
+      expect(hasCard(cardStatus({ status: CardStatus.ACTIVE, provider: CardProvider.WIREX }))).toBe(
+        true,
+      );
+    });
+  });
+
+  it('classifies every card into exactly one of the two states', () => {
+    // The routing branches are mutually exclusive by construction: a card cannot
+    // be both "usable" and "waiting to be issued", so no screen can receive
+    // contradictory redirects.
+    for (const status of [
+      CardStatus.PENDING,
+      CardStatus.ACTIVE,
+      CardStatus.FROZEN,
+      CardStatus.INACTIVE,
+    ]) {
+      const value = cardStatus({ status, provider: CardProvider.WIREX });
+      expect(hasCard(value) && hasPendingCard(value)).toBe(false);
+    }
+  });
+});

--- a/lib/utils/cardStatusRouting.ts
+++ b/lib/utils/cardStatusRouting.ts
@@ -1,0 +1,44 @@
+import { CardProvider, CardStatus, type CardStatusResponse } from '@/lib/types';
+
+/**
+ * Predicates that decide where a user in the card flow is routed.
+ *
+ * Kept in their own leaf module — importing only types — so they can be unit
+ * tested directly. `lib/utils/utils` pulls in AsyncStorage and the API client
+ * (and through it Sentry), none of which load under jest-expo, which is why
+ * routing logic this load-bearing had no test coverage before.
+ *
+ * Re-exported from `lib/utils/utils`, so `@/lib/utils` remains the import path
+ * for every consumer.
+ */
+
+/** Rain-first: only Rain cards count as "has card". Bridge-only users are treated as no card. */
+export const hasCard = (cardStatus: CardStatusResponse | null | undefined): boolean => {
+  if (!cardStatus?.status) return false;
+  const isActiveOrFrozen =
+    cardStatus.status === CardStatus.ACTIVE || cardStatus.status === CardStatus.FROZEN;
+  if (!isActiveOrFrozen) return false;
+  return cardStatus.provider !== CardProvider.BRIDGE;
+};
+
+export const hasCardStatusWithRainApplication = (
+  cardStatus: CardStatusResponse | null | undefined,
+): boolean => Boolean(cardStatus?.rainApplicationStatus);
+
+/**
+ * A card has been ordered and the issuer hasn't opened it yet.
+ *
+ * Distinct from `hasCard`, which means "usable card" and so requires
+ * active/frozen. A pending card is not usable, but it definitely exists — which
+ * matters for routing: sending this user back to country selection or to the
+ * consent screen would either restart onboarding they already finished or ask the
+ * backend to issue a second card (it refuses, one per provider). They belong on
+ * the issuance flow, which shows the "on its way" state and polls until the card
+ * opens.
+ *
+ * This is the state a Wirex virtual card sits in between issuance and the issuer
+ * opening it — normally seconds, but indefinitely if the activation webhook is
+ * dropped and nothing reconciles against the API.
+ */
+export const hasPendingCard = (cardStatus: CardStatusResponse | null | undefined): boolean =>
+  cardStatus?.status === CardStatus.PENDING && cardStatus.provider !== CardProvider.BRIDGE;

--- a/lib/utils/utils.ts
+++ b/lib/utils/utils.ts
@@ -24,7 +24,6 @@ import {
   AuthTokens,
   CardProvider,
   CardResponse,
-  CardStatus,
   CardStatusResponse,
   RainContractResponseDto,
   User,
@@ -412,18 +411,14 @@ export function getCardFundingAddress(
   return cardDetails ? getArbitrumFundingAddress(cardDetails) : undefined;
 }
 
-/** Rain-first: only Rain cards count as "has card". Bridge-only users are treated as no card. */
-export const hasCard = (cardStatus: CardStatusResponse | null | undefined): boolean => {
-  if (!cardStatus?.status) return false;
-  const isActiveOrFrozen =
-    cardStatus.status === CardStatus.ACTIVE || cardStatus.status === CardStatus.FROZEN;
-  if (!isActiveOrFrozen) return false;
-  return cardStatus.provider !== CardProvider.BRIDGE;
-};
-
-export const hasCardStatusWithRainApplication = (
-  cardStatus: CardStatusResponse | null | undefined,
-): boolean => Boolean(cardStatus?.rainApplicationStatus);
+// Card-flow routing predicates live in their own leaf module so they are unit
+// testable (this file's import graph does not load under jest-expo). Re-exported
+// here so `@/lib/utils` stays the single import path for consumers.
+export {
+  hasCard,
+  hasCardStatusWithRainApplication,
+  hasPendingCard,
+} from '@/lib/utils/cardStatusRouting';
 
 /**
  * Whether the user's residence country requires a minimum deposit before they

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "solid",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "solid",
-      "version": "1.0.0",
+      "version": "2.0.0",
       "hasInstallScript": true,
       "dependencies": {
         "@amplitude/analytics-react-native": "^1.5.52",


### PR DESCRIPTION
Card creation could leave a user with nowhere to go. Issuance returns a card in `pending` (the issuer hasn't opened it yet), and the consent screen handled that by showing a toast and keeping the user exactly where they were — on a page whose only button now fails with "card already exists", with nothing polling for the card going live. The routing then compounded it: `hasCard` requires active/frozen, so a pending-card user hitting `/card` was treated as having no card at all and redirected into country selection, restarting onboarding they had already completed.

The issuance flow (`/card/activate`) already renders the "on its way" state, disables the activate button and polls card status every 3s, forwarding to card details the moment the card opens. It just was never reachable from the pending state. Route to it instead:

- /card/ready: on a pending create, forward to the issuance flow rather than staying put, and set the welcome popup so it still fires when the card lands there. Re-entering the screen with a card already created (back button, deep link, stale tab) now redirects instead of offering a button guaranteed to fail.
- /card: a pending card resumes issuance instead of restarting onboarding.
- The country gate (issuance flow, country selection, CardWaitingModal) treats a pending card the same as an existing one — someone mid-issuance cleared that gate already, and re-running an IP check would bounce a traveller or VPN user out of the flow.

`hasPendingCard` ("a card exists") is added alongside `hasCard` ("a card is usable") rather than widening the latter, whose active/frozen meaning 14 other call sites depend on for showing the card itself.

Both predicates move to lib/utils/cardStatusRouting.ts, a leaf module, so they can finally be unit tested — lib/utils/utils pulls in AsyncStorage and the API client (and through it Sentry), none of which load under jest-expo, which is why routing logic this load-bearing had no coverage. They are re-exported from lib/utils/utils, so @/lib/utils stays the import path for every consumer.

Tests: 10 new unit tests covering the boundary between the two predicates.


Claude-Session: https://claude.ai/code/session_012RMmHwpDy819piV5jrnauN