### PR TITLE
Consolidate card freeze toggle logic into shared utility

### DIFF
--- a/app/(protected)/(tabs)/card/details.tsx
+++ b/app/(protected)/(tabs)/card/details.tsx
@@ -34,7 +34,8 @@ import { useDimension } from '@/hooks/useDimension';
 import { freezeCard, unfreezeCard } from '@/lib/api';
 import { getAsset } from '@/lib/assets';
 import { isProduction } from '@/lib/config';
-import { CardHolderName, CardProvider, CardStatus, FreezeInitiator, KycStatus } from '@/lib/types';
+import { CardHolderName, CardProvider, CardStatus, KycStatus } from '@/lib/types';
+import { canToggleCardFreeze } from '@/lib/utils/cardHelpers';
 import { cn } from '@/lib/utils/utils';
 import { useCardPaneStore } from '@/store/useCardPaneStore';
 import { useCardWelcomePopupStore } from '@/store/useCardWelcomePopupStore';
@@ -73,8 +74,7 @@ export default function CardDetails() {
   const availableAmount = Number(availableBalance?.amount || '0').toString();
   const isCardFrozen = cardDetails?.status === CardStatus.FROZEN;
 
-  const canUnfreeze =
-    isCardFrozen && cardDetails?.freezes?.some(f => f.initiator === FreezeInitiator.CUSTOMER);
+  const canToggleFreeze = canToggleCardFreeze(cardDetails);
 
   const isCustomerPausedOrOffboarded =
     customer?.status === KycStatus.PAUSED || customer?.status === KycStatus.OFFBOARDED;
@@ -135,7 +135,7 @@ export default function CardDetails() {
     <View className="mx-auto w-full max-w-7xl px-4 pt-12">
       <DesktopHeader
         isCardFrozen={isCardFrozen}
-        canUnfreeze={!!canUnfreeze}
+        canToggleFreeze={canToggleFreeze}
         isFreezing={isFreezing}
         isCardFlipped={isCardFlipped}
         isLoadingCardDetails={isLoadingCardDetails}
@@ -229,8 +229,10 @@ function CardDetailsRedirect() {
 }
 
 interface DesktopHeaderProps {
+  /** Drives the label only — whether to offer the toggle is `canToggleFreeze`. */
   isCardFrozen: boolean;
-  canUnfreeze: boolean;
+  /** Shared with the mobile card pane via `canToggleCardFreeze`. */
+  canToggleFreeze: boolean;
   isFreezing: boolean;
   isCardFlipped: boolean;
   isLoadingCardDetails: boolean;
@@ -242,7 +244,7 @@ interface DesktopHeaderProps {
 
 function DesktopHeader({
   isCardFrozen,
-  canUnfreeze,
+  canToggleFreeze,
   isFreezing,
   isCardFlipped,
   isLoadingCardDetails,
@@ -260,7 +262,7 @@ function DesktopHeader({
     right: 12,
   };
 
-  const showManageDropdown = isRain || !isCardFrozen || canUnfreeze;
+  const showManageDropdown = isRain || canToggleFreeze;
 
   return (
     <View className="flex-row justify-between">
@@ -315,7 +317,7 @@ function DesktopHeader({
                   }
                 />
               )}
-              {(!isCardFrozen || canUnfreeze) && (
+              {canToggleFreeze && (
                 <DropdownMenuItem
                   className="flex-row items-center gap-3 rounded-none px-5 py-3 web:cursor-pointer web:hover:bg-[#404040]"
                   onPress={onFreezeToggle}

--- a/components/Card/NewCardDetails/CardActionsRow.tsx
+++ b/components/Card/NewCardDetails/CardActionsRow.tsx
@@ -44,8 +44,14 @@ const CircleAction = ({
 );
 
 interface CardActionsRowProps {
+  /** Drives the label only — whether to offer the toggle is `canToggleFreeze`. */
   isCardFrozen: boolean;
-  canUnfreeze: boolean;
+  /**
+   * Whether to show the freeze toggle at all. Derived by the parent from
+   * `canToggleCardFreeze`, so this row and the desktop header can't drift into
+   * offering different actions for the same card.
+   */
+  canToggleFreeze: boolean;
   isFreezing: boolean;
   onFreezeToggle: () => void;
   onMorePress: () => void;
@@ -58,15 +64,13 @@ interface CardActionsRowProps {
 /** The Add funds / Withdraw / Freeze / More row on the redesigned card screen. */
 const CardActionsRow = ({
   isCardFrozen,
-  canUnfreeze,
+  canToggleFreeze,
   isFreezing,
   onFreezeToggle,
   onMorePress,
   canAddFunds,
   canWithdraw,
 }: CardActionsRowProps) => {
-  const showFreeze = !isCardFrozen || canUnfreeze;
-
   return (
     <View className="flex-row items-start justify-center">
       {canAddFunds && (
@@ -99,7 +103,7 @@ const CardActionsRow = ({
           />
         </View>
       )}
-      {showFreeze && (
+      {canToggleFreeze && (
         <View style={styles.item}>
           <CircleAction
             label={isCardFrozen ? 'Unfreeze' : 'Freeze'}

--- a/components/Card/NewCardDetails/CardDetailsPane.tsx
+++ b/components/Card/NewCardDetails/CardDetailsPane.tsx
@@ -30,7 +30,8 @@ import { useCardStatus } from '@/hooks/useCardStatus';
 import { useCustomer } from '@/hooks/useCustomer';
 import { useRewardsUserData } from '@/hooks/useRewards';
 import { freezeCard, unfreezeCard } from '@/lib/api';
-import { CardStatus, FreezeInitiator, KycStatus } from '@/lib/types';
+import { CardStatus, KycStatus } from '@/lib/types';
+import { canToggleCardFreeze } from '@/lib/utils/cardHelpers';
 import { useCardHeroStore } from '@/store/useCardHeroStore';
 import { useCardPaneStore } from '@/store/useCardPaneStore';
 import { useCardWelcomePopupStore } from '@/store/useCardWelcomePopupStore';
@@ -116,8 +117,7 @@ const CardDetailsPane = () => {
   const isVisible = isOpen || isSettling;
 
   const isCardFrozen = cardDetails?.status === CardStatus.FROZEN;
-  const canUnfreeze =
-    isCardFrozen && cardDetails?.freezes?.some(f => f.initiator === FreezeInitiator.CUSTOMER);
+  const canToggleFreeze = canToggleCardFreeze(cardDetails);
   const isCustomerPausedOrOffboarded =
     customer?.status === KycStatus.PAUSED || customer?.status === KycStatus.OFFBOARDED;
   const canMoveCardFunds = !isCardFrozen && !isCustomerPausedOrOffboarded;
@@ -220,7 +220,7 @@ const CardDetailsPane = () => {
           <HeroEnter spec={HERO_ENTER.actions} style={styles.actionsRow}>
             <CardActionsRow
               isCardFrozen={isCardFrozen}
-              canUnfreeze={!!canUnfreeze}
+              canToggleFreeze={canToggleFreeze}
               isFreezing={isFreezing}
               onFreezeToggle={handleFreezeToggle}
               onMorePress={() => setIsAddToWalletOpen(true)}

--- a/lib/utils/__tests__/cardFreeze.test.ts
+++ b/lib/utils/__tests__/cardFreeze.test.ts
@@ -1,0 +1,51 @@
+import { CardStatus, FreezeInitiator } from '@/lib/types';
+import { canToggleCardFreeze } from '@/lib/utils/cardHelpers';
+
+/**
+ * The card screens hide the Freeze/Unfreeze action entirely when this says no,
+ * so both directions matter: a customer locked out of their own freeze has to
+ * call support, and a customer let into a compliance freeze defeats it.
+ */
+describe('canToggleCardFreeze', () => {
+  const freeze = (initiator: FreezeInitiator) => ({
+    initiator,
+    card_account_id: 'card-1',
+    reason: 'other' as never,
+    created_at: '2026-08-16T00:00:00.000Z',
+  });
+
+  const card = (status: CardStatus, freezes: ReturnType<typeof freeze>[] = []) =>
+    ({ status, freezes }) as never;
+
+  it('offers Freeze on a live card', () => {
+    expect(canToggleCardFreeze(card(CardStatus.ACTIVE))).toBe(true);
+  });
+
+  it('offers Unfreeze on the customer’s own freeze', () => {
+    expect(canToggleCardFreeze(card(CardStatus.FROZEN, [freeze(FreezeInitiator.CUSTOMER)]))).toBe(
+      true,
+    );
+  });
+
+  it('hides the toggle on a freeze the provider put on', () => {
+    expect(canToggleCardFreeze(card(CardStatus.FROZEN, [freeze(FreezeInitiator.BRIDGE)]))).toBe(
+      false,
+    );
+    expect(canToggleCardFreeze(card(CardStatus.FROZEN, [freeze(FreezeInitiator.DEVELOPER)]))).toBe(
+      false,
+    );
+  });
+
+  it('hides the toggle when nothing is on file for a frozen card', () => {
+    // Rain and Wirex return no freeze records; the backend synthesises one and
+    // attributes anything it can't account for to the provider. An empty list is
+    // "we don't know", which is not permission.
+    expect(canToggleCardFreeze(card(CardStatus.FROZEN))).toBe(false);
+  });
+
+  it('offers Freeze before the card details have loaded', () => {
+    // An unloaded card is not a frozen one — the row should render its default
+    // action rather than dropping a column and reflowing once data arrives.
+    expect(canToggleCardFreeze(undefined)).toBe(true);
+  });
+});

--- a/lib/utils/cardHelpers.ts
+++ b/lib/utils/cardHelpers.ts
@@ -69,9 +69,7 @@ export const getAvatarColor = (name: string): string => {
  * Get a consistent color palette for transaction merchant icons
  * Returns background and text colors based on merchant name hash
  */
-export const getColorForTransaction = (
-  merchantName: string,
-): { bg: string; text: string } => {
+export const getColorForTransaction = (merchantName: string): { bg: string; text: string } => {
   const colors = [
     { bg: 'rgba(127,230,242,0.25)', text: '#7fe6f2' }, // cyan
     { bg: 'rgba(242,127,129,0.25)', text: '#f27f81' }, // red
@@ -99,10 +97,7 @@ function normalizeCardAmount(amount: string, provider?: CardProvider | null): nu
 /**
  * Format card transaction amount with proper sign and currency symbol.
  */
-export const formatCardAmount = (
-  amount: string,
-  provider?: CardProvider | null,
-): string => {
+export const formatCardAmount = (amount: string, provider?: CardProvider | null): string => {
   const numAmount = normalizeCardAmount(amount, provider);
   const sign = numAmount >= 0 ? '' : '-';
   return `${sign}$${Math.abs(numAmount).toFixed(2)}`;

--- a/lib/utils/cardHelpers.ts
+++ b/lib/utils/cardHelpers.ts
@@ -1,4 +1,44 @@
-import { CardProvider, Cashback, CashbackInfo, CashbackStatus } from '@/lib/types';
+import {
+  CardProvider,
+  CardResponse,
+  CardStatus,
+  Cashback,
+  CashbackInfo,
+  CashbackStatus,
+  FreezeInitiator,
+} from '@/lib/types';
+
+/** The freeze fields every card surface reads, so callers can pass a partial. */
+type FreezeState = Pick<CardResponse, 'status' | 'freezes'> | undefined | null;
+
+/**
+ * Whether the cardholder may lift the freeze that's currently on their card.
+ *
+ * `freezes` is the only signal for this, and it doesn't mean the same thing on
+ * every issuer: Bridge returns the provider's own records, while Rain and Wirex
+ * return none and the backend synthesises an entry from our card row. Both
+ * converge on one rule — a frozen card carries an entry naming who froze it, and
+ * only the customer's own freeze may be lifted from the app. A provider freeze
+ * (compliance, suspected fraud) has to go through support.
+ *
+ * An empty list on a frozen card is not permission: it means nothing is on file,
+ * so treat it as somebody else's freeze.
+ */
+const canCustomerUnfreezeCard = (cardDetails: FreezeState): boolean => {
+  if (cardDetails?.status !== CardStatus.FROZEN) return false;
+  return !!cardDetails.freezes?.some(freeze => freeze.initiator === FreezeInitiator.CUSTOMER);
+};
+
+/**
+ * Whether to offer the freeze toggle at all. Freezing is always available on a
+ * live card; unfreezing only when the customer's own freeze is what's in place.
+ *
+ * Shared by the card pane and the desktop header — when the two derived it
+ * separately, a fix to one silently left the other showing a different set of
+ * actions for the same card.
+ */
+export const canToggleCardFreeze = (cardDetails: FreezeState): boolean =>
+  cardDetails?.status !== CardStatus.FROZEN || canCustomerUnfreezeCard(cardDetails);
 
 /**
  * Get initials from merchant/person name for avatar display


### PR DESCRIPTION
## Summary
Extracted the card freeze toggle visibility logic into a shared utility function to prevent inconsistencies between the mobile card pane and desktop header. Previously, each component derived the freeze toggle availability independently, which could lead to them showing different actions for the same card state.

## Key Changes
- Created `canToggleCardFreeze()` utility in `cardHelpers.ts` that encapsulates the freeze toggle visibility logic
  - Returns `true` for active cards (offering freeze)
  - Returns `true` for frozen cards with a customer-initiated freeze (offering unfreeze)
  - Returns `false` for frozen cards with provider/compliance freezes or unknown freeze state
  - Handles undefined/null card state gracefully (treats as active)
- Added comprehensive test suite (`cardFreeze.test.ts`) documenting the freeze toggle behavior and edge cases
- Updated `CardDetailsPane` (mobile) and `DesktopHeader` (desktop) to use the shared utility instead of duplicating the logic
- Updated `CardActionsRow` to accept `canToggleFreeze` prop instead of `canUnfreeze`, making the intent clearer
- Added clarifying comments to component interfaces explaining the distinction between `isCardFrozen` (for labels) and `canToggleFreeze` (for visibility)

## Implementation Details
- The `FreezeState` type allows callers to pass partial card data, reducing coupling
- The logic properly handles the case where `freezes` is an empty array on a frozen card (treated as "unknown initiator" = no permission to unfreeze)
- Both the mobile and desktop implementations now derive their freeze toggle visibility from the same source of truth

https://claude.ai/code/session_01VKfPx8fKK84wyJFQgqqju7