### PR TITLE
fix(referral): match the design's row alignment and unlocking colour

### DIFF
--- a/components/Referral/ReferralFriendRow.tsx
+++ b/components/Referral/ReferralFriendRow.tsx
@@ -51,7 +51,7 @@ const CHIP_TONE: Record<ChipTone, { container: string; text: string }> = {
   neutral: { container: 'bg-white/[0.08]', text: 'text-white/60' },
   progress: { container: 'bg-referral-progress/[0.12]', text: 'text-referral-progress' },
   success: { container: 'bg-referral-success/[0.12]', text: 'text-referral-success' },
-  unlocking: { container: 'bg-pale-purple/[0.12]', text: 'text-pale-purple' },
+  unlocking: { container: 'bg-referral-unlocking/[0.12]', text: 'text-referral-unlocking' },
   warning: { container: 'bg-rewards/[0.12]', text: 'text-rewards' },
 };
 
@@ -246,9 +246,10 @@ export default function ReferralFriendRow({
       // Rows cascade in rather than all appearing at once — same easing family
       // as the hero avatars so the screen reads as one motion system.
       entering={FadeIn.delay(Math.min(index, 8) * 60).duration(320)}
-      // Three columns: numbering, details, status. `items-start` puts the
-      // status pill on the first row (level with the friend's name) rather than
-      // letting it drift to the row's vertical centre.
+      // Three columns: numbering, details, status. `items-center` matches the
+      // design, which centres the status pill against the row rather than
+      // aligning it to the name: the pill sits at y=38.5 with height 24 in a
+      // 100px row, so its centre lands on the row's centre.
       //
       // The divider is driven off `index` rather than a `first:` variant.
       // NativeWind only maps hover/active/focus/disabled/empty pseudo-classes;
@@ -260,7 +261,7 @@ export default function ReferralFriendRow({
       // tall), and the divider is full-bleed because the card itself carries no
       // horizontal padding.
       className={cn(
-        'flex-row items-start justify-between gap-2 px-4 py-3',
+        'flex-row items-center justify-between gap-2 px-4 py-3',
         index > 0 && 'border-t border-white/[0.06]',
       )}
     >

--- a/global.css
+++ b/global.css
@@ -41,6 +41,8 @@
     /* Referral friend-status accents (Figma "Referral program — all invite states") */
     --referral-progress: 202.9 100% 71.18%;
     --referral-success: 142.96 61.5% 63.33%;
+    /* #b39bff — brighter than --pale-purple (#a194eb), so it needs its own token */
+    --referral-unlocking: 254.4 100% 80.4%;
   }
 
   /* Override Tailwind's default system stack on web */

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -129,6 +129,9 @@ module.exports = {
         'referral-success': {
           DEFAULT: 'hsl(var(--referral-success))',
         },
+        'referral-unlocking': {
+          DEFAULT: 'hsl(var(--referral-unlocking))',
+        },
       },
       borderWidth: {
         hairline: hairlineWidth(),


### PR DESCRIPTION
Two corrections to follow the Figma node exactly.

The status pill is centred against the row, not aligned to the friend's name: the design places it at y=38.5 with height 24 inside a 100px row, so its centre sits on the row's centre. Reverts the row to items-center.

The "reward unlocks in" chip was reusing the pale-purple token, which is #a194eb — duller and darker than the design's #b39bff. Adds a dedicated --referral-unlocking token for the real value.

Verified against the node geometry: 36px avatar at radius 18 on #2c2c2c, 12px gap to the details column, 3px rhythm inside it, 14/18 name, 12/14 secondary lines, chips at radius 12 with 8x5 padding and 11/14 labels, and a 6% white divider.


Claude-Session: https://claude.ai/code/session_01YXUtkbGXqfZnCZgfNWdVZS