### PR TITLE
fix(card): show the issuing country instead of silently blanking it

### DIFF
--- a/components/Card/NewCardDetails/CardRevealSection.tsx
+++ b/components/Card/NewCardDetails/CardRevealSection.tsx
@@ -15,10 +15,12 @@ import {
 } from '@/components/Card/NewCardDetails/cardHeroLayout';
 import CardHeroTarget from '@/components/Card/NewCardDetails/CardHeroTarget';
 import CardRevealFace from '@/components/Card/NewCardDetails/CardRevealFace';
-import { resolveCardRevealValues } from '@/components/Card/NewCardDetails/cardRevealValues';
+import {
+  resolveCardRevealValues,
+  resolveIssuingCountryName,
+} from '@/components/Card/NewCardDetails/cardRevealValues';
 import { EASE_OUT_EXPO, HERO_ENTER, HeroEnter } from '@/components/Card/NewCardDetails/heroMotion';
 import NewCardArt from '@/components/Card/NewCardDetails/NewCardArt';
-import { COUNTRIES } from '@/constants/countries';
 import { useCardDetailsReveal } from '@/hooks/useCardDetailsReveal';
 import { CardHolderName, CardProvider } from '@/lib/types';
 import { useCardPaneStore } from '@/store/useCardPaneStore';
@@ -110,7 +112,7 @@ const CardRevealSection = ({
   }, [isPaneOpen, isRevealFaceWarm]);
 
   const issuingCountry = useMemo(
-    () => COUNTRIES.find(country => country.code === issuingCountryCode)?.name,
+    () => resolveIssuingCountryName(issuingCountryCode),
     [issuingCountryCode],
   );
 

--- a/components/Card/NewCardDetails/__tests__/cardRevealValues.test.ts
+++ b/components/Card/NewCardDetails/__tests__/cardRevealValues.test.ts
@@ -2,6 +2,7 @@
 import {
   groupCardNumber,
   resolveCardRevealValues,
+  resolveIssuingCountryName,
 } from '@/components/Card/NewCardDetails/cardRevealValues';
 
 /**
@@ -97,5 +98,36 @@ describe('resolveCardRevealValues', () => {
       // 15-digit PANs (Amex) must not gain characters.
       expect(groupCardNumber('411111111111111')).toBe('4111   1111   1111   111');
     });
+  });
+});
+
+/**
+ * The issuing-country row renders a country NAME resolved from an alpha-2 code.
+ * An exact, case-sensitive match against the upper-case country list is what
+ * blanked the row for Wirex cards.
+ */
+describe('resolveIssuingCountryName', () => {
+  it('resolves an upper-case alpha-2 code', () => {
+    expect(resolveIssuingCountryName('LT')).toBe('Lithuania');
+  });
+
+  it('resolves a lower-case code', () => {
+    expect(resolveIssuingCountryName('lt')).toBe('Lithuania');
+  });
+
+  it('tolerates surrounding whitespace', () => {
+    expect(resolveIssuingCountryName(' de ')).toBe('Germany');
+  });
+
+  it('returns undefined for an alpha-3 code rather than a wrong country', () => {
+    // There is no 3→2 table on the client, so the backend must send alpha-2.
+    // Guessing here would risk displaying the wrong issuing country.
+    expect(resolveIssuingCountryName('LTU')).toBeUndefined();
+  });
+
+  it('returns undefined for empty or missing input', () => {
+    expect(resolveIssuingCountryName('')).toBeUndefined();
+    expect(resolveIssuingCountryName(undefined)).toBeUndefined();
+    expect(resolveIssuingCountryName(null)).toBeUndefined();
   });
 });

--- a/components/Card/NewCardDetails/cardRevealValues.ts
+++ b/components/Card/NewCardDetails/cardRevealValues.ts
@@ -1,3 +1,4 @@
+import { COUNTRIES } from '@/constants/countries';
 import { CardDetailsRevealResponse, CardHolderName } from '@/lib/types';
 
 export interface CardRevealValues {
@@ -27,6 +28,21 @@ const MASK = {
   cvv: '•••',
   nameOnCard: '',
   issuingCountry: '',
+};
+
+/**
+ * Country name for an ISO 3166-1 **alpha-2** code, for the "issuing country" row.
+ *
+ * Normalises case before matching: COUNTRIES is keyed on upper-case alpha-2, and
+ * an exact comparison silently blanked the row whenever the backend sent a
+ * differently-cased code. Alpha-3 cannot be resolved here — there is no 3→2 table
+ * on the client — so the backend is responsible for emitting alpha-2, and an
+ * unresolvable code yields undefined rather than a wrong country.
+ */
+export const resolveIssuingCountryName = (code?: string | null): string | undefined => {
+  const normalised = code?.trim().toUpperCase();
+  if (!normalised) return undefined;
+  return COUNTRIES.find(country => country.code === normalised)?.name;
 };
 
 /** Figma renders the number as four groups separated by three spaces. */


### PR DESCRIPTION
The issuing-country row matched the country code against COUNTRIES with an exact, case-sensitive comparison, so any code that was not already upper-case alpha-2 resolved to nothing and the row rendered empty. Paired with the backend only populating `issuing_country` for Rain, that left the row blank for every Wirex card.

Normalise case before matching, and return undefined for a code that cannot be resolved (alpha-3, say) rather than guessing — there is no 3→2 table on the client, so the backend is responsible for emitting alpha-2, and a guess here would risk displaying the wrong issuing country.

The lookup moves into cardRevealValues, the pure module that already builds the rest of the panel's values, so it can be unit tested without rendering.

Tests: 5 new cases covering casing, whitespace, alpha-3 and empty input.


Claude-Session: https://claude.ai/code/session_012RMmHwpDy819piV5jrnauN