### PR TITLE
feat(card): reveal real Wirex card details instead of placeholder digits

### DIFF
--- a/components/Card/NewCardDetails/CardRevealSection.tsx
+++ b/components/Card/NewCardDetails/CardRevealSection.tsx
@@ -41,8 +41,9 @@ interface CardRevealSectionProps {
  * expose the name and issuing country — the two halves of the same gesture, so
  * they share one duration and easing.
  *
- * If the reveal request fails, the design's placeholder values are shown instead of
- * leaving the toggle spinning, so the state is still reachable.
+ * If the reveal request fails the card stays on its front face and the reason is
+ * surfaced as a toast, so the toggle can be tried again. It must never flip onto
+ * stand-in digits: that reads as a working card the user might try to spend.
  */
 const CardRevealSection = ({
   last4,
@@ -74,16 +75,29 @@ const CardRevealSection = ({
     };
   }, []);
 
-  // Flip once the request settles — on success with the real values, on failure with
-  // the placeholders. Held back by a frame on purpose: the values swap from
-  // placeholders to real ones in the render that the request triggers, and starting
-  // the flip and the panel in that same frame is what made the first reveal stutter
-  // on Android. A frame is enough for that render to commit first.
+  // Flip only once real values arrived. Held back by a frame on purpose: the values
+  // swap in on the render that the request triggers, and starting the flip and the
+  // panel in that same frame is what made the first reveal stutter on Android. A
+  // frame is enough for that render to commit first.
   useEffect(() => {
-    if (!hasRequested || isLoading || !(cardDetails || error)) return;
+    if (!hasRequested || isLoading || !cardDetails) return;
     const frame = requestAnimationFrame(() => setIsRevealed(true));
     return () => cancelAnimationFrame(frame);
-  }, [hasRequested, isLoading, cardDetails, error]);
+  }, [hasRequested, isLoading, cardDetails]);
+
+  // A failed reveal used to flip the card onto Figma's placeholder digits, which
+  // looked exactly like a working card. Report it and stay on the front face so the
+  // toggle can be tried again.
+  useEffect(() => {
+    if (!hasRequested || isLoading || !error || cardDetails) return;
+    setHasRequested(false);
+    Toast.show({
+      type: 'error',
+      text1: 'Could not show card details',
+      text2: error,
+      props: { badgeText: '' },
+    });
+  }, [hasRequested, isLoading, error, cardDetails]);
 
   // Build the revealed face while the pane sits idle, so the first tap doesn't pay
   // for three pieces of pill artwork decoding and the copy icons rasterising. Runs
@@ -115,8 +129,8 @@ const CardRevealSection = ({
     }
     setHasRequested(true);
     void revealDetails().catch(() => {
-      // Swallowed: the hook surfaces the failure through `error`, which flips the
-      // card onto the placeholder values.
+      // Swallowed: the hook surfaces the failure through `error`, which the effect
+      // above turns into a toast.
     });
   }, [isRevealed, revealDetails, clearCardDetails]);
 

