### PR TITLE
Fix card withdrawal to use on-chain collateral balance, not spending power

### DIFF
--- a/components/Card/CardWithdrawForm.tsx
+++ b/components/Card/CardWithdrawForm.tsx
@@ -12,6 +12,7 @@ import { Button } from '@/components/ui/button';
 import Skeleton from '@/components/ui/skeleton';
 import { Text } from '@/components/ui/text';
 import { CARD_WITHDRAW_MODAL } from '@/constants/modals';
+import { useCardCollateralAvailable } from '@/hooks/useCardCollateralAvailable';
 import { useCardContracts } from '@/hooks/useCardContracts';
 import { useCardDetails } from '@/hooks/useCardDetails';
 import useUser from '@/hooks/useUser';
@@ -20,6 +21,7 @@ import { withdrawFromCard, withdrawFromCardToSavings } from '@/lib/api';
 import { EXPO_PUBLIC_CARD_FUNDING_CHAIN_ID } from '@/lib/config';
 import { CardProvider } from '@/lib/types';
 import { cn, formatNumber, getCardDepositTokenSymbol } from '@/lib/utils';
+import { toAmountInputValue } from '@/lib/utils/cardHelpers';
 import { CardDepositSource } from '@/store/useCardDepositStore';
 import { useCardWithdrawStore } from '@/store/useCardWithdrawStore';
 
