### PR TITLE
fix(referral): put the status pill in the third column, top right

### DIFF
--- a/components/Referral/ReferralFriendRow.tsx
+++ b/components/Referral/ReferralFriendRow.tsx
@@ -241,23 +241,26 @@ export default function ReferralFriendRow({
     <Chip tone={presentation.detail.tone}>{presentation.detail.label}</Chip>
   ) : null;
 
-  // Stages with no detail chip (expired / reversed) show their status as the
-  // second-column pill instead, so the bottom pill always starts after the
-  // numbering column and hugs its label rather than spanning the row.
-  const statusInSecondColumn = !detailChip;
-
   return (
     <Animated.View
       // Rows cascade in rather than all appearing at once — same easing family
       // as the hero avatars so the screen reads as one motion system.
       entering={FadeIn.delay(Math.min(index, 8) * 60).duration(320)}
+      // Three columns: numbering, details, status. `items-start` puts the
+      // status pill on the first row (level with the friend's name) rather than
+      // letting it drift to the row's vertical centre.
+      //
       // The divider is driven off `index` rather than a `first:` variant.
       // NativeWind only maps hover/active/focus/disabled/empty pseudo-classes;
       // anything else — `:first-child` included — is discarded when the
       // stylesheet is converted for native, so `first:border-t-0` was silently
       // dead. An explicit index check works on both native and web.
+      //
+      // Padding matches the design's row box (16px sides, 12px ends → 100px
+      // tall), and the divider is full-bleed because the card itself carries no
+      // horizontal padding.
       className={cn(
-        'flex-row items-center justify-between gap-2 px-1 py-3',
+        'flex-row items-start justify-between gap-2 px-4 py-3',
         index > 0 && 'border-t border-white/[0.06]',
       )}
     >
@@ -284,10 +287,10 @@ export default function ReferralFriendRow({
             />
           ) : null}
 
-          {/* `items-start` keeps the pill hugging its label — without it the
-              chip would stretch to the column width. */}
+          {/* Bottom row of the details column — the wrapping flex-row keeps the
+              pill hugging its label instead of stretching to the column width. */}
           {detailChip ? (
-            <View className="mt-1 flex-row items-start">
+            <View className="flex-row items-start">
               {isPaidWithProof ? (
                 // Tapping the unlocked reward opens the on-chain payout, so
                 // "you were paid" is verifiable rather than just asserted.
@@ -307,20 +310,13 @@ export default function ReferralFriendRow({
               )}
             </View>
           ) : null}
-
-          {statusInSecondColumn ? (
-            <View className="mt-1 flex-row items-start">
-              <Chip tone={presentation.lifecycle.tone}>{presentation.lifecycle.label}</Chip>
-            </View>
-          ) : null}
         </View>
       </View>
 
-      {statusInSecondColumn ? null : (
-        <Chip tone={presentation.lifecycle.tone} className="shrink-0">
-          {presentation.lifecycle.label}
-        </Chip>
-      )}
+      {/* Third column — the lifecycle status, always top-right. */}
+      <Chip tone={presentation.lifecycle.tone} className="shrink-0">
+        {presentation.lifecycle.label}
+      </Chip>
     </Animated.View>
   );
 }

--- a/components/Referral/ReferralProgramContentNew.tsx
+++ b/components/Referral/ReferralProgramContentNew.tsx
@@ -298,7 +298,10 @@ export default function ReferralProgramContentNew({
         <View className="gap-2">
           <Text className="px-1 text-base text-white/50">Invited friends ({referrals.length})</Text>
           {referrals.length > 0 ? (
-            <View className="rounded-twice bg-card px-4 py-2">
+            // No padding here: each row carries the design's 16px sides so the
+            // dividers run the full width of the card. `overflow-hidden` keeps
+            // them inside the rounded corners.
+            <View className="overflow-hidden rounded-twice bg-card">
               {referrals.map((item, index) => (
                 <ReferralFriendRow
                   key={item.referredUserId || `${item.signupAt}-${index}`}


### PR DESCRIPTION
Corrects the friend row to the design's three-column layout:

  [01]  Friend name          [Pending]
        Joined Apr 18
        $0 spent
        [No Card]

The lifecycle status now always sits in the third column on the first row, level with the friend's name. My previous change had moved it to the bottom of the second column for stages with no detail chip, which put the wrong pill in the bottom slot — that slot belongs to the progress detail (no card / spend remaining / reward unlocked / unlock countdown), which starts at the second column on the last row.

Row metrics now follow the design's row box: 16px sides and 12px ends around 76px of content, giving the 100px row height. The card no longer carries horizontal padding, so the dividers run full width as they do in the design, with overflow-hidden keeping them inside the rounded corners. The detail pill's extra top margin is gone so the details column keeps a uniform 3px rhythm, matching the design's 52px chip offset.


Claude-Session: https://claude.ai/code/session_01YXUtkbGXqfZnCZgfNWdVZS