--- a/components/Card/NewCardDetails/__tests__/cardRevealValues.test.ts
+++ b/components/Card/NewCardDetails/__tests__/cardRevealValues.test.ts
@@ -1,0 +1,101 @@
+/// <reference types="jest" />
+import {
+  groupCardNumber,
+  resolveCardRevealValues,
+} from '@/components/Card/NewCardDetails/cardRevealValues';
+
+/**
+ * The reveal face must never invent card data.
+ *
+ * It used to substitute the Figma placeholders (6483 6483 6483 6483, 12/27, 234,
+ * JOHN DOE) whenever a reveal failed, so a failure rendered a plausible-looking
+ * card the user could try to spend — and read as the feature working when it had
+ * not. Missing values now render as masks, and the copyable number stays empty.
+ */
+describe('resolveCardRevealValues', () => {
+  const revealed = {
+    card_number: '4111111111111111',
+    card_security_code: '123',
+    expiry_date: '12/2027',
+  };
+
+  it('renders the real values when the reveal succeeded', () => {
+    const values = resolveCardRevealValues({
+      revealed,
+      cardholderName: { first_name: 'Alex', last_name: 'Grey' },
+      issuingCountry: 'Lithuania',
+    });
+
+    expect(values.numberPlain).toBe('4111111111111111');
+    expect(values.number).toBe('4111   1111   1111   1111');
+    expect(values.expiry).toBe('12/27');
+    expect(values.cvv).toBe('123');
+    expect(values.nameOnCard).toBe('ALEX GREY');
+    expect(values.issuingCountry).toBe('Lithuania');
+  });
+
+  describe('when the reveal failed', () => {
+    const values = resolveCardRevealValues({ revealed: null });
+
+    it('never renders digits that could pass for a card number', () => {
+      expect(values.number).not.toMatch(/\d/);
+      expect(values.expiry).not.toMatch(/\d/);
+      expect(values.cvv).not.toMatch(/\d/);
+    });
+
+    it('leaves the copyable number empty, so nothing fake reaches the clipboard', () => {
+      expect(values.numberPlain).toBe('');
+    });
+
+    it('does not invent a cardholder name or country', () => {
+      expect(values.nameOnCard).toBe('');
+      expect(values.issuingCountry).toBe('');
+    });
+  });
+
+  it('masks only the parts the issuer withheld', () => {
+    // Wirex serves the CVV from a separate endpoint, so a PAN can arrive without
+    // one; the number must still be real and copyable.
+    const values = resolveCardRevealValues({
+      revealed: { ...revealed, card_security_code: '' },
+    });
+
+    expect(values.numberPlain).toBe('4111111111111111');
+    expect(values.cvv).not.toMatch(/\d/);
+  });
+
+  describe('expiry formatting', () => {
+    it.each([
+      ['12/2027', '12/27'], // Wirex MM/YYYY
+      ['12/27', '12/27'], // Rain MM/YY, passed through
+      ['2027-12-31', '12/27'], // Bridge ISO date
+    ])('formats %s as %s', (input, expected) => {
+      const values = resolveCardRevealValues({
+        revealed: { ...revealed, expiry_date: input },
+      });
+      expect(values.expiry).toBe(expected);
+    });
+
+    it('passes through an unparseable value rather than inventing one', () => {
+      const values = resolveCardRevealValues({
+        revealed: { ...revealed, expiry_date: 'not-a-date' },
+      });
+      expect(values.expiry).toBe('not-a-date');
+    });
+  });
+
+  describe('groupCardNumber', () => {
+    it('groups into fours', () => {
+      expect(groupCardNumber('4111111111111111')).toBe('4111   1111   1111   1111');
+    });
+
+    it('regroups a number that already contains spaces', () => {
+      expect(groupCardNumber('4111 1111 1111 1111')).toBe('4111   1111   1111   1111');
+    });
+
+    it('does not pad a short trailing group', () => {
+      // 15-digit PANs (Amex) must not gain characters.
+      expect(groupCardNumber('411111111111111')).toBe('4111   1111   1111   111');
+    });
+  });
+});

--- a/components/Card/NewCardDetails/cardRevealValues.ts
+++ b/components/Card/NewCardDetails/cardRevealValues.ts
@@ -12,16 +12,21 @@ export interface CardRevealValues {
 }
 
 /**
- * Stand-in values used when the reveal request fails, so the flip + slide-down
- * still play and the screen can be inspected. These are the literal placeholders
- * from the Figma reveal frame (21742:4077).
+ * Masks shown when a value is genuinely unavailable.
+ *
+ * These used to be the literal placeholders from the Figma reveal frame
+ * (6483 6483 6483 6483, 12/27, 234, JOHN DOE) so the flip still played on a
+ * failed reveal. That rendered a plausible-looking card the user could try to
+ * type into a checkout, and read as the feature working when it had not — the
+ * reveal must never invent card data. Masks are unmistakably not data, and a
+ * failed reveal now surfaces the error instead of flipping the card.
  */
