### PR TITLE
fix(kyc): ask the backend for the gated card routing, ungated only fo…

### DIFF
--- a/hooks/useBuyCryptoKycRoute.ts
+++ b/hooks/useBuyCryptoKycRoute.ts
@@ -32,7 +32,9 @@ export const useBuyCryptoKycRoute = () => {
     async (fallbackProvider?: KycProvider) => {
       setKycFlow('transfi');
 
-      const { kycProvider, countryCode } = await resolveKycProvider(fallbackProvider);
+      // 'onramp': this identity is for TransFi, which uses Sumsub independently of
+      // the Wirex card, so it must not be switched off with the card's gate.
+      const { kycProvider, countryCode } = await resolveKycProvider(fallbackProvider, 'onramp');
 
       setKycProvider(kycProvider);
       track(TRACKING_EVENTS.CARD_KYC_FLOW_TRIGGERED, {

--- a/lib/__tests__/kycProviderRouting.test.ts
+++ b/lib/__tests__/kycProviderRouting.test.ts
@@ -48,7 +48,9 @@ describe('resolveKycProvider', () => {
       kycProvider: KycProvider.SUMSUB,
       countryCode: 'DE',
     });
-    expect(mockGetProviderRouting).toHaveBeenCalledWith('DE');
+    // 'card' is passed explicitly: the backend gates the card answer on whether
+    // Wirex is enabled in that environment.
+    expect(mockGetProviderRouting).toHaveBeenCalledWith('DE', 'card');
   });
 
   it('routes everywhere else to Didit', async () => {
@@ -93,7 +95,7 @@ describe('resolveKycProvider', () => {
       kycProvider: KycProvider.SUMSUB,
       countryCode: 'FR',
     });
-    expect(mockGetProviderRouting).toHaveBeenCalledWith('FR');
+    expect(mockGetProviderRouting).toHaveBeenCalledWith('FR', 'card');
   });
 
   it('prefers the stored country over an IP lookup, so a manual pick wins', async () => {
@@ -145,6 +147,49 @@ describe('resolveKycProvider', () => {
   it('keeps the fallback when the backend answers without a provider', async () => {
     storeCountry('DE');
     mockGetProviderRouting.mockResolvedValue({} as any);
+
+    await expect(resolveKycProvider()).resolves.toEqual({
+      kycProvider: KycProvider.DIDIT,
+      countryCode: 'DE',
+    });
+  });
+});
+
+/**
+ * The card answer is gated server-side on whether Wirex is enabled in the
+ * environment — Wirex is staging-only, and country→provider routing is a code
+ * constant that ships to production unchanged. The onramp must not be caught by
+ * that gate: TransFi's use of Sumsub for identity is live in its own right.
+ */
+describe('resolveKycProvider flow gating', () => {
+  it('asks for the card answer by default', async () => {
+    storeCountry('DE');
+    mockGetProviderRouting.mockResolvedValue(wirexRouting('DE'));
+
+    await resolveKycProvider();
+
+    expect(mockGetProviderRouting).toHaveBeenCalledWith('DE', 'card');
+  });
+
+  it('asks for the ungated onramp answer when the buy-crypto flow routes', async () => {
+    storeCountry('DE');
+    mockGetProviderRouting.mockResolvedValue(wirexRouting('DE'));
+
+    await resolveKycProvider(KycProvider.DIDIT, 'onramp');
+
+    expect(mockGetProviderRouting).toHaveBeenCalledWith('DE', 'onramp');
+  });
+
+  it('follows the backend when it gates a Wirex country down to Didit', async () => {
+    // What production now returns for a Wirex country: the geography says Wirex,
+    // the environment says no, so the user goes to Didit and is never routed into
+    // a staging-only issuer.
+    storeCountry('DE');
+    mockGetProviderRouting.mockResolvedValue({
+      countryCode: 'DE',
+      cardProvider: CardProvider.RAIN,
+      kycProvider: KycProvider.DIDIT,
+    });
 
     await expect(resolveKycProvider()).resolves.toEqual({
       kycProvider: KycProvider.DIDIT,

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -763,12 +763,23 @@ export const getSumsubVerificationStatus = async (): Promise<SumsubVerificationS
  * Ask the backend which KYC + card providers a country routes to. Server-driven
  * so the Wirex/Sumsub geography can change without an app release.
  */
-export const getProviderRouting = async (countryCode: string): Promise<ProviderRoutingResponse> => {
+/**
+ * Which providers a country routes to.
+ *
+ * `flow` matters: the backend gates the `card` answer on whether Wirex is enabled
+ * in that environment (it is staging-only), while `onramp` gets the ungated
+ * geographic answer because TransFi's use of Sumsub is live independently. The
+ * backend defaults to the gated `card` answer, so omitting it is the safe choice.
+ */
+export const getProviderRouting = async (
+  countryCode: string,
+  flow: 'card' | 'onramp' = 'card',
+): Promise<ProviderRoutingResponse> => {
   const jwt = getJWTToken();
   const response = await fetch(
     `${EXPO_PUBLIC_FLASH_API_BASE_URL}/accounts/v1/sumsub/provider-routing?countryCode=${encodeURIComponent(
       countryCode,
-    )}`,
+    )}&flow=${flow}`,
     {
       credentials: 'include',
       headers: {

--- a/lib/kycProviderRouting.ts
+++ b/lib/kycProviderRouting.ts
@@ -42,18 +42,25 @@ const resolveRoutingCountry = async (): Promise<string | undefined> => {
  * backend keeps `fallbackProvider`, which defaults to Didit because Didit is
  * available everywhere.
  *
+ * The card answer is gated server-side on whether Wirex is enabled in that
+ * environment, so a Wirex country resolves to Didit in production. That gate is
+ * why the country alone is not enough to decide: the routing must be asked for.
+ *
  * @param fallbackProvider provider to keep when the country or routing is
  *   unavailable — the buy-crypto flow passes the backend's own suggestion here.
+ * @param flow which product is asking. `onramp` skips the Wirex card gate, since
+ *   TransFi's use of Sumsub is live independently of the card.
  */
 export const resolveKycProvider = async (
   fallbackProvider: KycProvider = KycProvider.DIDIT,
+  flow: 'card' | 'onramp' = 'card',
 ): Promise<ResolvedKycProvider> => {
   const countryCode = await resolveRoutingCountry();
 
   if (!countryCode) return { kycProvider: fallbackProvider };
 
   try {
-    const routing = await withRefreshToken(() => getProviderRouting(countryCode));
+    const routing = await withRefreshToken(() => getProviderRouting(countryCode, flow));
     return { kycProvider: routing?.kycProvider ?? fallbackProvider, countryCode };
   } catch {
     // backend unavailable → keep the fallback


### PR DESCRIPTION
…r onramp

The provider-routing endpoint now gates its `card` answer on whether Wirex is enabled in that environment — Wirex is staging-only, and the country list it routes on is a backend code constant that ships to production unchanged, so production was answering `wirex/sumsub` for ~60 countries.

Pass the flow so each product gets the right answer: the card flow takes the gated one (which is also the backend's default, so this is belt and braces), and buy-crypto passes `onramp` to keep the ungated geographic answer, since TransFi's use of Sumsub for identity is live independently of the card.

Nothing changes for a client that omits the parameter beyond getting the safe answer, which is the point.

Tests: 3 new cases for the flow plumbing and the gated-down-to-Didit result; 2 existing assertions updated for the new call signature.


Claude-Session: https://claude.ai/code/session_012RMmHwpDy819piV5jrnauN