### PR TITLE
fix(card): report the real card issuer instead of always Rain

### DIFF
--- a/hooks/useCardProvider.ts
+++ b/hooks/useCardProvider.ts
@@ -2,17 +2,28 @@ import { useQuery } from '@tanstack/react-query';
 
 import { EXPO_PUBLIC_CARD_ISSUER } from '@/lib/config';
 import { CardProvider } from '@/lib/types';
-import { hasCard } from '@/lib/utils';
+import { resolveCardIssuer } from '@/lib/utils/cardStatusRouting';
 import { useUserStore } from '@/store/useUserStore';
 
 import { cardDetailsQueryOptions } from './cardDetailsQueryOptions';
 import { useCardStatus } from './useCardStatus';
 
 /**
- * Resolves card issuer. Bridge is deprecated — Rain is the only supported provider.
- * Uses, in order:
+ * Resolves which issuer the user's card is on. Bridge is deprecated and reported
+ * as "no card", matching `hasCard`.
+ *
+ * Resolution order:
  * 1. EXPO_PUBLIC_CARD_ISSUER if set (test/override)
- * 2. Rain when the user has an active Rain card (Bridge-only users are treated as no card)
+ * 2. The issuer the backend names on `/cards/status` or `/cards/details`
+ * 3. Rain, for legacy rows written before the provider field existed
+ *
+ * Step 2 matters: this used to return `CardProvider.RAIN` for *any* non-Bridge
+ * card, because Rain was the only one. Every consumer branches on
+ * `provider === RAIN`, so a Wirex card was driven down Rain-only paths — the
+ * card-details reveal POSTed to `/cards/secrets` (Rain's encrypted-secrets
+ * endpoint) and got back "Card reveal via SessionId is only supported for Rain
+ * cards", and the Rain balance/contracts queries fired for a card that has
+ * neither.
  */
 export function useCardProvider(): {
   provider: CardProvider | null;
@@ -22,12 +33,12 @@ export function useCardProvider(): {
   const { data: cardDetails } = useQuery(cardDetailsQueryOptions(selectedUserId));
   const { data: cardStatus } = useCardStatus();
 
-  if (EXPO_PUBLIC_CARD_ISSUER) {
-    return { provider: EXPO_PUBLIC_CARD_ISSUER, isLoading: false };
-  }
-
-  const hasRainCard =
-    hasCard(cardStatus) || (!!cardDetails?.id && cardDetails?.provider !== CardProvider.BRIDGE);
-
-  return { provider: hasRainCard ? CardProvider.RAIN : null, isLoading: false };
+  return {
+    provider: resolveCardIssuer({
+      cardStatus,
+      cardDetails,
+      issuerOverride: EXPO_PUBLIC_CARD_ISSUER,
+    }),
+    isLoading: false,
+  };
 }

--- a/lib/utils/__tests__/cardStatusRouting.test.ts
+++ b/lib/utils/__tests__/cardStatusRouting.test.ts
@@ -1,6 +1,6 @@
 /// <reference types="jest" />
 import { CardProvider, CardStatus, type CardStatusResponse } from '@/lib/types';
-import { hasCard, hasPendingCard } from '@/lib/utils/cardStatusRouting';
+import { hasCard, hasPendingCard, resolveCardIssuer } from '@/lib/utils/cardStatusRouting';
 
 const cardStatus = (overrides: Partial<CardStatusResponse> = {}): CardStatusResponse =>
   ({ ...overrides }) as CardStatusResponse;
@@ -79,5 +79,86 @@ describe('card status routing predicates', () => {
       const value = cardStatus({ status, provider: CardProvider.WIREX });
       expect(hasCard(value) && hasPendingCard(value)).toBe(false);
     }
+  });
+});
+
+/**
+ * Every card consumer branches on `provider === RAIN` to decide whether
+ * Rain-only endpoints apply. Reporting Rain for a Wirex card is what sent the
+ * card-details reveal to Rain's `/cards/secrets` and produced
+ * "Card reveal via SessionId is only supported for Rain cards".
+ */
+describe('resolveCardIssuer', () => {
+  const active = (provider?: CardProvider) =>
+    ({ status: CardStatus.ACTIVE, provider }) as CardStatusResponse;
+
+  it('reports Wirex for an active Wirex card', () => {
+    expect(resolveCardIssuer({ cardStatus: active(CardProvider.WIREX) })).toBe(CardProvider.WIREX);
+  });
+
+  it('reports Rain for an active Rain card', () => {
+    expect(resolveCardIssuer({ cardStatus: active(CardProvider.RAIN) })).toBe(CardProvider.RAIN);
+  });
+
+  it('falls back to the issuer on card details when status has not loaded', () => {
+    expect(
+      resolveCardIssuer({
+        cardStatus: null,
+        cardDetails: { id: 'card-1', provider: CardProvider.WIREX },
+      }),
+    ).toBe(CardProvider.WIREX);
+  });
+
+  it('prefers the issuer from card status when both are present', () => {
+    expect(
+      resolveCardIssuer({
+        cardStatus: active(CardProvider.WIREX),
+        cardDetails: { id: 'card-1', provider: CardProvider.RAIN },
+      }),
+    ).toBe(CardProvider.WIREX);
+  });
+
+  it('treats a card with no reported issuer as Rain (legacy rows)', () => {
+    // The provider field postdates those cards, and they are all Rain.
+    expect(resolveCardIssuer({ cardStatus: active() })).toBe(CardProvider.RAIN);
+  });
+
+  it('reports no issuer for a Bridge-only card', () => {
+    expect(resolveCardIssuer({ cardStatus: active(CardProvider.BRIDGE) })).toBeNull();
+    expect(
+      resolveCardIssuer({ cardDetails: { id: 'card-1', provider: CardProvider.BRIDGE } }),
+    ).toBeNull();
+  });
+
+  it('reports no issuer before a card exists, so nothing fetches during KYC', () => {
+    // /cards/status names the issuer during KYC too; that must not start
+    // issuer-specific queries for a card that has not been created.
+    expect(
+      resolveCardIssuer({ cardStatus: { provider: CardProvider.WIREX } as CardStatusResponse }),
+    ).toBeNull();
+    expect(resolveCardIssuer({})).toBeNull();
+  });
+
+  it('reports Wirex for a pending Wirex card once details exist', () => {
+    // hasCard is false while pending, but the details response resolves, and the
+    // issuer must still be named so the reveal does not fall through to Rain.
+    expect(
+      resolveCardIssuer({
+        cardStatus: {
+          status: CardStatus.PENDING,
+          provider: CardProvider.WIREX,
+        } as CardStatusResponse,
+        cardDetails: { id: 'card-1', provider: CardProvider.WIREX },
+      }),
+    ).toBe(CardProvider.WIREX);
+  });
+
+  it('honours the build-level issuer override', () => {
+    expect(
+      resolveCardIssuer({
+        cardStatus: active(CardProvider.RAIN),
+        issuerOverride: CardProvider.WIREX,
+      }),
+    ).toBe(CardProvider.WIREX);
   });
 });