-const DUMMY = {
-  number: '6483',
-  expiry: '12/27',
-  cvv: '234',
-  nameOnCard: 'JOHN DOE',
-  issuingCountry: 'Singapore',
+const MASK = {
+  numberGroup: '••••',
+  expiry: '••/••',
+  cvv: '•••',
+  nameOnCard: '',
+  issuingCountry: '',
 };
 
 /** Figma renders the number as four groups separated by three spaces. */
@@ -32,8 +37,13 @@ export const groupCardNumber = (cardNumber: string) =>
     .trim();
 
 const formatExpiry = (expiryDate: string) => {
-  // Rain returns MM/YY directly; Bridge returns YYYY-MM-DD.
+  // Rain returns MM/YY directly.
   if (/^\d{2}\/\d{2}$/.test(expiryDate)) return expiryDate;
+  // Wirex returns MM/YYYY. `new Date('12/2027')` is not reliably parseable, so
+  // truncate the century rather than routing it through Date.
+  const monthYear = /^(\d{2})\/\d{2}(\d{2})$/.exec(expiryDate);
+  if (monthYear) return `${monthYear[1]}/${monthYear[2]}`;
+  // Bridge returns YYYY-MM-DD.
   const date = new Date(expiryDate);
   if (Number.isNaN(date.getTime())) return expiryDate;
   const month = (date.getMonth() + 1).toString().padStart(2, '0');
@@ -48,9 +58,11 @@ interface ResolveArgs {
 }
 
 /**
- * Builds the values shown on the revealed card and in the panel. Anything the
- * backend couldn't supply falls back to the design's placeholder, so a failed
- * reveal still renders the designed layout instead of a dead spinner.
+ * Builds the values shown on the revealed card and in the panel.
+ *
+ * Anything the issuer didn't supply renders as a mask, never as invented data —
+ * `numberPlain` stays empty in that case so a copy action cannot put a
+ * made-up card number on the clipboard.
  */
 export const resolveCardRevealValues = ({
   revealed,
@@ -63,11 +75,14 @@ export const resolveCardRevealValues = ({
     : '';
 
   return {
-    number: numberPlain ? groupCardNumber(numberPlain) : groupCardNumber(DUMMY.number.repeat(4)),
-    numberPlain: numberPlain || DUMMY.number.repeat(4),
-    expiry: revealed?.expiry_date ? formatExpiry(revealed.expiry_date) : DUMMY.expiry,
-    cvv: revealed?.card_security_code || DUMMY.cvv,
-    nameOnCard: name || DUMMY.nameOnCard,
-    issuingCountry: issuingCountry || DUMMY.issuingCountry,
+    number: numberPlain
+      ? groupCardNumber(numberPlain)
+      : Array(4).fill(MASK.numberGroup).join('   '),
+    // Deliberately empty rather than masked: this is what gets copied.
+    numberPlain,
+    expiry: revealed?.expiry_date ? formatExpiry(revealed.expiry_date) : MASK.expiry,
+    cvv: revealed?.card_security_code || MASK.cvv,
+    nameOnCard: name || MASK.nameOnCard,
+    issuingCountry: issuingCountry || MASK.issuingCountry,
   };
 };

--- a/hooks/useCardDetailsReveal.ts
+++ b/hooks/useCardDetailsReveal.ts
@@ -2,6 +2,7 @@ import { useCallback, useState } from 'react';
 import { useMutation } from '@tanstack/react-query';
 
 import { DUMMY_CARD_REVEAL, isDummyUserId } from '@/constants/dummyCard';
+import { useWalletMessageSigner } from '@/hooks/useWalletMessageSigner';
 import { revealCardDetailsComplete } from '@/lib/api';
 import { CardDetailsRevealResponse, CardProvider } from '@/lib/types';
 import { useUserStore } from '@/store/useUserStore';
@@ -15,12 +16,12 @@ export interface UseCardDetailsRevealReturn {
 }
 
 /**
- * Hook for safely revealing card details using the Bridge API
+ * Hook for safely revealing card details.
  *
- * This hook implements the complete card details reveal flow:
- * - Generates a client secret and nonce
- * - Requests an ephemeral key from your backend
- * - Directly calls Bridge API to reveal card details
+ * Neither issuer lets a plaintext card number pass through our backend:
+ * - Rain: the backend fetches encrypted secrets and this client decrypts them.
+ * - Wirex: the client calls Wirex directly with a short-lived user token, after
+ *   the user signs a confirmation message with their wallet (a passkey prompt).
  *
  * Important: The revealed card details should NOT be stored persistently
  * and must be cleared from memory after use to comply with PCI DSS.
@@ -32,6 +33,9 @@ export const useCardDetailsReveal = (
   const isDummyUser = isDummyUserId(selectedUserId);
   // Store card details in local state (not in React Query cache for PCI compliance)
   const [cardDetails, setCardDetails] = useState<CardDetailsRevealResponse | null>(null);
+  // Wirex requires a signature from the card's own wallet before it releases the
+  // PAN; Rain ignores this.
+  const { signMessage } = useWalletMessageSigner();
 
   const {
     mutateAsync,
@@ -39,7 +43,7 @@ export const useCardDetailsReveal = (
     error: mutationError,
     reset,
   } = useMutation({
-    mutationFn: () => revealCardDetailsComplete(provider ?? undefined),
+    mutationFn: () => revealCardDetailsComplete(provider ?? undefined, signMessage),
     onSuccess: data => {
       setCardDetails(data);
     },

--- a/hooks/useWalletMessageSigner.ts
+++ b/hooks/useWalletMessageSigner.ts
@@ -1,0 +1,47 @@
+import { useCallback } from 'react';
+import { StamperType, useTurnkey } from '@turnkey/react-native-wallet-kit';
+import { createAccount } from '@turnkey/viem';
+
+import useUser from '@/hooks/useUser';
+
+/**
+ * Signs an arbitrary message with the user's Turnkey signer EOA
+ * (`user.walletAddress`) — not the Safe smart account.
+ *
+ * The key lives in Turnkey behind the user's passkey, so signing raises a
+ * biometric/passkey prompt. Where a provider requires proof that the human
+ * authorised an action, that prompt IS the confirmation, which is why this is a
+ * client-side signature and not something the backend can produce.
+ *
+ * Building the account does not prompt; only signing does.
+ */
+export function useWalletMessageSigner() {
+  const { user } = useUser();
+  const { createHttpClient } = useTurnkey();
+
+  const signMessage = useCallback(
+    async (message: string): Promise<string> => {
+      if (!user?.walletAddress || !user?.suborgId) {
+        throw new Error('Wallet is not ready yet');
+      }
+
+      const passkeyClient = createHttpClient({ defaultStamperType: StamperType.Passkey });
+      const turnkeyAccount = await createAccount({
+        client: passkeyClient,
+        organizationId: user.suborgId,
+        signWith: user.walletAddress,
+      });
+
+      return turnkeyAccount.signMessage({ message });
+    },
+    [createHttpClient, user?.walletAddress, user?.suborgId],
+  );
+
+  return {
+    signMessage,
+    /** Whether a signature can be attempted at all. */
+    canSign: Boolean(user?.walletAddress && user?.suborgId),
+    /** The EOA that will sign — the address a provider verifies against. */
+    walletAddress: user?.walletAddress,
+  };
+}

--- a/lib/__tests__/wirexCardReveal.test.ts
+++ b/lib/__tests__/wirexCardReveal.test.ts
@@ -1,0 +1,231 @@
+/// <reference types="jest" />
+import { revealWirexCardWithSession } from '@/lib/utils/wirexCardReveal';
+
+const WALLET = '0xaB2c32046543b71c84B0C816BeE7831ADC603C89';
+const CARD_ID = '9cc695f3-21b6-4f2d-a44c-a1473e6e8527';
+const API = 'https://api-baas.wirexapp.tech';
+const SIGNATURE = '0xdeadbeef';
+
+const session = {
+  accessToken: 'wirex-user-token',
+  expiresAt: 1_800_000_000,
+  apiBaseUrl: API,
+  chainId: '8453',
+  cardId: CARD_ID,
+  walletAddress: WALLET,
+  actionType: 'GetCardDetails',
+  messageTemplate: 'By signing this I confirm that I am executing action GetCardDetails at {nonce}',
+};
+
+const jsonResponse = (body: unknown, ok = true, status = 200) =>
+  ({ ok, status, json: async () => body }) as Response;
+
+/** Route each call by URL so assertions do not depend on call ordering. */
+const routeFetch = (overrides: Partial<Record<'confirm' | 'details' | 'cvv', Response>> = {}) =>
+  jest.fn(async (url: string, _init?: RequestInit) => {
+    if (url.includes('/confirmation/signature/verify')) {
+      return overrides.confirm ?? jsonResponse({ action_token: 'action-token-1' });
+    }
+    if (url.endsWith('/details')) {
+      return (
+        overrides.details ??
+        jsonResponse({ card_number: '4111111111111111', expiry_date: '12/2027' })
+      );
+    }
+    if (url.endsWith('/cvv')) {
+      return overrides.cvv ?? jsonResponse({ cvv: '123' });
+    }
+    throw new Error(`Unexpected fetch: ${url}`);
+  });
+
+type FetchCall = [string, RequestInit?];
+
+const callTo = (fetchMock: jest.Mock, match: (url: string) => boolean): FetchCall => {
+  const call = (fetchMock.mock.calls as FetchCall[]).find(([url]) => match(url));
+  if (!call) throw new Error('expected a matching fetch call');
+  return call;
+};
+
+const bodyOf = (call: FetchCall): Record<string, unknown> =>
+  JSON.parse(String(call[1]?.body ?? '{}'));
+
+const headersOf = (call: FetchCall): Record<string, string> =>
+  (call[1]?.headers ?? {}) as Record<string, string>;
+
+/**
+ * Wirex releases card data only after the user confirms with a wallet signature,
+ * and requires the read to happen client-side (proxying cardholder data through a
+ * non-PCI-compliant backend is not permitted). These tests pin that contract:
+ * the exact message signed, and that PAN/CVV are fetched straight from Wirex.
+ */
+describe('revealWirexCardWithSession', () => {
+  let signMessage: jest.Mock;
+
+  beforeEach(() => {
+    jest.useFakeTimers().setSystemTime(new Date('2026-08-12T00:00:00.000Z'));
+    signMessage = jest.fn().mockResolvedValue(SIGNATURE);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+  });
+
+  const run = (fetchMock: jest.Mock) => {
+    global.fetch = fetchMock as unknown as typeof fetch;
+    return revealWirexCardWithSession(session, signMessage);
+  };
+
+  it('returns the PAN, expiry and CVV read from Wirex', async () => {
+    await expect(run(routeFetch())).resolves.toEqual({
+      card_number: '4111111111111111',
+      card_security_code: '123',
+      expiry_date: '12/2027',
+    });
+  });
+
+  it('signs exactly the message Wirex specifies, with a fresh nonce', async () => {
+    await run(routeFetch());
+
+    const nonce = Math.floor(new Date('2026-08-12T00:00:00.000Z').getTime() / 1000);
+    // One character of drift here and Wirex answers `signature: invalid_signature`.
+    expect(signMessage).toHaveBeenCalledWith(
+      `By signing this I confirm that I am executing action GetCardDetails at ${nonce}`,
+    );
+  });
+
+  it('sends the signature and the same nonce it signed', async () => {
+    const fetchMock = routeFetch();
+    await run(fetchMock);
+
+    const body = bodyOf(callTo(fetchMock, url => url.includes('/confirmation/signature/verify')));
+    const signedNonce = Number(/at (\d+)$/.exec(String(signMessage.mock.calls[0][0]))![1]);
+
+    expect(body).toEqual({
+      action_type: 'GetCardDetails',
+      message_signature: SIGNATURE,
+      nonce: signedNonce,
+    });
+  });
+
+  it('reads the card data directly from Wirex', async () => {
+    const fetchMock = routeFetch();
+    await run(fetchMock);
+
+    const secretCalls = (fetchMock.mock.calls as FetchCall[])
+      .map(([url]) => url)
+      .filter(url => url.endsWith('/details') || url.endsWith('/cvv'));
+
+    expect(secretCalls).toEqual([
+      `${API}/api/v1/cards/${CARD_ID}/details`,
+      `${API}/api/v1/cards/${CARD_ID}/cvv`,
+    ]);
+  });
+
+  it('authenticates to Wirex with the user token and the card’s own wallet', async () => {
+    const fetchMock = routeFetch();
+    await run(fetchMock);
+
+    expect(headersOf(callTo(fetchMock, url => url.endsWith('/details')))).toMatchObject({
+      Authorization: 'Bearer wirex-user-token',
+      'X-Chain-Id': '8453',
+      'X-User-Wallet': WALLET,
+    });
+  });
+
+  it('reuses one action token across both reads, so the user signs once', async () => {
+    const fetchMock = routeFetch();
+    await run(fetchMock);
+
+    const tokens = (fetchMock.mock.calls as FetchCall[])
+      .filter(([url]) => url.endsWith('/details') || url.endsWith('/cvv'))
+      .map(call => bodyOf(call).action_token);
+
+    expect(tokens).toEqual(['action-token-1', 'action-token-1']);
+    expect(signMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it('still returns the PAN when only the CVV read fails', async () => {
+    // A card is less useful without its CVV, but a PAN beats failing outright.
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const result = await run(
+      routeFetch({ cvv: jsonResponse({ error_description: 'nope' }, false, 500) }),
+    );
+
+    expect(result.card_number).toBe('4111111111111111');
+    expect(result.card_security_code).toBe('');
+  });
+
+  describe('error reporting', () => {
+    it('surfaces the reason Wirex hides in error_details', async () => {
+      // error_description stays generic, so without unpacking error_details every
+      // failure looks the same.
+      await expect(
+        run(
+          routeFetch({
+            confirm: jsonResponse(
+              {
+                error_description: 'Request failed validation',
+                error_details: [{ key: 'signature', details: 'invalid_signature' }],
+              },
+              false,
+              400,
+            ),
+          }),
+        ),
+      ).rejects.toThrow('Request failed validation (signature: invalid_signature)');
+    });
+
+    it('reports an expired nonce distinctly', async () => {
+      await expect(
+        run(
+          routeFetch({
+            confirm: jsonResponse(
+              {
+                error_description: 'Request failed validation',
+                error_details: [{ key: 'nonce', details: 'expired' }],
+              },
+              false,
+              400,
+            ),
+          }),
+        ),
+      ).rejects.toThrow('nonce: expired');
+    });
+
+    it('reports a card that is not active', async () => {
+      await expect(
+        run(
+          routeFetch({
+            details: jsonResponse(
+              {
+                error_description: 'Invalid card status',
+                error_details: [{ key: 'card_status', details: 'not_active' }],
+              },
+              false,
+              400,
+            ),
+          }),
+        ),
+      ).rejects.toThrow('card_status: not_active');
+    });
+
+    it('fails when Wirex returns no action token', async () => {
+      await expect(run(routeFetch({ confirm: jsonResponse({}) }))).rejects.toThrow(
+        'did not return a confirmation token',
+      );
+    });
+
+    it('does not attempt a read when the user declines to sign', async () => {
+      signMessage.mockRejectedValue(new Error('User cancelled'));
+      const fetchMock = routeFetch();
+
+      await expect(run(fetchMock)).rejects.toThrow('User cancelled');
+
+      const reads = (fetchMock.mock.calls as FetchCall[]).filter(([url]) =>
+        url.includes('/api/v1/cards/'),
+      );
+      expect(reads).toHaveLength(0);
+    });
+  });
+});

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -122,12 +122,14 @@ import {
   WebhookStatus,
   WebProvisioningTokenResponse,
   WhatsNew,
+  WirexRevealSessionResponse,
   WithdrawCollateralRequest,
   WithdrawCollateralSignatureResponse,
   WithdrawFromCardToSavingsResponse,
 } from './types';
 import { generateClientNonceData } from './utils/cardDetailsReveal';
 import { decryptSecret, generateSessionId } from './utils/rainCardSecrets';
+import { revealWirexCardWithSession } from './utils/wirexCardReveal';
 
 // Helper function to get platform-specific headers
 export const getPlatformHeaders = () => {
@@ -2611,12 +2613,66 @@ export const revealCardDetailsCompleteRain = async (): Promise<CardDetailsReveal
 };
 
 /**
- * Complete card details reveal flow. Rain is the only supported provider;
- * Bridge is deprecated and no longer dispatched, even if the caller passes it.
+ * Mint a Wirex reveal session on our backend (JWT-authenticated). The backend
+ * resolves which card and wallet from its own records, so nothing about the card
+ * is client-supplied.
+ */
+export const getWirexRevealSession = async (): Promise<WirexRevealSessionResponse> => {
+  const jwt = getJWTToken();
+
+  const response = await fetch(
+    `${EXPO_PUBLIC_FLASH_API_BASE_URL}/accounts/v1/cards/wirex/reveal-session`,
+    {
+      method: 'POST',
+      headers: {
+        ...getPlatformHeaders(),
+        ...(jwt ? { Authorization: `Bearer ${jwt}` } : {}),
+      },
+      credentials: 'include',
+    },
+  );
+
+  if (!response.ok) throw response;
+
+  return response.json();
+};
+
+/**
+ * Wirex card reveal: confirm with a wallet signature, then read the PAN/CVV
+ * DIRECTLY from Wirex.
+ *
+ * Only the session comes from our backend. The card data itself is fetched by the
+ * device, because Wirex permits proxying cardholder data only through a PCI DSS
+ * compliant backend — the same principle as Rain, where the backend only ever
+ * handles ciphertext. The protocol lives in `lib/utils/wirexCardReveal`.
+ *
+ * @param signMessage Signs a message with the card's wallet (passkey-gated), so
+ *   the prompt the user sees is the confirmation Wirex requires.
+ */
+export const revealCardDetailsCompleteWirex = async (
+  signMessage: (message: string) => Promise<string>,
+): Promise<CardDetailsRevealResponse> => {
+  const session = await getWirexRevealSession();
+  return revealWirexCardWithSession(session, signMessage);
+};
+
+/**
+ * Complete card details reveal flow, dispatched by issuer. Bridge is deprecated
+ * and never dispatched.
+ *
+ * Wirex needs a wallet signature from the user, so callers on that path must
+ * supply a signer; without one there is nothing to confirm the reveal with.
  */
 export const revealCardDetailsComplete = async (
-  _provider?: CardProvider,
+  provider?: CardProvider,
+  signMessage?: (message: string) => Promise<string>,
 ): Promise<CardDetailsRevealResponse> => {
+  if (provider === CardProvider.WIREX) {
+    if (!signMessage) {
+      throw new Error('A wallet signature is required to show Wirex card details');
+    }
+    return revealCardDetailsCompleteWirex(signMessage);
+  }
   return revealCardDetailsCompleteRain();
 };
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -703,6 +703,31 @@ export interface CardPinResponseDto {
   encryptedPin: CardSecretsEncryptedField;
 }
 
+// --- Wirex card reveal ---
+/**
+ * A short-lived, user-scoped Wirex session minted by our backend so this client
+ * can read its own card's PAN/CVV directly from Wirex.
+ *
+ * Wirex requires sensitive card data to be fetched client-side unless the
+ * proxying backend is PCI DSS compliant, so the card number travels from Wirex
+ * straight to the device and never through our servers. `accessToken` is a
+ * secret: keep it in memory for the duration of the reveal and never persist it.
+ */
+export interface WirexRevealSessionResponse {
+  accessToken: string;
+  expiresAt?: number;
+  /** Wirex API origin, supplied by the backend so envs can move without a release. */
+  apiBaseUrl: string;
+  chainId: string;
+  cardId: string;
+  /** The EOA that must sign the confirmation message. */
+  walletAddress: string;
+  /** Action the signature is scoped to (`GetCardDetails`). */
+  actionType: string;
+  /** Message to sign, containing a `{nonce}` placeholder to substitute. */
+  messageTemplate: string;
+}
+
 // --- Rain contracts (funding) ---
 export interface RainContractTokenDto {
   address: string;

--- a/lib/utils/wirexCardReveal.ts
+++ b/lib/utils/wirexCardReveal.ts
@@ -1,0 +1,131 @@
+import { CardDetailsRevealResponse, WirexRevealSessionResponse } from '@/lib/types';
+
+/**
+ * The Wirex card-reveal protocol, run DIRECTLY against Wirex from the device.
+ *
+ * Wirex gates sensitive card data behind an explicit user confirmation: the user
+ * signs `By signing this I confirm that I am executing action GetCardDetails at
+ * {nonce}` with the wallet the card belongs to, and that signature is exchanged
+ * for a single-purpose `action_token` valid for 5 minutes.
+ *
+ * The reads go straight to Wirex rather than through our backend on purpose —
+ * Wirex permits proxying cardholder data only through a PCI DSS compliant
+ * backend, so the PAN must reach the device without an intermediate hop. This
+ * mirrors the Rain flow, where the backend only ever handles ciphertext.
+ *
+ * Kept in a leaf module (types only) so the protocol is unit testable: `lib/api`
+ * transitively imports Sentry, AsyncStorage and animated assets, none of which
+ * load under jest-expo.
+ *
+ * @see https://docs.wirexapp.com/docs/card-details
+ */
+
+/** Placeholder the backend leaves in `messageTemplate` for the signing timestamp. */
+const NONCE_PLACEHOLDER = '{nonce}';
+
+/**
+ * Pull the actionable cause out of a Wirex error body.
+ *
+ * Wirex keeps `error_description` generic ("Request failed validation") and hides
+ * the real reason in `error_details` — `signature: invalid_signature`,
+ * `nonce: expired`, `card_status: not_active`. Without unpacking it, every
+ * failure looks identical to the user and to us.
+ */
+export const describeWirexError = async (response: Response, fallback: string): Promise<string> => {
+  try {
+    const body = await response.json();
+    const details: string = Array.isArray(body?.error_details)
+      ? body.error_details
+          .map((d: { key?: string; details?: string }) =>
+            [d?.key, d?.details].filter(Boolean).join(': '),
+          )
+          .filter(Boolean)
+          .join('; ')
+      : '';
+    const base = body?.error_description || body?.error_reason || fallback;
+    return details ? `${base} (${details})` : base;
+  } catch {
+    return fallback;
+  }
+};
+
+/**
+ * Confirm with a wallet signature, then read the PAN, expiry and CVV from Wirex.
+ *
+ * @param session Short-lived, user-scoped Wirex session from our backend.
+ * @param signMessage Signs with the card's own wallet (passkey-gated), which is
+ *   what makes the prompt a genuine user confirmation.
+ */
+export const revealWirexCardWithSession = async (
+  session: WirexRevealSessionResponse,
+  signMessage: (message: string) => Promise<string>,
+): Promise<CardDetailsRevealResponse> => {
+  // Wirex rejects a nonce older than 5 minutes, so it is stamped immediately
+  // before signing — not when the session was minted.
+  const nonce = Math.floor(Date.now() / 1000);
+  const message = session.messageTemplate.replace(NONCE_PLACEHOLDER, String(nonce));
+  const signature = await signMessage(message);
+
+  const headers = {
+    Authorization: `Bearer ${session.accessToken}`,
+    'X-Chain-Id': session.chainId,
+    // Sent alongside the user token so the request is unambiguous about whose
+    // card is being read.
+    'X-User-Wallet': session.walletAddress,
+    'Content-Type': 'application/json',
+  };
+
+  const confirmation = await fetch(`${session.apiBaseUrl}/api/v1/confirmation/signature/verify`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({
+      action_type: session.actionType,
+      message_signature: signature,
+      nonce,
+    }),
+  });
+
+  if (!confirmation.ok) {
+    throw new Error(
+      await describeWirexError(
+        confirmation,
+        'Could not confirm your identity with the card issuer',
+      ),
+    );
+  }
+
+  const { action_token: actionToken } = await confirmation.json();
+  if (!actionToken) throw new Error('Card issuer did not return a confirmation token');
+
+  const readSecret = (path: 'details' | 'cvv') =>
+    fetch(`${session.apiBaseUrl}/api/v1/cards/${session.cardId}/${path}`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ action_token: actionToken }),
+    });
+
+  // Sequential, not parallel: Wirex documents the action token as reusable across
+  // the PAN/CVV/PIN endpoints but also as single-use, so two concurrent requests
+  // could race for it. One token means the user signs once.
+  const panResponse = await readSecret('details');
+  if (!panResponse.ok) {
+    throw new Error(await describeWirexError(panResponse, 'Could not read your card details'));
+  }
+  const { card_number, expiry_date } = await panResponse.json();
+
+  // A card is far less useful online without its CVV, but a PAN without one still
+  // beats failing the whole reveal, so this stays best-effort.
+  let cvv = '';
+  const cvvResponse = await readSecret('cvv');
+  if (cvvResponse.ok) {
+    cvv = (await cvvResponse.json())?.cvv ?? '';
+  } else {
+    console.warn('Wirex CVV read failed:', await describeWirexError(cvvResponse, 'unknown error'));
+  }
+
+  return {
+    card_number,
+    card_security_code: cvv,
+    expiry_date,
+  };
+};


### PR DESCRIPTION
"Show details" on a Wirex card displayed Figma's placeholder values — 6483 6483 6483 6483, 12/27, 234, JOHN DOE. Two separate causes: revealCardDetailsComplete ignored the provider and always ran the Rain flow (which cannot work for a Wirex card), and resolveCardRevealValues substituted those placeholders whenever a reveal failed, so the failure rendered as a plausible-looking card.

Implement the real flow. Wirex gates card data behind an explicit user confirmation: the user signs `By signing this I confirm that I am executing action GetCardDetails at {nonce}` with the wallet the card belongs to, and that signature is exchanged for a single-use action_token valid 5 minutes. The signer is the user's Turnkey EOA, so the passkey prompt IS the confirmation Wirex is asking for — which is why this cannot be done server-side.

The PAN/CVV reads go straight from the device to Wirex, using a short-lived user-scoped token from our backend. Wirex permits proxying cardholder data only through a PCI DSS compliant backend, so the card number never passes through our servers — the same principle as Rain, where the backend only ever handles ciphertext. Verified Wirex serves `access-control-allow-origin: *`, so the web build can call it directly.

One action token covers both reads, so the user signs once. The CVV read is best-effort: a PAN without it still beats failing the whole reveal.

A failed reveal now surfaces the reason and leaves the card unflipped rather than showing stand-in digits. Wirex buries the actionable cause in `error_details` (`signature: invalid_signature`, `nonce: expired`, `card_status: not_active`) while `error_description` stays generic, so that is unpacked into the message. Where a value is genuinely unavailable it renders as a mask, and the copyable number stays empty so nothing fabricated can reach the clipboard.

Also fixes expiry formatting: Wirex returns MM/YYYY, which fell through both existing branches and rendered as "12/2027" instead of "12/27".

The protocol lives in lib/utils/wirexCardReveal (a leaf module) so it is unit testable — lib/api transitively imports Sentry, AsyncStorage and animated assets, none of which load under jest-expo.

Tests: 24 new cases across the reveal protocol and the display values.


Claude-Session: https://claude.ai/code/session_012RMmHwpDy819piV5jrnauN