### PR TITLE
fix(referral): hug the friend status pill in the second column

### DIFF
--- a/components/Referral/ReferralFriendRow.tsx
+++ b/components/Referral/ReferralFriendRow.tsx
@@ -241,12 +241,25 @@ export default function ReferralFriendRow({
     <Chip tone={presentation.detail.tone}>{presentation.detail.label}</Chip>
   ) : null;
 
+  // Stages with no detail chip (expired / reversed) show their status as the
+  // second-column pill instead, so the bottom pill always starts after the
+  // numbering column and hugs its label rather than spanning the row.
+  const statusInSecondColumn = !detailChip;
+
   return (
     <Animated.View
       // Rows cascade in rather than all appearing at once — same easing family
       // as the hero avatars so the screen reads as one motion system.
       entering={FadeIn.delay(Math.min(index, 8) * 60).duration(320)}
-      className="flex-row items-center justify-between border-t border-white/[0.06] px-1 py-3 first:border-t-0"
+      // The divider is driven off `index` rather than a `first:` variant.
+      // NativeWind only maps hover/active/focus/disabled/empty pseudo-classes;
+      // anything else — `:first-child` included — is discarded when the
+      // stylesheet is converted for native, so `first:border-t-0` was silently
+      // dead. An explicit index check works on both native and web.
+      className={cn(
+        'flex-row items-center justify-between gap-2 px-1 py-3',
+        index > 0 && 'border-t border-white/[0.06]',
+      )}
     >
       <View className="flex-1 flex-row items-start gap-3">
         <View className="h-9 w-9 items-center justify-center rounded-[18px] bg-[#2c2c2c]">
@@ -271,8 +284,10 @@ export default function ReferralFriendRow({
             />
           ) : null}
 
+          {/* `items-start` keeps the pill hugging its label — without it the
+              chip would stretch to the column width. */}
           {detailChip ? (
-            <View className="mt-1 flex-row">
+            <View className="mt-1 flex-row items-start">
               {isPaidWithProof ? (
                 // Tapping the unlocked reward opens the on-chain payout, so
                 // "you were paid" is verifiable rather than just asserted.
@@ -292,12 +307,20 @@ export default function ReferralFriendRow({
               )}
             </View>
           ) : null}
+
+          {statusInSecondColumn ? (
+            <View className="mt-1 flex-row items-start">
+              <Chip tone={presentation.lifecycle.tone}>{presentation.lifecycle.label}</Chip>
+            </View>
+          ) : null}
         </View>
       </View>
 
-      <Chip tone={presentation.lifecycle.tone} className="ml-2 shrink-0">
-        {presentation.lifecycle.label}
-      </Chip>
+      {statusInSecondColumn ? null : (
+        <Chip tone={presentation.lifecycle.tone} className="shrink-0">
+          {presentation.lifecycle.label}
+        </Chip>
+      )}
     </Animated.View>
   );
 }


### PR DESCRIPTION
The status pill rendered as a full-width bar stacked under the friend's details instead of a chip beside them. It now sits in the second column, aligned with the name and joined date, hugging its label.

Two changes behind that:

The row's divider used a `first:` variant. NativeWind only maps the hover/active/focus/disabled/empty pseudo-classes, so `:first-child` is discarded when the stylesheet is converted for native — the class was silently dead. The divider is now driven off `index`, which works on native and web.

Stages with no detail chip (expired, reversed) previously fell through to the right-hand lifecycle chip as their only pill. That pill now renders in the second column inside an explicit flex-row wrapper, so it hugs its label and left-aligns regardless of how the parent row lays out. Stages that do have a detail chip keep the design's two-chip arrangement, with the lifecycle chip on the right.


Claude-Session: https://claude.ai/code/session_01YXUtkbGXqfZnCZgfNWdVZS