--- a/lib/utils/cardStatusRouting.ts
+++ b/lib/utils/cardStatusRouting.ts
@@ -1,4 +1,9 @@
-import { CardProvider, CardStatus, type CardStatusResponse } from '@/lib/types';
+import {
+  type CardDetailsResponseDto,
+  CardProvider,
+  CardStatus,
+  type CardStatusResponse,
+} from '@/lib/types';
 
 /**
  * Predicates that decide where a user in the card flow is routed.
@@ -42,3 +47,36 @@ export const hasCardStatusWithRainApplication = (
  */
 export const hasPendingCard = (cardStatus: CardStatusResponse | null | undefined): boolean =>
   cardStatus?.status === CardStatus.PENDING && cardStatus.provider !== CardProvider.BRIDGE;
+
+/**
+ * Which issuer the user's card is on, or null when they effectively have none.
+ *
+ * Every consumer branches on `provider === RAIN` to decide whether Rain-only
+ * endpoints apply (encrypted card secrets, spending-power balance, funding
+ * contracts). Naming the issuer correctly is therefore what keeps a Wirex card
+ * off those endpoints — reporting Rain for any non-Bridge card is what made the
+ * card-details reveal POST to Rain's `/cards/secrets` and fail.
+ *
+ * An issuer is only reported once a card exists, so nothing begins
+ * issuer-specific fetching while the user is still in KYC.
+ */
+export const resolveCardIssuer = ({
+  cardStatus,
+  cardDetails,
+  issuerOverride,
+}: {
+  cardStatus?: CardStatusResponse | null;
+  cardDetails?: Pick<CardDetailsResponseDto, 'id' | 'provider'> | null;
+  /** EXPO_PUBLIC_CARD_ISSUER — a build-level override for testing. */
+  issuerOverride?: CardProvider | null;
+}): CardProvider | null => {
+  if (issuerOverride) return issuerOverride;
+
+  const hasNonBridgeCard =
+    hasCard(cardStatus) || (!!cardDetails?.id && cardDetails?.provider !== CardProvider.BRIDGE);
+  if (!hasNonBridgeCard) return null;
+
+  const reported = cardStatus?.provider ?? cardDetails?.provider;
+  // Legacy rows predate the provider field; those cards are all Rain.
+  return reported && reported !== CardProvider.BRIDGE ? reported : CardProvider.RAIN;
+};


### PR DESCRIPTION
Showing details for a Wirex card POSTed to /cards/secrets — Rain's encrypted-secrets endpoint — and got back 400 "Card reveal via SessionId is only supported for Rain cards."

useCardProvider returned CardProvider.RAIN for *any* non-Bridge card:

  const hasRainCard = hasCard(cardStatus) || (!!cardDetails?.id && ...);
  return { provider: hasRainCard ? CardProvider.RAIN : null };

Correct when Rain was the only non-Bridge issuer, wrong once Wirex existed — the variable name already said "Rain" while the condition only meant "not Bridge". Every consumer branches on `provider === RAIN` to decide whether Rain-only endpoints apply, so a Wirex card was routed down all of them: the details reveal, the spending-power balance (/cards/balance) and the funding contracts (/cards/contracts), none of which a Wirex card has. The provider dispatch added for the Wirex reveal never fired, because the provider it was handed was Rain.

Report the issuer the backend already names on /cards/status and /cards/details, falling back to Rain only when no issuer is reported (rows predating the field). The precondition is unchanged — an issuer is named only once a card exists — so nothing begins issuer-specific fetching while the user is still in KYC.

This also correctly hides the Rain-only PIN action for Wirex cards, which is gated on the same value; Wirex offers a PIN for physical cards only.

Resolution moves to lib/utils/cardStatusRouting so it can be unit tested without mounting react-query and zustand.

Tests: 9 new cases covering each issuer, the legacy fallback, Bridge, and the pre-card state.


Claude-Session: https://claude.ai/code/session_012RMmHwpDy819piV5jrnauN