### PR TITLE
fix(referral): share an environment-appropriate referral link

### DIFF
--- a/components/Referral/ReferralProgramContent.tsx
+++ b/components/Referral/ReferralProgramContent.tsx
@@ -12,10 +12,12 @@ import { path } from '@/constants/path';
 import { useReferralSummary } from '@/hooks/useRewards';
 import useUser from '@/hooks/useUser';
 import { getAsset } from '@/lib/assets';
+import { SOLID_WEBSITE_URL } from '@/lib/config';
 import { ReferralRewardListItem, ReferralRewardStatus } from '@/lib/types';
 import { cn } from '@/lib/utils';
 
-const REFERRAL_BASE_URL = 'https://www.solid.xyz/refer?ref=';
+/** Environment-aware, so a QA build never shares a production referral link. */
+const REFERRAL_BASE_URL = `${SOLID_WEBSITE_URL}/refer?ref=`;
 
 const STATUS_LABEL: Record<ReferralRewardStatus, string> = {
   [ReferralRewardStatus.PENDING]: 'In progress',

--- a/components/Referral/ReferralProgramContentNew.tsx
+++ b/components/Referral/ReferralProgramContentNew.tsx
@@ -10,6 +10,7 @@ import { ChevronRight, X } from 'lucide-react-native';
 import CountUp from '@/components/CountUp';
 import { Text } from '@/components/ui/text';
 import { useReferralSummary } from '@/hooks/useRewards';
+import { SOLID_WEBSITE_URL } from '@/lib/config';
 import useUser from '@/hooks/useUser';
 import { getAsset } from '@/lib/assets';
 import { ReferralFriendStage } from '@/lib/types';
@@ -17,7 +18,8 @@ import { ReferralFriendStage } from '@/lib/types';
 import ReferralFriendRow, { formatUsdWhole, REFERRAL_SUCCESS_COLOR } from './ReferralFriendRow';
 import ReferralHeroAnimation from './ReferralHeroAnimation';
 
-const REFERRAL_BASE_URL = 'https://www.solid.xyz/refer?ref=';
+/** Environment-aware, so a QA build never shares a production referral link. */
+const REFERRAL_BASE_URL = `${SOLID_WEBSITE_URL}/refer?ref=`;
 
 // Matches the app's `--background` token (see global.css) — used for the top/bottom
 // scroll fades so they blend seamlessly into the modal's background.

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -79,6 +79,17 @@ export const isProduction = EXPO_PUBLIC_ENVIRONMENT === 'production';
 // In-development features: visible on qa/preview builds, hidden in production.
 export const isDevFeatureEnabled = !isProduction;
 
+/**
+ * Marketing site that hosts the referral landing page.
+ *
+ * Distinct from {@link EXPO_PUBLIC_BASE_URL}, which is the app's own origin.
+ * Staging points at the Webflow preview so a referral link shared from a QA
+ * build lands on the QA site instead of sending testers into production.
+ */
+export const SOLID_WEBSITE_URL = isProduction
+  ? 'https://www.solid.xyz'
+  : 'https://solid-qa.webflow.io';
+
 type Addresses = {
   ethereum: {
     teller: Address;


### PR DESCRIPTION
Both production and staging handed out the same production referral link, so a link copied from a QA build sent the recipient to the live site.

Adds SOLID_WEBSITE_URL to config, resolved from the existing isProduction flag: production keeps www.solid.xyz, everything else uses the Webflow QA site. Both referral screens build their link from it.

Kept separate from EXPO_PUBLIC_BASE_URL, which is the app's own origin for KYC redirects rather than the marketing site that hosts the referral landing page.


Claude-Session: https://claude.ai/code/session_01YXUtkbGXqfZnCZgfNWdVZS