### PR TITLE
Fix savings activity filter to exclude card-destined transactions

### DIFF
--- a/components/Savings/NewSavings/RecentSavingsActivity.tsx
+++ b/components/Savings/NewSavings/RecentSavingsActivity.tsx
@@ -4,28 +4,22 @@ import { router } from 'expo-router';
 import Transaction from '@/components/Transaction';
 import { Text } from '@/components/ui/text';
 import { path } from '@/constants/path';
-import { getTransactionCategory } from '@/constants/transaction';
+import { isSavingsVaultActivity } from '@/constants/transaction';
 import { useActivity } from '@/hooks/useActivity';
-import { ActivityEvent, TransactionCategory } from '@/lib/types';
 
-// soUSD / soFUSE / soETH — the three savings vault tokens.
-const SAVINGS_SYMBOLS = new Set(['sousd', 'sofuse', 'soeth']);
 const MAX_ITEMS = 4;
 
-/** Keep only savings-related activity (by category or by vault-token symbol). */
-const isSavingsActivity = (activity: ActivityEvent) =>
-  getTransactionCategory(activity.type, activity.title) === TransactionCategory.SAVINGS_ACCOUNT ||
-  SAVINGS_SYMBOLS.has((activity.symbol ?? '').toLowerCase());
-
 /**
- * "Recent activity" for the funded savings screen — the most recent
- * savings-related transactions, with a "See all activity" link to the full
- * Activity screen. Renders nothing when there are no savings activities.
+ * "Recent activity" for the funded savings screen — the most recent deposits
+ * into and withdrawals out of the savings vault, with a "See all activity" link
+ * to the full Activity screen. Card funding, wallet transfers and everything
+ * else stay on their own surfaces. Renders nothing when there is no savings
+ * activity.
  */
 const RecentSavingsActivity = () => {
   const { activities, isLoading } = useActivity();
 
-  const savings = (activities ?? []).filter(isSavingsActivity).slice(0, MAX_ITEMS);
+  const savings = (activities ?? []).filter(isSavingsVaultActivity).slice(0, MAX_ITEMS);
 
   if (isLoading || savings.length === 0) return null;
 

--- a/constants/transaction.ts
+++ b/constants/transaction.ts
@@ -129,6 +129,15 @@ export const TRANSACTION_DETAILS: Record<TransactionType, TransactionDetails> = 
 };
 
 /**
+ * Every card-destined movement is titled with "Card" — "Card deposit" for a
+ * direct deposit the webhook routed to the card, "Deposit soUSD to Card" for
+ * the bridge flows. No savings title mentions a card, and it is the only marker
+ * activities created before `metadata.destinationType` existed carry, so the
+ * category resolver and the savings filter both key off it.
+ */
+const hasCardTitle = (title?: string): boolean => !!title?.toLowerCase().includes('card');
+
+/**
  * Resolve the user-facing transaction category.
  *
  * BRIDGE_DEPOSIT is dual-use: the same type backs both real cross-chain
@@ -143,10 +152,58 @@ export const getTransactionCategory = (
   type: TransactionType,
   title?: string,
 ): TransactionCategory | undefined => {
-  if (type === TransactionType.BRIDGE_DEPOSIT && title?.toLowerCase().includes('card')) {
+  if (type === TransactionType.BRIDGE_DEPOSIT && hasCardTitle(title)) {
     return TransactionCategory.CARD_DEPOSIT;
   }
   return TRANSACTION_DETAILS[type]?.category;
+};
+
+/**
+ * Types that move money into or out of the savings vault. Everything else —
+ * card spend and funding, wallet sends/receives, swaps, bank transfers,
+ * rewards, agent wallet and GoodDollar UBI — belongs to another surface.
+ *
+ * `DEPOSIT` and `BRIDGE_DEPOSIT` are on this list but are not savings on their
+ * own: both also back card funding, so they need the card checks below.
+ * The Rain collateral types (`WITHDRAW_COLLATERAL`,
+ * `REPAY_AND_WITHDRAW_COLLATERAL`) are deliberately absent — they settle card
+ * debt against Rain, not the vault, even though they are labelled
+ * "Savings account".
+ */
+const SAVINGS_VAULT_TYPES: ReadonlySet<TransactionType> = new Set([
+  TransactionType.DEPOSIT,
+  TransactionType.BRIDGE_DEPOSIT,
+  TransactionType.WITHDRAW,
+  TransactionType.UNSTAKE,
+  TransactionType.CANCEL_WITHDRAW,
+  TransactionType.FAST_WITHDRAW,
+]);
+
+/** `DepositDestinationType.RAIN_CARD` — a direct deposit delivered to the card. */
+const CARD_DESTINATION_TYPE = 'RAIN_CARD';
+
+/**
+ * Whether an activity is a deposit into, or a withdrawal out of, the savings
+ * vault — the only history that belongs on the savings screen.
+ *
+ * Deliberately keyed on the type rather than on the category: card deposits are
+ * recorded as `DEPOSIT` (direct deposits routed to the card) or `BRIDGE_DEPOSIT`
+ * ("Deposit soUSD to Card"), so they resolve to the "Savings account" category
+ * and read as savings. They are told apart by the destination the webhook
+ * recorded, falling back to the card title convention for older rows.
+ *
+ * Nor is the symbol enough on its own: card deposits and plain wallet sends are
+ * denominated in soUSD too, so a vault-token symbol does not make an activity
+ * savings.
+ */
+export const isSavingsVaultActivity = (activity: {
+  type: TransactionType;
+  title?: string;
+  metadata?: Record<string, any>;
+}): boolean => {
+  if (!SAVINGS_VAULT_TYPES.has(activity.type)) return false;
+  if (activity.metadata?.destinationType === CARD_DESTINATION_TYPE) return false;
+  return !hasCardTitle(activity.title);
 };
 
 /**

--- a/lib/utils/__tests__/savings-activity-filter.test.ts
+++ b/lib/utils/__tests__/savings-activity-filter.test.ts
@@ -1,0 +1,147 @@
+/// <reference types="jest" />
+import { isSavingsVaultActivity } from '@/constants/transaction';
+import { ActivityEvent, TransactionStatus, TransactionType } from '@/lib/types';
+
+function makeActivity(overrides: Partial<ActivityEvent> = {}): ActivityEvent {
+  return {
+    clientTxId: 'tx-1',
+    type: TransactionType.DEPOSIT,
+    status: TransactionStatus.SUCCESS,
+    amount: '5',
+    symbol: 'USDC',
+    timestamp: '1781426763',
+    title: 'Deposit USDC on Ethereum',
+    ...overrides,
+  } as ActivityEvent;
+}
+
+describe('isSavingsVaultActivity — card activity stays off the savings screen', () => {
+  // The reported bug: a direct deposit routed to the Rain card is recorded as
+  // `DEPOSIT`, which resolves to the "Savings account" category, so it read as
+  // savings and showed up under the savings balance.
+  it('excludes a direct deposit the webhook routed to the card', () => {
+    const cardDeposit = makeActivity({
+      clientTxId: 'direct_deposit_8453_USDC_1781426763',
+      title: 'Card deposit',
+      shortTitle: 'Card deposit',
+      symbol: 'USDC',
+      metadata: { description: 'Card deposit', destinationType: 'RAIN_CARD' },
+    });
+
+    expect(isSavingsVaultActivity(cardDeposit)).toBe(false);
+  });
+
+  it('excludes older card deposits that predate metadata.destinationType', () => {
+    const legacy = makeActivity({ title: 'Card deposit', metadata: {} });
+
+    expect(isSavingsVaultActivity(legacy)).toBe(false);
+  });
+
+  // Bridged card funding: `BRIDGE_DEPOSIT` denominated in the vault share token,
+  // so neither the type nor the symbol tells it apart from savings.
+  it.each([
+    ['Deposit soUSD to Card', 'soUSD'],
+    ['Deposit USDC to Card', 'USDC.e'],
+  ])('excludes the bridged card deposit "%s"', (title, symbol) => {
+    const activity = makeActivity({
+      type: TransactionType.BRIDGE_DEPOSIT,
+      title,
+      symbol,
+    });
+
+    expect(isSavingsVaultActivity(activity)).toBe(false);
+  });
+
+  it.each([
+    ['card deposit from savings', TransactionType.CARD_DEPOSIT, 'soUSD', 'Deposit to Card'],
+    [
+      'borrow-and-deposit to card',
+      TransactionType.BORROW_AND_DEPOSIT_TO_CARD,
+      'soUSD',
+      'Borrow and deposit to card',
+    ],
+    ['card spend', TransactionType.CARD_TRANSACTION, 'USDC', 'Coffee'],
+    ['card withdrawal', TransactionType.CARD_WITHDRAWAL, 'USDC', 'Card withdraw'],
+  ])('excludes a %s', (_label, type, symbol, title) => {
+    expect(isSavingsVaultActivity(makeActivity({ type, symbol, title }))).toBe(false);
+  });
+
+  // These settle card debt against Rain rather than moving vault balance, even
+  // though the static category map labels them "Savings account".
+  it.each([
+    [TransactionType.WITHDRAW_COLLATERAL, 'Withdraw collateral'],
+    [TransactionType.REPAY_AND_WITHDRAW_COLLATERAL, 'Repay from collateral'],
+  ])('excludes the Rain collateral flow "%s"', (type, title) => {
+    expect(isSavingsVaultActivity(makeActivity({ type, title }))).toBe(false);
+  });
+});
+
+describe('isSavingsVaultActivity — vault deposits and withdrawals are kept', () => {
+  it('keeps a direct deposit routed to savings', () => {
+    const savingsDeposit = makeActivity({
+      clientTxId: 'direct_deposit_1_USDC_1781426763',
+      title: 'Deposit USDC on Ethereum',
+      metadata: { description: 'Direct deposit', destinationType: 'PROTOCOL' },
+    });
+
+    expect(isSavingsVaultActivity(savingsDeposit)).toBe(true);
+  });
+
+  it('keeps a connect-wallet deposit denominated in the share token', () => {
+    const deposit = makeActivity({ symbol: 'soUSD', title: 'Deposit 100 soUSD' });
+
+    expect(isSavingsVaultActivity(deposit)).toBe(true);
+  });
+
+  it.each([
+    [TransactionType.WITHDRAW, 'Withdraw 20000 soUSD', 'soUSD'],
+    [TransactionType.UNSTAKE, 'Unstake 100 soUSD', 'soUSD'],
+    [TransactionType.CANCEL_WITHDRAW, 'Cancel withdraw', 'soUSD'],
+    [TransactionType.FAST_WITHDRAW, 'Fast withdraw 10 soUSD', 'soUSD'],
+  ])('keeps the vault withdrawal type %s', (type, title, symbol) => {
+    expect(isSavingsVaultActivity(makeActivity({ type, title, symbol }))).toBe(true);
+  });
+
+  // The same `BRIDGE_DEPOSIT` type that backs card funding also backs real vault
+  // movements; only the card-titled ones are dropped.
+  it.each([
+    ['Stake 100 soUSD to Fuse', 'soUSD'],
+    ['Withdraw 20000 soUSD', 'USDC'],
+    ['Withdraw 1 soETH', 'soETH'],
+    ['Withdraw soUSD to Arbitrum', 'soUSD'],
+  ])('keeps the bridged vault movement "%s"', (title, symbol) => {
+    const activity = makeActivity({ type: TransactionType.BRIDGE_DEPOSIT, title, symbol });
+
+    expect(isSavingsVaultActivity(activity)).toBe(true);
+  });
+});
+
+describe('isSavingsVaultActivity — other surfaces stay out', () => {
+  // A vault-token symbol used to be enough to qualify, which pulled plain soUSD
+  // sends onto the savings screen.
+  it('excludes a wallet send denominated in soUSD', () => {
+    const send = makeActivity({
+      type: TransactionType.SEND,
+      title: 'Send 10 soUSD',
+      symbol: 'soUSD',
+    });
+
+    expect(isSavingsVaultActivity(send)).toBe(false);
+  });
+
+  it.each([
+    [TransactionType.RECEIVE, 'Received 10 USDC'],
+    [TransactionType.FUND, 'Add funds'],
+    [TransactionType.BRIDGE, 'Bridge to Arbitrum'],
+    [TransactionType.BANK_TRANSFER, 'Bank deposit'],
+    [TransactionType.MERCURYO_TRANSACTION, 'Buy crypto'],
+    [TransactionType.SWAP, 'Swap USDC for ETH'],
+    [TransactionType.MERKL_CLAIM, 'Merkl rewards'],
+    [TransactionType.DEPOSIT_BONUS, 'Deposit bonus'],
+    [TransactionType.AGENT_WALLET_DEPOSIT, 'Agent wallet deposit'],
+    [TransactionType.GOODDOLLAR_CLAIM, 'GoodDollar claim'],
+    [TransactionType.RESCUE_TOKEN, 'Recovered 5 USDC'],
+  ])('excludes %s activity', (type, title) => {
+    expect(isSavingsVaultActivity(makeActivity({ type, title }))).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
Fixes a bug where direct deposits and bridge transfers routed to the Rain card were incorrectly appearing on the savings screen. Introduces a new `isSavingsVaultActivity()` filter function that properly distinguishes between actual vault deposits/withdrawals and card-related transactions.

## Key Changes
- **Added `isSavingsVaultActivity()` function** in `constants/transaction.ts` that filters activities to only include actual savings vault movements (deposits, withdrawals, unstaking, etc.)
  - Checks transaction type against a whitelist of vault-related types
  - Excludes transactions with `metadata.destinationType === 'RAIN_CARD'` (direct deposits routed to card)
  - Excludes transactions with "card" in the title (covers bridged card deposits and legacy card deposits)
  - Deliberately ignores symbol-based filtering to prevent vault token sends from being misclassified as savings

- **Refactored `RecentSavingsActivity.tsx`** to use the new filter instead of category-based + symbol-based logic
  - Removed the `isSavingsActivity()` helper that relied on category and vault token symbols
  - Now uses `isSavingsVaultActivity()` for more accurate filtering

- **Extracted `hasCardTitle()` helper** in `constants/transaction.ts` for consistent card title detection across both the category resolver and the new savings filter

- **Added comprehensive test suite** (`savings-activity-filter.test.ts`) covering:
  - Card deposits (direct deposits, bridged, legacy)
  - Legitimate vault deposits and withdrawals
  - Other transaction types that should not appear on savings screen

## Implementation Details
The fix addresses the root cause: `DEPOSIT` and `BRIDGE_DEPOSIT` transaction types can represent either vault movements or card funding, so type alone is insufficient. The solution uses a multi-layered approach:
1. Type whitelist (only vault-related types)
2. Destination metadata check (for newer direct deposits)
3. Title pattern matching (for card-titled transactions and legacy entries)

This ensures card-destined transactions are properly excluded while legitimate vault activity is preserved.

https://claude.ai/code/session_01YC5Acab8rFVaFeeWN9SkKD