### PR TITLE
Add app open tracking and card deposit store review trigger

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -40,6 +40,7 @@ import AppErrorBoundary from '@/components/ErrorBoundary';
 import Intercom from '@/components/Intercom/index';
 import { LazyThirdwebProvider } from '@/components/LazyThirdwebProvider';
 import LazyWhatsNewModal from '@/components/LazyWhatsNewModal';
+import CardDepositStoreReviewTrigger from '@/components/StoreReview/CardDepositStoreReviewTrigger';
 import CashbackStoreReviewTrigger from '@/components/StoreReview/CashbackStoreReviewTrigger';
 import ThirdwebConnectionBridge from '@/components/ThirdwebConnectionBridge';
 import { toastProps } from '@/components/Toast';
@@ -447,7 +448,12 @@ function RootLayout() {
                       {hasSelectedUser && params.notificationPermission !== 'open' && (
                         <WhatsNewWrapper />
                       )}
-                      {hasSelectedUser && Platform.OS !== 'web' && <CashbackStoreReviewTrigger />}
+                      {hasSelectedUser && Platform.OS !== 'web' && (
+                        <>
+                          <CashbackStoreReviewTrigger />
+                          <CardDepositStoreReviewTrigger />
+                        </>
+                      )}
                     </BottomSheetModalProvider>
                   </GestureHandlerRootView>
                 </Intercom>

--- a/components/StoreReview/CardDepositStoreReviewTrigger.tsx
+++ b/components/StoreReview/CardDepositStoreReviewTrigger.tsx
@@ -1,0 +1,12 @@
+import { useCardDepositStoreReview } from '@/hooks/useCardDepositStoreReview';
+
+/**
+ * Headless component that records app opens and asks the user to rate the app
+ * (via the native in-app store review sheet) once they've funded their card
+ * twice and come back to it. Renders nothing; mount it once inside the
+ * authenticated app tree.
+ */
+export default function CardDepositStoreReviewTrigger() {
+  useCardDepositStoreReview();
+  return null;
+}

--- a/hooks/useCardDepositStoreReview.ts
+++ b/hooks/useCardDepositStoreReview.ts
@@ -1,0 +1,129 @@
+import { useCallback, useEffect, useRef } from 'react';
+import { AppState, Platform } from 'react-native';
+
+import { useStoreReview } from '@/hooks/useStoreReview';
+import { getAmplitudeDeviceId } from '@/lib/analytics';
+import { markStoreReviewPrompted, recordAppOpen } from '@/lib/api';
+import { StoreReviewDecisionReason } from '@/lib/types';
+import { nextAppOpenState, shouldRecordAppOpen } from '@/lib/utils/appOpen';
+import { useUserStore } from '@/store/useUserStore';
+
+// Small settle delay so the rating sheet lands at a resting moment rather than
+// on top of a still-rendering home screen. Matches the cashback trigger.
+const REVIEW_PROMPT_DELAY_MS = 2000;
+
+// The backend owns the real spacing between prompts for this trigger (30 days
+// plus "a new deposit since last time"), so the local guard only needs to be
+// loose enough not to override it — the default 120 days would.
+const REVIEW_REQUEST_COOLDOWN_MS = 1000 * 60 * 60 * 24 * 30; // 30 days
+
+/**
+ * Records every app open on the backend and asks for an in-app store review when
+ * the backend says this open qualifies — today that means the user has funded
+ * their card at least twice and has come back to the app.
+ *
+ * Eligibility deliberately lives server-side: it needs the card deposit count
+ * from `rainCollateralTransactions`, and keeping the prompt history in the
+ * `appOpens` collection means a reinstall (which wipes device storage) can't
+ * reset the cooldown. This hook only decides *when* an open happened, and
+ * surfaces the sheet when told to.
+ *
+ * Runs headlessly (renders nothing) and is a no-op on web, which has no native
+ * review sheet.
+ */
+export const useCardDepositStoreReview = () => {
+  const { requestReview } = useStoreReview();
+
+  const isAuthenticated = useUserStore(state =>
+    state.users.some(u => u.selected && !!u.tokens?.accessToken),
+  );
+
+  // Epoch ms of when the app last left the foreground; null while in front.
+  const backgroundedAtRef = useRef<number | null>(null);
+  const appStateRef = useRef(AppState.currentState);
+  // Guards against two opens being reported at once (e.g. a foreground event
+  // landing while the launch request is still in flight).
+  const isRecordingRef = useRef(false);
+  // Epoch ms of the last open we reported, so a re-mount or a brief blip in the
+  // auth state can't book a second open for the same session. A genuine
+  // foreground open is always at least one session gap after the last one.
+  const lastRecordedAtRef = useRef<number | null>(null);
+  const promptTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const handleAppOpen = useCallback(async () => {
+    const now = Date.now();
+    if (isRecordingRef.current) return;
+    if (!shouldRecordAppOpen(lastRecordedAtRef.current, now)) return;
+    isRecordingRef.current = true;
+    lastRecordedAtRef.current = now;
+
+    try {
+      const { shouldRequestReview, reason } = await recordAppOpen(
+        Platform.OS,
+        getAmplitudeDeviceId(),
+      );
+
+      if (!shouldRequestReview || reason !== StoreReviewDecisionReason.ELIGIBLE) return;
+
+      promptTimerRef.current = setTimeout(() => {
+        promptTimerRef.current = null;
+
+        void (async () => {
+          const wasPrompted = await requestReview({
+            trigger: 'card_deposits',
+            cooldownMs: REVIEW_REQUEST_COOLDOWN_MS,
+          });
+
+          // Only start the server-side cooldown if the sheet really was
+          // invoked; the OS quota can swallow it, and a prompt the user never
+          // saw shouldn't silence the trigger for a month.
+          if (!wasPrompted) return;
+
+          try {
+            await markStoreReviewPrompted(Platform.OS);
+          } catch {
+            console.warn('Failed to record store review prompt');
+          }
+        })();
+      }, REVIEW_PROMPT_DELAY_MS);
+    } catch {
+      // Passive telemetry behind a rating prompt — never surface this.
+      console.warn('Failed to record app open');
+    } finally {
+      isRecordingRef.current = false;
+    }
+  }, [requestReview]);
+
+  useEffect(() => {
+    if (Platform.OS === 'web') return;
+    if (!isAuthenticated) return;
+
+    // The mount itself is an open: this hook is mounted once the user is
+    // authenticated, either at launch or right after signing in.
+    void handleAppOpen();
+
+    const subscription = AppState.addEventListener('change', nextAppState => {
+      const { backgroundedAt, isNewOpen } = nextAppOpenState({
+        previousState: appStateRef.current,
+        nextState: nextAppState,
+        backgroundedAt: backgroundedAtRef.current,
+        now: Date.now(),
+      });
+
+      appStateRef.current = nextAppState;
+      backgroundedAtRef.current = backgroundedAt;
+
+      if (isNewOpen) {
+        void handleAppOpen();
+      }
+    });
+
+    return () => {
+      subscription.remove();
+      if (promptTimerRef.current) {
+        clearTimeout(promptTimerRef.current);
+        promptTimerRef.current = null;
+      }
+    };
+  }, [isAuthenticated, handleAppOpen]);
+};

--- a/hooks/useStoreReview.ts
+++ b/hooks/useStoreReview.ts
@@ -6,14 +6,22 @@ import { TRACKING_EVENTS } from '@/constants/tracking-events';
 import { track } from '@/lib/analytics';
 import { useStoreReviewStore } from '@/store/useStoreReviewStore';
 
-// Minimum time between two native review prompts. The OS enforces its own quota
-// (iOS shows the sheet at most a few times a year; Android is quota-limited too),
-// but we add a generous cooldown so we never nag a user who keeps earning cashback.
-const REVIEW_REQUEST_COOLDOWN_MS = 1000 * 60 * 60 * 24 * 120; // 120 days
+// Default minimum time between two native review prompts. The OS enforces its
+// own quota (iOS shows the sheet at most a few times a year; Android is
+// quota-limited too), but we add a generous cooldown so we never nag a user who
+// keeps earning cashback. Triggers with their own server-side gating can pass a
+// shorter `cooldownMs`.
+export const DEFAULT_REVIEW_REQUEST_COOLDOWN_MS = 1000 * 60 * 60 * 24 * 120; // 120 days
 
 interface RequestReviewOptions {
   /** Free-form context for analytics, e.g. what triggered the prompt. */
   trigger?: string;
+  /**
+   * Overrides the local cooldown for this call. Use it when the trigger already
+   * enforces its own (e.g. server-side) spacing and the default 120 days would
+   * suppress a prompt that should be allowed.
+   */
+  cooldownMs?: number;
   [key: string]: unknown;
 }
 
@@ -23,49 +31,59 @@ interface RequestReviewOptions {
  * caller — this hook only owns availability checks, cooldown, foreground guard,
  * and analytics. It never opens the store listing (that would leave the app),
  * so it no-ops whenever the native in-app prompt isn't available.
+ *
+ * Resolves to true only when the native sheet was actually requested, so callers
+ * can record the prompt (locally or server-side) without guessing.
  */
 export const useStoreReview = () => {
-  const requestReview = useCallback(async (options: RequestReviewOptions = {}) => {
-    // The native in-app prompt only exists on iOS/Android.
-    if (Platform.OS === 'web') return;
+  const requestReview = useCallback(
+    async (options: RequestReviewOptions = {}): Promise<boolean> => {
+      const { cooldownMs = DEFAULT_REVIEW_REQUEST_COOLDOWN_MS, ...context } = options;
 
-    const { lastReviewRequestAt } = useStoreReviewStore.getState();
+      // The native in-app prompt only exists on iOS/Android.
+      if (Platform.OS === 'web') return false;
 
-    // Respect our own cooldown before touching the SDK.
-    if (lastReviewRequestAt && Date.now() - lastReviewRequestAt < REVIEW_REQUEST_COOLDOWN_MS) {
-      track(TRACKING_EVENTS.STORE_REVIEW_SKIPPED, { reason: 'cooldown', ...options });
-      return;
-    }
+      const { lastReviewRequestAt } = useStoreReviewStore.getState();
 
-    // Don't surface the sheet while the app is backgrounded/transitioning.
-    if (AppState.currentState !== 'active') {
-      track(TRACKING_EVENTS.STORE_REVIEW_SKIPPED, { reason: 'not_active', ...options });
-      return;
-    }
-
-    try {
-      const isAvailable = await StoreReview.isAvailableAsync();
-      if (!isAvailable) {
-        track(TRACKING_EVENTS.STORE_REVIEW_UNAVAILABLE, { reason: 'not_available', ...options });
-        return;
+      // Respect our own cooldown before touching the SDK.
+      if (lastReviewRequestAt && Date.now() - lastReviewRequestAt < cooldownMs) {
+        track(TRACKING_EVENTS.STORE_REVIEW_SKIPPED, { reason: 'cooldown', ...context });
+        return false;
       }
 
-      // Re-check foreground state after the async availability call.
+      // Don't surface the sheet while the app is backgrounded/transitioning.
       if (AppState.currentState !== 'active') {
-        track(TRACKING_EVENTS.STORE_REVIEW_SKIPPED, { reason: 'not_active', ...options });
-        return;
+        track(TRACKING_EVENTS.STORE_REVIEW_SKIPPED, { reason: 'not_active', ...context });
+        return false;
       }
 
-      await StoreReview.requestReview();
-      useStoreReviewStore.getState().recordReviewRequest(Date.now());
-      track(TRACKING_EVENTS.STORE_REVIEW_REQUESTED, options);
-    } catch (error) {
-      track(TRACKING_EVENTS.STORE_REVIEW_ERROR, {
-        message: error instanceof Error ? error.message : String(error),
-        ...options,
-      });
-    }
-  }, []);
+      try {
+        const isAvailable = await StoreReview.isAvailableAsync();
+        if (!isAvailable) {
+          track(TRACKING_EVENTS.STORE_REVIEW_UNAVAILABLE, { reason: 'not_available', ...context });
+          return false;
+        }
+
+        // Re-check foreground state after the async availability call.
+        if (AppState.currentState !== 'active') {
+          track(TRACKING_EVENTS.STORE_REVIEW_SKIPPED, { reason: 'not_active', ...context });
+          return false;
+        }
+
+        await StoreReview.requestReview();
+        useStoreReviewStore.getState().recordReviewRequest(Date.now());
+        track(TRACKING_EVENTS.STORE_REVIEW_REQUESTED, context);
+        return true;
+      } catch (error) {
+        track(TRACKING_EVENTS.STORE_REVIEW_ERROR, {
+          message: error instanceof Error ? error.message : String(error),
+          ...context,
+        });
+        return false;
+      }
+    },
+    [],
+  );
 
   return { requestReview };
 };

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -27,6 +27,7 @@ import {
   AddressBookResponse,
   AgentApiKeySummary,
   AgentSummary,
+  AppOpenResponse,
   APYsByAsset,
   BridgeCustomerEndorsement,
   BridgeCustomerResponse,
@@ -98,6 +99,7 @@ import {
   SavingsSummaryResponse,
   SearchCoin,
   SourceDepositInstructions,
+  StoreReviewPromptedResponse,
   SubmitPersonaKycResponse,
   SumsubSessionFlow,
   SumsubSessionResponse,
@@ -3305,6 +3307,57 @@ export const trackUserPlatform = async (platform: typeof Platform.OS) => {
     body: JSON.stringify({ platform }),
   });
   if (!response.ok) throw response;
+};
+
+/**
+ * Record that the user opened the app (launch or return to the foreground) and
+ * read back whether this open should surface the native in-app review sheet.
+ * The eligibility rules — card deposits, cooldown — live on the backend so they
+ * survive a reinstall and can be tuned without shipping an app update.
+ */
+export const recordAppOpen = async (
+  platform: typeof Platform.OS,
+  deviceId?: string,
+): Promise<AppOpenResponse> => {
+  const jwt = getJWTToken();
+  const response = await fetch(`${EXPO_PUBLIC_FLASH_API_BASE_URL}/accounts/v1/app-opens`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...getPlatformHeaders(),
+      ...(jwt ? { Authorization: `Bearer ${jwt}` } : {}),
+    },
+    credentials: 'include',
+    body: JSON.stringify({
+      platform,
+      appVersion: Application.nativeApplicationVersion ?? undefined,
+      deviceId,
+    }),
+  });
+  if (!response.ok) throw response;
+  return response.json();
+};
+
+/** Confirm the native review sheet was actually invoked, starting its cooldown. */
+export const markStoreReviewPrompted = async (
+  platform: typeof Platform.OS,
+): Promise<StoreReviewPromptedResponse> => {
+  const jwt = getJWTToken();
+  const response = await fetch(
+    `${EXPO_PUBLIC_FLASH_API_BASE_URL}/accounts/v1/app-opens/review-prompted`,
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        ...getPlatformHeaders(),
+        ...(jwt ? { Authorization: `Bearer ${jwt}` } : {}),
+      },
+      credentials: 'include',
+      body: JSON.stringify({ platform }),
+    },
+  );
+  if (!response.ok) throw response;
+  return response.json();
 };
 
 export const fetchSavingsSummary = async (

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -2175,3 +2175,34 @@ export interface ReferralSummary {
   hasActiveCard: boolean;
   referrals: ReferralRewardListItem[];
 }
+
+/**
+ * Why the backend did — or did not — ask the app to show the native in-app
+ * review sheet on this app open. Mirrors the accounts-service decision enum.
+ */
+export enum StoreReviewDecisionReason {
+  ELIGIBLE = 'eligible',
+  UNSUPPORTED_PLATFORM = 'unsupported_platform',
+  NOT_ENOUGH_DEPOSITS = 'not_enough_deposits',
+  NOT_ENOUGH_OPENS = 'not_enough_opens',
+  COOLDOWN = 'cooldown',
+  NO_NEW_DEPOSITS = 'no_new_deposits',
+}
+
+/** Response to recording an app open (`POST /accounts/v1/app-opens`). */
+export interface AppOpenResponse {
+  /** Opens recorded for this user on this platform, including the current one. */
+  openCount: number;
+  lastOpenedAt: string;
+  /** Deposits the user has made to their card, per the backend. */
+  cardDepositCount: number;
+  /** True when the app should show the native review sheet now. */
+  shouldRequestReview: boolean;
+  reason: StoreReviewDecisionReason;
+}
+
+/** Response to confirming the review sheet was shown. */
+export interface StoreReviewPromptedResponse {
+  reviewPromptCount: number;
+  lastReviewPromptedAt: string;
+}

--- a/lib/utils/__tests__/appOpen.test.ts
+++ b/lib/utils/__tests__/appOpen.test.ts
@@ -1,0 +1,145 @@
+/// <reference types="jest" />
+import {
+  isBackgroundedState,
+  isNewAppOpen,
+  MIN_BACKGROUND_MS_FOR_NEW_OPEN,
+  nextAppOpenState,
+  shouldRecordAppOpen,
+} from '@/lib/utils/appOpen';
+
+const NOW = 1_800_000_000_000;
+
+describe('isBackgroundedState', () => {
+  it('treats background and inactive as away from the foreground', () => {
+    expect(isBackgroundedState('background')).toBe(true);
+    expect(isBackgroundedState('inactive')).toBe(true);
+  });
+
+  it('treats active as in the foreground', () => {
+    expect(isBackgroundedState('active')).toBe(false);
+  });
+});
+
+describe('isNewAppOpen', () => {
+  it('is true once the app was away for the session gap', () => {
+    expect(isNewAppOpen(NOW - MIN_BACKGROUND_MS_FOR_NEW_OPEN, NOW)).toBe(true);
+    expect(isNewAppOpen(NOW - MIN_BACKGROUND_MS_FOR_NEW_OPEN * 3, NOW)).toBe(true);
+  });
+
+  it('is false for the brief detours native flows cause', () => {
+    // Passkey sheet, biometrics, copying a code from another app.
+    expect(isNewAppOpen(NOW - 2000, NOW)).toBe(false);
+    expect(isNewAppOpen(NOW - MIN_BACKGROUND_MS_FOR_NEW_OPEN + 1, NOW)).toBe(false);
+  });
+
+  it('is false when the app was never seen leaving the foreground', () => {
+    expect(isNewAppOpen(null, NOW)).toBe(false);
+  });
+
+  it('honours a custom gap', () => {
+    expect(isNewAppOpen(NOW - 5000, NOW, 1000)).toBe(true);
+    expect(isNewAppOpen(NOW - 500, NOW, 1000)).toBe(false);
+  });
+});
+
+describe('shouldRecordAppOpen', () => {
+  it('always records the first open', () => {
+    expect(shouldRecordAppOpen(null, NOW)).toBe(true);
+  });
+
+  it('records again once a session gap has passed', () => {
+    expect(shouldRecordAppOpen(NOW - MIN_BACKGROUND_MS_FOR_NEW_OPEN, NOW)).toBe(true);
+  });
+
+  it('drops a duplicate from a re-mount or an auth-state blip', () => {
+    expect(shouldRecordAppOpen(NOW - 200, NOW)).toBe(false);
+  });
+});
+
+describe('nextAppOpenState', () => {
+  it('stamps the time the app left the foreground', () => {
+    expect(
+      nextAppOpenState({
+        previousState: 'active',
+        nextState: 'background',
+        backgroundedAt: null,
+        now: NOW,
+      }),
+    ).toEqual({ backgroundedAt: NOW, isNewOpen: false });
+  });
+
+  it('keeps the first timestamp across the inactive → background sequence', () => {
+    const afterInactive = nextAppOpenState({
+      previousState: 'active',
+      nextState: 'inactive',
+      backgroundedAt: null,
+      now: NOW,
+    });
+
+    const afterBackground = nextAppOpenState({
+      previousState: 'inactive',
+      nextState: 'background',
+      backgroundedAt: afterInactive.backgroundedAt,
+      now: NOW + 1500,
+    });
+
+    expect(afterBackground).toEqual({ backgroundedAt: NOW, isNewOpen: false });
+  });
+
+  it('reports a new open when the app comes back after the session gap', () => {
+    expect(
+      nextAppOpenState({
+        previousState: 'background',
+        nextState: 'active',
+        backgroundedAt: NOW - MIN_BACKGROUND_MS_FOR_NEW_OPEN,
+        now: NOW,
+      }),
+    ).toEqual({ backgroundedAt: null, isNewOpen: true });
+  });
+
+  it('clears the timestamp without an open for a quick return', () => {
+    expect(
+      nextAppOpenState({
+        previousState: 'inactive',
+        nextState: 'active',
+        backgroundedAt: NOW - 3000,
+        now: NOW,
+      }),
+    ).toEqual({ backgroundedAt: null, isNewOpen: false });
+  });
+
+  it('ignores an active event that did not follow a background state', () => {
+    expect(
+      nextAppOpenState({
+        previousState: 'active',
+        nextState: 'active',
+        backgroundedAt: null,
+        now: NOW,
+      }),
+    ).toEqual({ backgroundedAt: null, isNewOpen: false });
+  });
+
+  it('leaves state untouched for unknown transitions', () => {
+    expect(
+      nextAppOpenState({
+        previousState: 'background',
+        nextState: 'unknown',
+        backgroundedAt: NOW - 10_000,
+        now: NOW,
+      }),
+    ).toEqual({ backgroundedAt: NOW - 10_000, isNewOpen: false });
+  });
+
+  it('does not report an open when the app was already in front at launch', () => {
+    // Mount-time open is recorded explicitly; a foreground event without a
+    // recorded background must not double-count it.
+    expect(
+      nextAppOpenState({
+        previousState: 'inactive',
+        nextState: 'active',
+        backgroundedAt: null,
+        now: NOW,
+      }),
+    ).toEqual({ backgroundedAt: null, isNewOpen: false });
+  });
+});

--- a/lib/utils/appOpen.ts
+++ b/lib/utils/appOpen.ts
@@ -1,0 +1,94 @@
+import type { AppStateStatus } from 'react-native';
+
+/**
+ * How long the app has to stay backgrounded before coming back counts as a new
+ * "app open" rather than a continuation of the same session.
+ *
+ * Native flows bounce the app through `inactive`/`background` constantly —
+ * passkey and biometric sheets, the OS share sheet, copying a code from another
+ * app — and none of those are the user opening the app. Five minutes is the
+ * usual session cut-off, and keeping it here means brief detours neither inflate
+ * the open count nor spend an app-open request.
+ */
+export const MIN_BACKGROUND_MS_FOR_NEW_OPEN = 5 * 60 * 1000;
+
+/** True for the states that mean the app is no longer in front of the user. */
+export const isBackgroundedState = (state: AppStateStatus): boolean =>
+  state === 'background' || state === 'inactive';
+
+/**
+ * True when a return to the foreground should be recorded as a fresh app open.
+ * `backgroundedAt` is epoch ms of when the app left the foreground, or null if
+ * we never saw it leave (in which case there is nothing new to record).
+ */
+export const isNewAppOpen = (
+  backgroundedAt: number | null,
+  now: number,
+  minBackgroundMs: number = MIN_BACKGROUND_MS_FOR_NEW_OPEN,
+): boolean => {
+  if (backgroundedAt === null) return false;
+  return now - backgroundedAt >= minBackgroundMs;
+};
+
+/**
+ * True when an open should be reported given when we last reported one.
+ * `lastRecordedAt` is null before the first report, which always counts.
+ *
+ * Note the deliberate asymmetry with {@link isNewAppOpen}: there, null means the
+ * app was never seen leaving the foreground, so there is nothing new to record.
+ */
+export const shouldRecordAppOpen = (
+  lastRecordedAt: number | null,
+  now: number,
+  minGapMs: number = MIN_BACKGROUND_MS_FOR_NEW_OPEN,
+): boolean => {
+  if (lastRecordedAt === null) return true;
+  return now - lastRecordedAt >= minGapMs;
+};
+
+export interface AppOpenTransitionInput {
+  previousState: AppStateStatus;
+  nextState: AppStateStatus;
+  /** Epoch ms of when the app left the foreground; null while it is in front. */
+  backgroundedAt: number | null;
+  now: number;
+  minBackgroundMs?: number;
+}
+
+export interface AppOpenTransition {
+  /** Value to carry into the next transition. */
+  backgroundedAt: number | null;
+  /** True when this transition is a fresh app open worth recording. */
+  isNewOpen: boolean;
+}
+
+/**
+ * Fold one `AppState` change into the app-open tracking state.
+ *
+ * Kept as a pure function because the interesting part is the sequencing: iOS
+ * emits `active → inactive → background` on the way out and
+ * `background → inactive → active` on the way back, so only the *first*
+ * background timestamp may be kept (otherwise the clock restarts on the way
+ * out) and only a transition that ends in `active` can be an open.
+ */
+export const nextAppOpenState = ({
+  previousState,
+  nextState,
+  backgroundedAt,
+  now,
+  minBackgroundMs,
+}: AppOpenTransitionInput): AppOpenTransition => {
+  if (isBackgroundedState(nextState)) {
+    return { backgroundedAt: backgroundedAt ?? now, isNewOpen: false };
+  }
+
+  // Only a background/inactive → active transition can be a new open.
+  if (nextState !== 'active' || !isBackgroundedState(previousState)) {
+    return { backgroundedAt, isNewOpen: false };
+  }
+
+  return {
+    backgroundedAt: null,
+    isNewOpen: isNewAppOpen(backgroundedAt, now, minBackgroundMs),
+  };
+};


### PR DESCRIPTION
## Summary
Implements app open tracking on the backend and adds a new store review trigger for users who have made card deposits. The feature records every app open/foreground return and prompts users to rate the app via the native in-app review sheet when they meet eligibility criteria (2+ card deposits and returning to the app).

## Key Changes

- **App Open Tracking Utilities** (`lib/utils/appOpen.ts`):
  - Added pure functions to track app state transitions and determine when an app open should be recorded
  - Implements 5-minute session gap threshold to distinguish genuine app opens from native flow interruptions (passkey sheets, biometrics, etc.)
  - Handles iOS's `active → inactive → background` state sequence correctly

- **Card Deposit Store Review Hook** (`hooks/useCardDepositStoreReview.ts`):
  - New hook that records app opens to the backend and surfaces the native review sheet when eligible
  - Tracks app state changes and prevents duplicate open recordings during re-mounts or auth state blips
  - Implements 2-second delay before showing the review sheet for better UX
  - Server-side eligibility rules ensure the feature survives reinstalls and can be tuned without app updates

- **Store Review Hook Enhancement** (`hooks/useStoreReview.ts`):
  - Modified `requestReview()` to accept optional `cooldownMs` parameter for trigger-specific cooldowns
  - Now returns a boolean indicating whether the native sheet was actually invoked
  - Exported `DEFAULT_REVIEW_REQUEST_COOLDOWN_MS` constant for reuse
  - Allows triggers with server-side gating (like card deposits) to use shorter local cooldowns

- **API Endpoints** (`lib/api.ts`):
  - Added `recordAppOpen()` to POST app opens and receive eligibility decision
  - Added `markStoreReviewPrompted()` to confirm the review sheet was shown and start server-side cooldown

- **Type Definitions** (`lib/types.ts`):
  - Added `StoreReviewDecisionReason` enum for backend eligibility reasons
  - Added `AppOpenResponse` and `StoreReviewPromptedResponse` interfaces

- **UI Component** (`components/StoreReview/CardDepositStoreReviewTrigger.tsx`):
  - Headless component that mounts the card deposit review hook in the authenticated app tree

- **App Layout** (`app/_layout.tsx`):
  - Integrated `CardDepositStoreReviewTrigger` into the authenticated app tree

## Implementation Details

- App open detection uses a pure state machine approach (`nextAppOpenState`) for testability and clarity
- Prevents double-recording through local tracking of the last recorded open timestamp
- Respects both local cooldowns and server-side eligibility rules
- Gracefully handles OS quota limits and unavailable review sheets
- Comprehensive test coverage for all app state transition scenarios

https://claude.ai/code/session_01QdcLe43142Y5oa8afA5inV