### PR TITLE
fix: improve wallet actions and referral modal

### DIFF
--- a/components/Home/NewHome/WalletActions.tsx
+++ b/components/Home/NewHome/WalletActions.tsx
@@ -1,4 +1,4 @@
-import { Pressable, useWindowDimensions, View } from 'react-native';
+import { Platform, Pressable, StyleSheet, useWindowDimensions, View } from 'react-native';
 
 import HomeSend from '@/assets/images/home-send';
 import HomeSwap from '@/assets/images/home-swap';
@@ -21,6 +21,18 @@ type TriggerProps = React.ComponentProps<typeof Pressable>;
 // grow taller/narrower than its neighbours.
 const COMPACT_WIDTH = 400;
 
+// Keep the modal/trigger implementation out of flex sizing. Each visible action
+// gets an identical zero-basis slot, then its pill fills that slot. This is
+// explicit instead of relying on flex styles surviving through trigger clones.
+const styles = StyleSheet.create({
+  equalActionSlot: {
+    flexBasis: 0,
+    flexGrow: 1,
+    flexShrink: 1,
+    minWidth: 0,
+  },
+});
+
 const AddFundsTrigger = ({
   fullWidth,
   compact,
@@ -33,7 +45,7 @@ const AddFundsTrigger = ({
       compact ? 'px-2' : 'px-4',
       // On its own it stops at 24rem and centres, rather than stretching the full
       // width of a desktop column.
-      fullWidth ? 'mx-auto w-full max-w-[24rem]' : 'flex-1',
+      fullWidth ? 'mx-auto w-full max-w-[24rem]' : 'w-full',
     )}
   >
     <Text
@@ -46,13 +58,12 @@ const AddFundsTrigger = ({
   </Pressable>
 );
 
-// flex-1 like "Add Funds", so the row always splits evenly between however many
-// pills it has — two halves on iOS (no Swap there), three thirds elsewhere.
+// The equal-width parent slot controls sizing; the pill just fills it.
 const ActionPill = ({ children, compact, ...props }: TriggerProps & { compact?: boolean }) => (
   <Pressable
     {...props}
     className={cn(
-      'h-14 flex-1 flex-row items-center justify-center rounded-full bg-[#1C1C1C] transition-all active:scale-95 active:opacity-80',
+      'h-14 w-full flex-row items-center justify-center rounded-full bg-[#1C1C1C] transition-all active:scale-95 active:opacity-80',
       compact ? 'gap-1.5 px-2' : 'gap-2 px-4',
     )}
   >
@@ -90,23 +101,20 @@ const WalletActions = ({ hasFunds, hasCard }: WalletActionsProps) => {
   const { width } = useWindowDimensions();
   // Only the crowded three-pill row needs to shrink; alone, "Add Funds" always fits.
   const compact = hasFunds && width > 0 && width < COMPACT_WIDTH;
+  const showSwap = hasFunds && Platform.OS !== 'ios';
   const addFundsTrigger = <AddFundsTrigger fullWidth={!hasFunds} compact={compact} />;
 
   return (
     <View className={cn('flex-row items-center', compact ? 'gap-2 px-3' : 'gap-3 px-4')}>
-      {hasCard ? (
-        // AddFundsDestinationModal also mounts two controlled dialog roots. On
-        // web those roots render as zero-width Views, which the row otherwise
-        // counts as extra children and inserts a gap around. Keep the whole flow
-        // in one flex item so only the three visible actions define this layout.
-        <View className={hasFunds ? 'h-14 flex-1' : 'w-full'}>
+      <View className={hasFunds ? 'h-14' : 'w-full'} style={hasFunds && styles.equalActionSlot}>
+        {hasCard ? (
           <AddFundsDestinationModal trigger={addFundsTrigger} />
-        </View>
-      ) : (
-        <DepositOptionModal trigger={addFundsTrigger} />
-      )}
-      {hasFunds && (
-        <>
+        ) : (
+          <DepositOptionModal trigger={addFundsTrigger} />
+        )}
+      </View>
+      {showSwap && (
+        <View className="h-14" style={styles.equalActionSlot}>
           <SwapModal
             trigger={
               <ActionPill compact={compact}>
@@ -120,6 +128,10 @@ const WalletActions = ({ hasFunds, hasCard }: WalletActionsProps) => {
               </ActionPill>
             }
           />
+        </View>
+      )}
+      {hasFunds && (
+        <View className="h-14" style={styles.equalActionSlot}>
           <SendModal
             trigger={
               <ActionPill compact={compact}>
@@ -133,7 +145,7 @@ const WalletActions = ({ hasFunds, hasCard }: WalletActionsProps) => {
               </ActionPill>
             }
           />
-        </>
+        </View>
       )}
     </View>
   );

--- a/components/Referral/ReferralProgramContentNew.tsx
+++ b/components/Referral/ReferralProgramContentNew.tsx
@@ -5,14 +5,17 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import * as Clipboard from 'expo-clipboard';
 import { Image } from 'expo-image';
 import { LinearGradient } from 'expo-linear-gradient';
+import { Link } from 'expo-router';
 import { ChevronRight, X } from 'lucide-react-native';
 
 import CountUp from '@/components/CountUp';
 import { Text } from '@/components/ui/text';
+import { path } from '@/constants/path';
+import { useDimension } from '@/hooks/useDimension';
 import { useReferralSummary } from '@/hooks/useRewards';
-import { SOLID_WEBSITE_URL } from '@/lib/config';
 import useUser from '@/hooks/useUser';
 import { getAsset } from '@/lib/assets';
+import { SOLID_WEBSITE_URL } from '@/lib/config';
 import { ReferralFriendStage } from '@/lib/types';
 
 import ReferralFriendRow, { formatUsdWhole, REFERRAL_SUCCESS_COLOR } from './ReferralFriendRow';
@@ -89,6 +92,7 @@ export default function ReferralProgramContentNew({
   onClose,
 }: ReferralProgramContentNewProps) {
   const insets = useSafeAreaInsets();
+  const { isDesktop } = useDimension();
   const { user } = useUser();
   const [isSettling, setIsSettling] = useState(false);
   const { data: summary, refetch } = useReferralSummary({
@@ -198,7 +202,7 @@ export default function ReferralProgramContentNew({
         contentContainerStyle={{
           paddingTop: 72,
           paddingBottom: insets.bottom + 48,
-          paddingHorizontal: 16,
+          paddingHorizontal: isDesktop ? 0 : 16,
           gap: 24,
         }}
         showsVerticalScrollIndicator={false}
@@ -360,6 +364,14 @@ export default function ReferralProgramContentNew({
             </Text>
           </View>
         )}
+
+        {/* Add referrer */}
+        <Link href={path.ADD_REFERRER} onPress={onClose} asChild>
+          <Pressable className="flex-row items-center justify-between px-1 py-2">
+            <Text className="flex-1 pr-2 text-base font-medium text-white/70">Add a referrer</Text>
+            <ChevronRight size={20} color="rgba(255,255,255,0.7)" />
+          </Pressable>
+        </Link>
       </ScrollView>
 
       <LinearGradient
@@ -375,8 +387,8 @@ export default function ReferralProgramContentNew({
       >
         <Pressable
           onPress={onClose}
-          className="absolute right-4 h-[50px] w-[50px] items-center justify-center rounded-full bg-popover web:transition-colors web:hover:bg-muted"
-          style={{ top: 12 }}
+          className="absolute h-[50px] w-[50px] items-center justify-center rounded-full bg-popover web:transition-colors web:hover:bg-muted"
+          style={{ top: 12, right: isDesktop ? 0 : 16 }}
         >
           <X size={18} color="rgba(255,255,255,0.7)" />
         </Pressable>

--- a/components/Referral/ReferralProgramModalNew.tsx
+++ b/components/Referral/ReferralProgramModalNew.tsx
@@ -1,5 +1,6 @@
 import ReferralProgramContentNew from '@/components/Referral/ReferralProgramContentNew';
 import ResponsiveModal, { ModalState } from '@/components/ResponsiveModal';
+import { useDimension } from '@/hooks/useDimension';
 
 interface ReferralProgramModalNewProps {
   isOpen: boolean;
@@ -16,6 +17,8 @@ const CLOSE_STATE: ModalState = { name: 'close', number: 0 };
  * page of content rather than a compact popup.
  */
 export default function ReferralProgramModalNew({ isOpen, onClose }: ReferralProgramModalNewProps) {
+  const { isDesktop } = useDimension();
+
   return (
     <ResponsiveModal
       currentModal={MODAL_STATE}
@@ -26,7 +29,11 @@ export default function ReferralProgramModalNew({ isOpen, onClose }: ReferralPro
       }}
       trigger={null}
       contentKey="referral-program-new"
-      contentClassName="overflow-hidden bg-background px-0 pb-0 pt-0 md:max-w-xl md:px-0 md:pt-0"
+      contentClassName={
+        isDesktop
+          ? 'overflow-hidden bg-background md:max-w-xl'
+          : 'overflow-hidden bg-background px-0 pb-0 pt-0 md:max-w-xl md:px-0 md:pt-0'
+      }
       shouldAnimate={false}
       hideHeader
       disableScroll


### PR DESCRIPTION
## What changed

- Give each visible wallet action an equal, zero-basis layout slot so modal internals and trigger cloning do not distort pill widths.
- Hide Swap on iOS while preserving equal sizing for the remaining actions.
- Add an **Add a referrer** route from the referral program and close the modal during navigation.
- Adjust referral content padding and close-button placement for desktop modal spacing.

## Why

Modal wrappers and cloned triggers could participate inconsistently in flex layout, producing uneven wallet action widths. The referral modal also needed desktop-specific spacing and a direct path to add a referrer.

## Impact

Wallet actions now size consistently across supported layouts and platforms. Referral users can navigate directly to add a referrer, with cleaner desktop modal alignment.

## Validation

- `prettier --check` on the three changed files
- `eslint` on the three changed files
- `tsc --noEmit` was run; it remains blocked by unrelated existing type errors in KYC, settings, card banner, path typing, bridge hooks, Spin and Win, and withdrawal code. No reported type error is in the changed files.