@@ -33,6 +35,11 @@ export default function CardWithdrawForm() {
   const { user } = useUser();
   const { data: cardDetails, refetch, isLoading: isCardDetailsLoading } = useCardDetails();
   const { data: contracts } = useCardContracts();
+  const {
+    data: collateral,
+    refetch: refetchCollateral,
+    isLoading: isCollateralLoading,
+  } = useCardCollateralAvailable();
   const { setModal, setTransaction } = useCardWithdrawStore(
     useShallow(state => ({ setModal: state.setModal, setTransaction: state.setTransaction })),
   );
@@ -41,22 +48,30 @@ export default function CardWithdrawForm() {
   const formattedBalance = formatNumber(spendableAmount, 2, 2);
 
   const { withdrawCollateral } = useWithdrawRainCollateral();
-  // Prefer a contract that currently holds collateral (non-zero token balance).
-  // Fall back to the configured funding chain, then the first contract.
+  // Prefer the contract the backend priced the available collateral against, so
+  // the amount we validate and the contract we withdraw from cannot diverge.
+  // Fall back to a contract holding collateral, then the configured funding
+  // chain, then the first contract.
   const fundingContract =
+    contracts?.find(c => c.chainId === collateral?.chainId) ||
     contracts?.find(c => c.tokens?.some(t => Number(t.balance ?? '0') > 0)) ||
     contracts?.find(c => c.chainId === EXPO_PUBLIC_CARD_FUNDING_CHAIN_ID) ||
     contracts?.[0];
 
   const fundingTokenAddress =
+    collateral?.tokenAddress ||
     fundingContract?.tokens?.find(t => Number(t.balance ?? '0') > 0)?.address ||
     fundingContract?.tokens?.[0]?.address;
 
   const depositTokenSymbol = getCardDepositTokenSymbol(CardProvider.RAIN);
 
-  // Use card spending balance for withdraw (same as card details). Collateral API may differ.
-  const collateralAvailable = spendableAmount;
-  const collateralFormatted = formattedBalance;
+  // A collateral withdrawal moves real tokens out of the Rain collateral proxy,
+  // so it is capped by that proxy's on-chain balance — NOT by the card's
+  // spending balance, which is Rain's credit-side spending power and can be far
+  // higher (a $101.30 spending balance backed by $0.40 of USDC would offer a
+  // "Max" that Rain refuses to sign).
+  const collateralAvailable = collateral?.availableUsd ?? 0;
+  const collateralFormatted = formatNumber(collateralAvailable, 2, 2);
 
   const { control, handleSubmit, formState, watch, setValue, setError, clearErrors, trigger } =
     useForm<FormData>({
@@ -95,7 +110,10 @@ export default function CardWithdrawForm() {
           .refine(val => val !== '' && !isNaN(Number(val)), { message: 'Enter a valid amount' })
           .refine(val => Number(val) >= 1, { message: 'Minimum withdrawal is $1' })
           .refine(val => Number(val) <= collateralAvailable, {
-            message: `Amount exceeds available (${collateralFormatted} available)`,
+            message:
+              collateralAvailable > 0
+                ? `Amount exceeds available ($${collateralFormatted} available to withdraw)`
+                : 'No collateral is available to withdraw right now',
           }),
       }),
     [collateralAvailable, collateralFormatted],
@@ -104,6 +122,9 @@ export default function CardWithdrawForm() {
   const validationError = useMemo(() => {
     if (isCollateral) {
       if (!watchedAmount) return null;
+      // The available figure starts at 0 until the on-chain read lands; don't
+      // accuse the user of over-withdrawing before we know the balance.
+      if (isCollateralLoading) return null;
       const parsed = collateralSchema.safeParse({ amount: watchedAmount });
       if (parsed.success) return null;
       return parsed.error.issues[0]?.message ?? null;
@@ -116,7 +137,7 @@ export default function CardWithdrawForm() {
       const err = error as { issues?: { message?: string }[] };
       return err.issues?.[0]?.message ?? null;
     }
-  }, [watchedAmount, isCollateral, schema, collateralSchema]);
+  }, [watchedAmount, isCollateral, isCollateralLoading, schema, collateralSchema]);
 
   const onSubmit = useCallback(
     async (data: FormData) => {
@@ -180,7 +201,7 @@ export default function CardWithdrawForm() {
             chainId: fundingContract?.chainId,
           });
           setModal(CARD_WITHDRAW_MODAL.OPEN_TRANSACTION_STATUS);
-          await refetch();
+          await Promise.all([refetch(), refetchCollateral()]);
           const explorerUrl = getExplorerTxUrl(fundingContract?.chainId, txHash);
           Toast.show({
             type: 'success',
@@ -225,6 +246,9 @@ export default function CardWithdrawForm() {
         } else if (err instanceof Error) {
           message = err.message;
         }
+        // Collateral can move between the read and the submit (a charge settles,
+        // a deposit lands), so re-read it before the user retries.
+        if (toCollateral) void refetchCollateral();
         Toast.show({ type: 'error', text1: 'Withdrawal failed', text2: message });
       } finally {
         setIsSubmitting(false);
@@ -235,16 +259,27 @@ export default function CardWithdrawForm() {
       setModal,
       setTransaction,
       refetch,
+      refetchCollateral,
       schema,
       collateralSchema,
       setError,
       fundingContract?.chainId,
+      fundingTokenAddress,
       withdrawCollateral,
     ],
   );
 
+  const isAvailableLoading = isCollateral ? isCollateralLoading : isCardDetailsLoading;
   const disabled = isSubmitting;
   const availableFormatted = isCollateral ? collateralFormatted : formattedBalance;
+
+  // The card's spending balance and its withdrawable collateral are different
+  // numbers; say so when they diverge, rather than letting the user discover it
+  // through a rejected withdrawal.
+  const collateralShortfallHint =
+    isCollateral && !isCollateralLoading && collateral && collateralAvailable < spendableAmount
+      ? `Your card balance is $${formattedBalance}, but only $${collateralFormatted} is currently available to withdraw.`
+      : null;
 
   return (
     <View className="gap-3">
@@ -256,7 +291,7 @@ export default function CardWithdrawForm() {
           <View className="flex-row items-center gap-2">
             <View className="flex-row items-center gap-1">
               <WalletIcon color="#A1A1A1" size={16} />
-              {isCardDetailsLoading ? (
+              {isAvailableLoading ? (
                 <Skeleton className="h-5 w-14 rounded-md" />
               ) : (
                 <Text className="font-medium opacity-50">${availableFormatted}</Text>
@@ -264,11 +299,13 @@ export default function CardWithdrawForm() {
             </View>
             <Max
               onPress={() => {
-                const value = isCollateral ? collateralFormatted : formattedBalance;
-                setValue('amount', value);
+                setValue(
+                  'amount',
+                  toAmountInputValue(isCollateral ? collateralAvailable : spendableAmount),
+                );
                 trigger('amount');
               }}
-              disabled={isCardDetailsLoading}
+              disabled={isAvailableLoading || (isCollateral && collateralAvailable <= 0)}
             />
           </View>
         </View>
@@ -318,6 +355,8 @@ export default function CardWithdrawForm() {
         <Text className="text-sm text-red-500">
           {validationError ?? formState.errors.amount?.message}
         </Text>
+      ) : collateralShortfallHint ? (
+        <Text className="text-sm opacity-50">{collateralShortfallHint}</Text>
       ) : null}
 
       <Button

--- a/hooks/useCardCollateralAvailable.ts
+++ b/hooks/useCardCollateralAvailable.ts
@@ -1,0 +1,32 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { getCardCollateralAvailable } from '@/lib/api';
+import { CardProvider } from '@/lib/types';
+import { withRefreshToken } from '@/lib/utils';
+
+import { useCardProvider } from './useCardProvider';
+
+const CARD_COLLATERAL_AVAILABLE_KEY = 'cardCollateralAvailable';
+
+/**
+ * How much collateral the user can actually withdraw from their card, read
+ * from the collateral proxy on-chain by the backend.
+ *
+ * The card's spending balance (`useCardDetails`) is Rain's credit-side
+ * spending power and can exceed the collateral backing it, so it must not be
+ * used as the maximum on the withdraw-to-wallet screen — a withdrawal above
+ * the on-chain balance is rejected once the user has already committed to it.
+ */
+export function useCardCollateralAvailable() {
+  const { provider } = useCardProvider();
+
+  return useQuery({
+    queryKey: [CARD_COLLATERAL_AVAILABLE_KEY],
+    queryFn: () => withRefreshToken(() => getCardCollateralAvailable()),
+    enabled: provider === CardProvider.RAIN,
+    // Collateral moves when deposits settle and when charges are swept, so the
+    // withdraw screen re-reads it on the same cadence as the card balance.
+    refetchInterval: 5000,
+    retry: 2,
+  });
+}

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -35,6 +35,7 @@ import {
   BridgeTransactionRequest,
   CardAccessResponse,
   CardBalanceResponseDto,
+  CardCollateralAvailableDto,
   CardDepositBonusConfig,
   CardDetailsResponseDto,
   CardDetailsRevealResponse,
@@ -1089,6 +1090,31 @@ export const getCardContracts = async (): Promise<RainContractResponseDto[]> => 
       ...(jwt ? { Authorization: `Bearer ${jwt}` } : {}),
     },
   });
+
+  if (!response.ok) throw response;
+
+  return response.json();
+};
+
+/**
+ * Rain only: how much collateral can actually be withdrawn to the wallet, read
+ * from the collateral proxy on-chain. Use this for the withdraw screen's max —
+ * `getCardBalance` reports credit-side spending power, which can be higher than
+ * the collateral backing it. Returns 400 for Bridge.
+ */
+export const getCardCollateralAvailable = async (): Promise<CardCollateralAvailableDto> => {
+  const jwt = getJWTToken();
+
+  const response = await fetch(
+    `${EXPO_PUBLIC_FLASH_API_BASE_URL}/accounts/v1/cards/collateral/available`,
+    {
+      credentials: 'include',
+      headers: {
+        ...getPlatformHeaders(),
+        ...(jwt ? { Authorization: `Bearer ${jwt}` } : {}),
+      },
+    },
+  );
 
   if (!response.ok) throw response;
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -783,6 +783,46 @@ export interface RainContractResponseDto {
   onramp?: RainContractOnrampDto;
 }
 
+/** On-chain collateral held by one Rain collateral proxy, for one token. */
+export interface CardCollateralContractBalanceDto {
+  rainCollateralContractId: string;
+  chainId: number;
+  collateralProxy: string;
+  tokenAddress: string;
+  decimals: number;
+  /** Proxy's token balance in smallest units. */
+  rawBalance: string;
+  /** Same balance in dollars, floored to the cent. */
+  balanceUsd: number;
+  /** Set when the balance could not be read (RPC failure, unsupported chain). */
+  unavailableReason?: string;
+}
+
+/**
+ * GET /cards/collateral/available — what can actually be withdrawn from the
+ * card to the wallet right now. Distinct from `CardBalanceResponseDto`, which
+ * carries Rain's credit-side spending power: that figure can exceed the
+ * collateral on-chain, and a withdrawal above this one is rejected.
+ */
+export interface CardCollateralAvailableDto {
+  /** Withdrawable amount in dollars — the binding cap, floored to the cent. */
+  availableUsd: number;
+  /** `availableUsd` in the selected token's smallest units. */
+  availableRaw: string;
+  /** On-chain collateral of the selected contract, in dollars. */
+  onChainCollateralUsd: number;
+  /** Rain's credit-side spending power, in dollars, when known. */
+  spendingPowerUsd?: number;
+  /** Which of the two caps is currently binding. */
+  limitedBy: 'collateral' | 'spendingPower' | 'none';
+  /** Contract a withdrawal would draw from; absent when the user has none. */
+  chainId?: number;
+  collateralProxy?: string;
+  tokenAddress?: string;
+  decimals?: number;
+  contracts: CardCollateralContractBalanceDto[];
+}
+
 export type OnrampAutomationRail = 'ach' | 'wire';
 
 export interface OnrampAutomationDepositAddressDto {

--- a/lib/utils/__tests__/cardWithdrawAmount.test.ts
+++ b/lib/utils/__tests__/cardWithdrawAmount.test.ts
@@ -1,0 +1,36 @@
+import { toAmountInputValue } from '@/lib/utils/cardHelpers';
+
+describe('toAmountInputValue', () => {
+  it('produces a value the amount field can parse back', () => {
+    // `formatNumber` is display-only: it delegates to Intl.NumberFormat, which
+    // groups thousands into a string Number() cannot read. Feeding that back
+    // into the field is why "Max" on a four-figure balance failed validation.
+    const displayed = new Intl.NumberFormat('en-us', {
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
+    }).format(1234.56);
+    expect(displayed).toBe('1,234.56');
+    expect(Number(displayed)).toBeNaN();
+
+    expect(toAmountInputValue(1234.56)).toBe('1234.56');
+    expect(Number(toAmountInputValue(1234.56))).toBe(1234.56);
+  });
+
+  it('floors to the cent so Max never exceeds the real balance', () => {
+    expect(toAmountInputValue(100.949)).toBe('100.94');
+    expect(toAmountInputValue(0.409)).toBe('0.40');
+    expect(Number(toAmountInputValue(100.949))).toBeLessThanOrEqual(100.949);
+  });
+
+  it('keeps two decimals for whole and sub-dollar amounts', () => {
+    expect(toAmountInputValue(5)).toBe('5.00');
+    expect(toAmountInputValue(0.4)).toBe('0.40');
+  });
+
+  it('collapses empty, negative and non-finite balances to zero', () => {
+    expect(toAmountInputValue(0)).toBe('0');
+    expect(toAmountInputValue(-1)).toBe('0');
+    expect(toAmountInputValue(NaN)).toBe('0');
+    expect(toAmountInputValue(Infinity)).toBe('0');
+  });
+});

--- a/lib/utils/cardHelpers.ts
+++ b/lib/utils/cardHelpers.ts
@@ -95,6 +95,21 @@ function normalizeCardAmount(amount: string, provider?: CardProvider | null): nu
 }
 
 /**
+ * A balance turned into a plain numeric string an amount input can hold,
+ * floored to the cent.
+ *
+ * `formatNumber` is for display only — it groups thousands ("1,234.56"), and
+ * feeding that back into the field makes `Number()` NaN, so a "Max" press on a
+ * balance over $1,000 failed validation. Flooring rather than rounding keeps
+ * Max at or below the real balance: a maximum rounded a fraction of a cent
+ * upwards is a withdrawal the provider rejects.
+ */
+export const toAmountInputValue = (amount: number): string => {
+  if (!Number.isFinite(amount) || amount <= 0) return '0';
+  return (Math.floor(amount * 100) / 100).toFixed(2);
+};
+
+/**
  * Format card transaction amount with proper sign and currency symbol.
  */
 export const formatCardAmount = (amount: string, provider?: CardProvider | null): string => {


### PR DESCRIPTION
## Summary
This PR fixes a critical issue where the card withdrawal form was using the card's spending balance (Rain's credit-side spending power) as the maximum withdrawal amount, when it should use the actual on-chain collateral balance. This caused withdrawals to be rejected after the user committed to them if the spending balance exceeded the collateral backing it.

## Key Changes

- **New API endpoint**: Added `getCardCollateralAvailable()` to fetch the actual withdrawable collateral amount from the backend, which reads the collateral proxy's on-chain balance
- **New hook**: Created `useCardCollateralAvailable()` to query and cache the collateral availability with 5-second refetch intervals (matching card balance refresh cadence)
- **New types**: Added `CardCollateralAvailableDto` and `CardCollateralContractBalanceDto` to represent on-chain collateral data
- **Form validation**: Updated withdrawal validation to use on-chain collateral balance instead of spending balance, with improved error messaging that distinguishes between "no collateral available" and "exceeds available"
- **Contract selection**: Modified funding contract selection to prefer the contract the backend priced the collateral against, ensuring the validated amount and withdrawal source cannot diverge
- **Amount input helper**: Added `toAmountInputValue()` utility to convert numeric balances to input-safe strings (floored to the cent, no thousand separators) to fix "Max" button failures on balances over $1,000
- **User feedback**: Added a hint message when the card's spending balance exceeds withdrawable collateral, explaining the discrepancy
- **Error recovery**: Added collateral re-fetch on withdrawal failure to account for balance changes between read and submit

## Notable Implementation Details

- The collateral balance is read on-chain by the backend to avoid RPC calls from the client
- Collateral availability is floored to the cent to ensure "Max" never exceeds the real balance
- Loading state is properly handled to avoid false validation errors while the collateral balance is being fetched
- Both card details and collateral are refetched after a successful withdrawal to keep UI in sync

https://claude.ai/code/session_01BVUpcPpGFF9w4VxH4rvT9r