### PR TITLE
feat(card): let users pick which collateral asset to withdraw

### DIFF
--- a/components/Card/CardWithdrawForm.tsx
+++ b/components/Card/CardWithdrawForm.tsx
@@ -6,14 +6,13 @@ import { Wallet as WalletIcon } from 'lucide-react-native';
 import { z } from 'zod';
 import { useShallow } from 'zustand/react/shallow';
 
-import ToDestinationSelector from '@/components/Card/ToDestinationSelector';
+import ToDestinationSelector, { assetLabel } from '@/components/Card/ToDestinationSelector';
 import Max from '@/components/Max';
 import { Button } from '@/components/ui/button';
 import Skeleton from '@/components/ui/skeleton';
 import { Text } from '@/components/ui/text';
 import { CARD_WITHDRAW_MODAL } from '@/constants/modals';
 import { useCardCollateralAvailable } from '@/hooks/useCardCollateralAvailable';
-import { useCardContracts } from '@/hooks/useCardContracts';
 import { useCardDetails } from '@/hooks/useCardDetails';
 import useUser from '@/hooks/useUser';
 import useWithdrawRainCollateral from '@/hooks/useWithdrawRainCollateral';
@@ -34,12 +33,14 @@ function getExplorerTxUrl(_chainId: number | undefined, txHash: string): string 
 export default function CardWithdrawForm() {
   const { user } = useUser();
   const { data: cardDetails, refetch, isLoading: isCardDetailsLoading } = useCardDetails();
-  const { data: contracts } = useCardContracts();
+  // Undefined until the user picks: the backend then opens on the richest
+  // asset, which is the one worth withdrawing.
+  const [selectedTokenAddress, setSelectedTokenAddress] = useState<string | undefined>();
   const {
     data: collateral,
     refetch: refetchCollateral,
     isLoading: isCollateralLoading,
-  } = useCardCollateralAvailable();
+  } = useCardCollateralAvailable(selectedTokenAddress);
   const { setModal, setTransaction } = useCardWithdrawStore(
     useShallow(state => ({ setModal: state.setModal, setTransaction: state.setTransaction })),
   );
@@ -48,28 +49,23 @@ export default function CardWithdrawForm() {
   const formattedBalance = formatNumber(spendableAmount, 2, 2);
 
   const { withdrawCollateral } = useWithdrawRainCollateral();
-  // Prefer the contract the backend priced the available collateral against, so
-  // the amount we validate and the contract we withdraw from cannot diverge.
-  // Fall back to a contract holding collateral, then the configured funding
-  // chain, then the first contract.
-  const fundingContract =
-    contracts?.find(c => c.chainId === collateral?.chainId) ||
-    contracts?.find(c => c.tokens?.some(t => Number(t.balance ?? '0') > 0)) ||
-    contracts?.find(c => c.chainId === EXPO_PUBLIC_CARD_FUNDING_CHAIN_ID) ||
-    contracts?.[0];
 
-  const fundingTokenAddress =
-    collateral?.tokenAddress ||
-    fundingContract?.tokens?.find(t => Number(t.balance ?? '0') > 0)?.address ||
-    fundingContract?.tokens?.[0]?.address;
+  // The asset the withdrawal will actually move. The backend priced
+  // `availableUsd` against exactly this token, so taking chain + address from
+  // the same response keeps the validated amount and the signed withdrawal on
+  // the same asset.
+  const withdrawChainId = collateral?.chainId ?? EXPO_PUBLIC_CARD_FUNDING_CHAIN_ID;
+  const fundingTokenAddress = collateral?.tokenAddress;
 
   const depositTokenSymbol = getCardDepositTokenSymbol(CardProvider.RAIN);
+  const assetSymbol = collateral?.symbol || depositTokenSymbol;
 
   // A collateral withdrawal moves real tokens out of the Rain collateral proxy,
-  // so it is capped by that proxy's on-chain balance — NOT by the card's
-  // spending balance, which is Rain's credit-side spending power and can be far
-  // higher (a $101.30 spending balance backed by $0.40 of USDC would offer a
-  // "Max" that Rain refuses to sign).
+  // so it is capped by that proxy's on-chain balance of THIS asset — not by the
+  // card's spending balance, which is Rain's credit-side spending power and is
+  // credited against every asset at once. A $100.60 spending balance can sit on
+  // $100.53 of USDT and $0.42 of USDC; only one of those is withdrawable per
+  // transaction, and neither equals the balance.
   const collateralAvailable = collateral?.availableUsd ?? 0;
   const collateralFormatted = formatNumber(collateralAvailable, 2, 2);
 
@@ -110,13 +106,15 @@ export default function CardWithdrawForm() {
           .refine(val => val !== '' && !isNaN(Number(val)), { message: 'Enter a valid amount' })
           .refine(val => Number(val) >= 1, { message: 'Minimum withdrawal is $1' })
           .refine(val => Number(val) <= collateralAvailable, {
+            // Name the asset: "$0.42 available" is baffling next to a $100.60
+            // card balance unless it says which asset that $0.42 is.
             message:
               collateralAvailable > 0
-                ? `Amount exceeds available ($${collateralFormatted} available to withdraw)`
-                : 'No collateral is available to withdraw right now',
+                ? `Amount exceeds available ($${collateralFormatted} of ${assetSymbol} available to withdraw)`
+                : `No ${assetSymbol} is available to withdraw right now`,
           }),
       }),
-    [collateralAvailable, collateralFormatted],
+    [collateralAvailable, collateralFormatted, assetSymbol],
   );
 
   const validationError = useMemo(() => {
@@ -189,7 +187,7 @@ export default function CardWithdrawForm() {
           const res = await withdrawCollateral({
             amount: data.amount,
             recipientAddress: user!.safeAddress!,
-            ...(fundingContract?.chainId != null && { chainId: fundingContract.chainId }),
+            ...(withdrawChainId != null && { chainId: withdrawChainId }),
             ...(fundingTokenAddress && { tokenAddress: fundingTokenAddress }),
           });
           const txHash = res.transactionHash;
@@ -198,15 +196,15 @@ export default function CardWithdrawForm() {
             clientTxId: txHash,
             to: data.to,
             transactionHash: txHash,
-            chainId: fundingContract?.chainId,
+            chainId: withdrawChainId,
           });
           setModal(CARD_WITHDRAW_MODAL.OPEN_TRANSACTION_STATUS);
           await Promise.all([refetch(), refetchCollateral()]);
-          const explorerUrl = getExplorerTxUrl(fundingContract?.chainId, txHash);
+          const explorerUrl = getExplorerTxUrl(withdrawChainId, txHash);
           Toast.show({
             type: 'success',
             text1: 'Withdrawal started',
-            text2: `$${data.amount} collateral withdrawal.`,
+            text2: `$${data.amount} ${assetSymbol} collateral withdrawal.`,
             onPress: () => Linking.openURL(explorerUrl),
             props: { badgeText: 'Onchain' },
           });
@@ -263,8 +261,9 @@ export default function CardWithdrawForm() {
       schema,
       collateralSchema,
       setError,
-      fundingContract?.chainId,
+      withdrawChainId,
       fundingTokenAddress,
+      assetSymbol,
       withdrawCollateral,
     ],
   );
@@ -273,13 +272,45 @@ export default function CardWithdrawForm() {
   const disabled = isSubmitting;
   const availableFormatted = isCollateral ? collateralFormatted : formattedBalance;
 
+  /** Assets other than the selected one that still hold a balance. */
+  const otherFundedAssets = useMemo(
+    () =>
+      (collateral?.tokens ?? []).filter(
+        t =>
+          !t.unavailableReason &&
+          t.balanceUsd > 0 &&
+          t.tokenAddress.toLowerCase() !== collateral?.tokenAddress?.toLowerCase(),
+      ),
+    [collateral],
+  );
+
   // The card's spending balance and its withdrawable collateral are different
   // numbers; say so when they diverge, rather than letting the user discover it
-  // through a rejected withdrawal.
-  const collateralShortfallHint =
-    isCollateral && !isCollateralLoading && collateral && collateralAvailable < spendableAmount
-      ? `Your card balance is $${formattedBalance}, but only $${collateralFormatted} is currently available to withdraw.`
-      : null;
+  // through a rejected withdrawal. When the shortfall is only because the rest
+  // sits in another asset, say that instead — the money is not missing, it just
+  // has to be withdrawn one asset at a time.
+  const collateralShortfallHint = useMemo(() => {
+    if (!isCollateral || isCollateralLoading || !collateral) return null;
+    if (collateralAvailable >= spendableAmount) return null;
+
+    if (otherFundedAssets.length) {
+      const others = otherFundedAssets
+        .map(t => `$${formatNumber(t.balanceUsd, 2, 2)} of ${assetLabel(t)}`)
+        .join(', ');
+      return `You can withdraw $${collateralFormatted} of ${assetSymbol} now. The rest of your $${formattedBalance} balance is held as ${others} — switch asset above to withdraw it.`;
+    }
+    return `Your card balance is $${formattedBalance}, but only $${collateralFormatted} of ${assetSymbol} is currently available to withdraw.`;
+  }, [
+    isCollateral,
+    isCollateralLoading,
+    collateral,
+    collateralAvailable,
+    spendableAmount,
+    otherFundedAssets,
+    collateralFormatted,
+    formattedBalance,
+    assetSymbol,
+  ]);
 
   return (
     <View className="gap-3">
@@ -346,7 +377,19 @@ export default function CardWithdrawForm() {
           control={control}
           name="to"
           render={({ field: { onChange } }) => (
-            <ToDestinationSelector onChange={onChange} tokenSymbol={depositTokenSymbol} />
+            <ToDestinationSelector
+              onChange={onChange}
+              tokenSymbol={depositTokenSymbol}
+              assets={collateral?.tokens}
+              selectedTokenAddress={collateral?.tokenAddress}
+              onSelectAsset={asset => {
+                setSelectedTokenAddress(asset.tokenAddress);
+                // The cap belongs to the old asset; clear it rather than
+                // validate the typed amount against a balance it never had.
+                setValue('amount', '');
+                clearErrors('amount');
+              }}
+            />
           )}
         />
       </View>

--- a/components/Card/ToDestinationSelector.native.tsx
+++ b/components/Card/ToDestinationSelector.native.tsx
@@ -3,18 +3,27 @@ import { Pressable, View } from 'react-native';
 import { ChevronDown, Wallet as WalletIcon } from 'lucide-react-native';
 
 import { Text } from '@/components/ui/text';
+import { formatNumber } from '@/lib/utils';
 import { CardDepositSource } from '@/store/useCardDepositStore';
 
-export type ToDestinationProps = {
-  onChange: (value: CardDepositSource) => void;
-  tokenSymbol?: string;
-};
+import { assetLabel, type ToDestinationProps } from './ToDestinationSelector.web';
+
+export type { ToDestinationProps };
 
 export default function ToDestinationSelector({
   onChange,
   tokenSymbol = 'USDC',
+  assets,
+  selectedTokenAddress,
+  onSelectAsset,
 }: ToDestinationProps) {
   const [isOpen, setIsOpen] = useState(false);
+
+  const withdrawable = assets?.filter(asset => !asset.unavailableReason) ?? [];
+  const selected = withdrawable.find(
+    asset => asset.tokenAddress.toLowerCase() === selectedTokenAddress?.toLowerCase(),
+  );
+  const triggerSymbol = selected ? assetLabel(selected) : tokenSymbol;
 
   return (
     <View>
@@ -27,23 +36,46 @@ export default function ToDestinationSelector({
           <Text className="text-lg font-semibold">Wallet</Text>
         </View>
         <View className="flex-row items-center gap-2">
-          <Text className="text-sm text-muted-foreground">{tokenSymbol}</Text>
+          <Text className="text-sm text-muted-foreground">{triggerSymbol}</Text>
           <ChevronDown color="#A1A1A1" size={20} />
         </View>
       </Pressable>
       {isOpen && (
         <View className="mt-1 overflow-hidden rounded-2xl bg-accent">
-          <Pressable
-            className="flex-row items-center gap-2 px-4 py-3"
-            onPress={() => {
-              onChange(CardDepositSource.COLLATERAL);
-              setIsOpen(false);
-            }}
-          >
-            <WalletIcon color="#A1A1A1" size={20} />
-            <Text className="text-lg">Wallet</Text>
-            <Text className="text-sm text-muted-foreground">{tokenSymbol}</Text>
-          </Pressable>
+          {withdrawable.length ? (
+            withdrawable.map(asset => (
+              <Pressable
+                key={`${asset.chainId}-${asset.tokenAddress}`}
+                className="flex-row items-center justify-between px-4 py-3"
+                onPress={() => {
+                  onChange(CardDepositSource.COLLATERAL);
+                  onSelectAsset?.(asset);
+                  setIsOpen(false);
+                }}
+              >
+                <View className="flex-row items-center gap-2">
+                  <WalletIcon color="#A1A1A1" size={20} />
+                  <Text className="text-lg">Wallet</Text>
+                  <Text className="text-sm text-muted-foreground">{assetLabel(asset)}</Text>
+                </View>
+                <Text className="text-sm text-muted-foreground">
+                  ${formatNumber(asset.balanceUsd, 2, 2)}
+                </Text>
+              </Pressable>
+            ))
+          ) : (
+            <Pressable
+              className="flex-row items-center gap-2 px-4 py-3"
+              onPress={() => {
+                onChange(CardDepositSource.COLLATERAL);
+                setIsOpen(false);
+              }}
+            >
+              <WalletIcon color="#A1A1A1" size={20} />
+              <Text className="text-lg">Wallet</Text>
+              <Text className="text-sm text-muted-foreground">{tokenSymbol}</Text>
+            </Pressable>
+          )}
         </View>
       )}
     </View>

--- a/components/Card/ToDestinationSelector.tsx
+++ b/components/Card/ToDestinationSelector.tsx
@@ -1,2 +1,3 @@
 export type { ToDestinationProps } from './ToDestinationSelector.web';
+export { assetLabel } from './ToDestinationSelector.web';
 export { default } from './ToDestinationSelector.web';

--- a/components/Card/ToDestinationSelector.web.tsx
+++ b/components/Card/ToDestinationSelector.web.tsx
@@ -8,17 +8,42 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { Text } from '@/components/ui/text';
+import { CardCollateralTokenBalanceDto } from '@/lib/types';
+import { formatNumber } from '@/lib/utils';
 import { CardDepositSource } from '@/store/useCardDepositStore';
 
 export type ToDestinationProps = {
   onChange: (value: CardDepositSource) => void;
   tokenSymbol?: string;
+  /**
+   * Collateral assets the card actually holds, richest first. A card funded in
+   * USDT and one funded in USDC both back the same spending balance, but each
+   * is withdrawn separately — so every asset has to be offered, not just the
+   * one the app happens to default to.
+   */
+  assets?: CardCollateralTokenBalanceDto[];
+  /** Address of the asset currently selected. */
+  selectedTokenAddress?: string;
+  onSelectAsset?: (asset: CardCollateralTokenBalanceDto) => void;
 };
+
+/** "USDC" when the chain answered `symbol()`, else a short address. */
+export const assetLabel = (asset: CardCollateralTokenBalanceDto): string =>
+  asset.symbol || `${asset.tokenAddress.slice(0, 6)}…${asset.tokenAddress.slice(-4)}`;
 
 export default function ToDestinationSelector({
   onChange,
   tokenSymbol = 'USDC',
+  assets,
+  selectedTokenAddress,
+  onSelectAsset,
 }: ToDestinationProps) {
+  const withdrawable = assets?.filter(asset => !asset.unavailableReason) ?? [];
+  const selected = withdrawable.find(
+    asset => asset.tokenAddress.toLowerCase() === selectedTokenAddress?.toLowerCase(),
+  );
+  const triggerSymbol = selected ? assetLabel(selected) : tokenSymbol;
+
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
@@ -28,20 +53,42 @@ export default function ToDestinationSelector({
             <Text className="text-lg font-semibold">Wallet</Text>
           </View>
           <View className="flex-row items-center gap-2">
-            <Text className="text-sm text-muted-foreground">{tokenSymbol}</Text>
+            <Text className="text-sm text-muted-foreground">{triggerSymbol}</Text>
             <ChevronDown color="#A1A1A1" size={20} />
           </View>
         </Pressable>
       </DropdownMenuTrigger>
       <DropdownMenuContent className="-mt-4 w-full min-w-[380px] rounded-b-2xl rounded-t-none border-0">
-        <DropdownMenuItem
-          onPress={() => onChange(CardDepositSource.COLLATERAL)}
-          className="flex-row items-center gap-2 px-4 py-3 web:cursor-pointer"
-        >
-          <WalletIcon color="#A1A1A1" size={20} />
-          <Text className="text-lg">Wallet</Text>
-          <Text className="text-sm text-muted-foreground">{tokenSymbol}</Text>
-        </DropdownMenuItem>
+        {withdrawable.length ? (
+          withdrawable.map(asset => (
+            <DropdownMenuItem
+              key={`${asset.chainId}-${asset.tokenAddress}`}
+              onPress={() => {
+                onChange(CardDepositSource.COLLATERAL);
+                onSelectAsset?.(asset);
+              }}
+              className="flex-row items-center justify-between px-4 py-3 web:cursor-pointer"
+            >
+              <View className="flex-row items-center gap-2">
+                <WalletIcon color="#A1A1A1" size={20} />
+                <Text className="text-lg">Wallet</Text>
+                <Text className="text-sm text-muted-foreground">{assetLabel(asset)}</Text>
+              </View>
+              <Text className="text-sm text-muted-foreground">
+                ${formatNumber(asset.balanceUsd, 2, 2)}
+              </Text>
+            </DropdownMenuItem>
+          ))
+        ) : (
+          <DropdownMenuItem
+            onPress={() => onChange(CardDepositSource.COLLATERAL)}
+            className="flex-row items-center gap-2 px-4 py-3 web:cursor-pointer"
+          >
+            <WalletIcon color="#A1A1A1" size={20} />
+            <Text className="text-lg">Wallet</Text>
+            <Text className="text-sm text-muted-foreground">{tokenSymbol}</Text>
+          </DropdownMenuItem>
+        )}
       </DropdownMenuContent>
     </DropdownMenu>
   );

--- a/hooks/useCardCollateralAvailable.ts
+++ b/hooks/useCardCollateralAvailable.ts
@@ -16,17 +16,27 @@ const CARD_COLLATERAL_AVAILABLE_KEY = 'cardCollateralAvailable';
  * spending power and can exceed the collateral backing it, so it must not be
  * used as the maximum on the withdraw-to-wallet screen — a withdrawal above
  * the on-chain balance is rejected once the user has already committed to it.
+ *
+ * `tokens` lists every collateral asset the card holds. Spending power is
+ * credited against all of them, but a withdrawal moves one named asset, so the
+ * screen has to let the user pick: a card funded in USDT cannot be emptied
+ * through a USDC withdrawal.
+ *
+ * @param tokenAddress open on a specific asset; omit for the richest one.
  */
-export function useCardCollateralAvailable() {
+export function useCardCollateralAvailable(tokenAddress?: string) {
   const { provider } = useCardProvider();
 
   return useQuery({
-    queryKey: [CARD_COLLATERAL_AVAILABLE_KEY],
-    queryFn: () => withRefreshToken(() => getCardCollateralAvailable()),
+    queryKey: [CARD_COLLATERAL_AVAILABLE_KEY, tokenAddress ?? null],
+    queryFn: () => withRefreshToken(() => getCardCollateralAvailable({ tokenAddress })),
     enabled: provider === CardProvider.RAIN,
     // Collateral moves when deposits settle and when charges are swept, so the
     // withdraw screen re-reads it on the same cadence as the card balance.
     refetchInterval: 5000,
+    // Switching asset re-queries; keeping the last result avoids the amount
+    // field flashing back to a skeleton mid-edit.
+    placeholderData: previous => previous,
     retry: 2,
   });
 }

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -1102,11 +1102,16 @@ export const getCardContracts = async (): Promise<RainContractResponseDto[]> => 
  * `getCardBalance` reports credit-side spending power, which can be higher than
  * the collateral backing it. Returns 400 for Bridge.
  */
-export const getCardCollateralAvailable = async (): Promise<CardCollateralAvailableDto> => {
+export const getCardCollateralAvailable = async (
+  params: { tokenAddress?: string } = {},
+): Promise<CardCollateralAvailableDto> => {
   const jwt = getJWTToken();
+  const query = params.tokenAddress
+    ? `?tokenAddress=${encodeURIComponent(params.tokenAddress)}`
+    : '';
 
   const response = await fetch(
-    `${EXPO_PUBLIC_FLASH_API_BASE_URL}/accounts/v1/cards/collateral/available`,
+    `${EXPO_PUBLIC_FLASH_API_BASE_URL}/accounts/v1/cards/collateral/available${query}`,
     {
       credentials: 'include',
       headers: {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -783,12 +783,20 @@ export interface RainContractResponseDto {
   onramp?: RainContractOnrampDto;
 }
 
-/** On-chain collateral held by one Rain collateral proxy, for one token. */
-export interface CardCollateralContractBalanceDto {
+/**
+ * On-chain collateral held by one Rain collateral proxy, for ONE token.
+ *
+ * A proxy can hold several assets at once. Rain credits card spending power
+ * against all of them, but a withdrawal moves a single named token, so each is
+ * offered and capped separately.
+ */
+export interface CardCollateralTokenBalanceDto {
   rainCollateralContractId: string;
   chainId: number;
   collateralProxy: string;
   tokenAddress: string;
+  /** ERC-20 symbol read on-chain, e.g. "USDC"/"USDT". Empty when unreadable. */
+  symbol: string;
   decimals: number;
   /** Proxy's token balance in smallest units. */
   rawBalance: string;
@@ -805,22 +813,26 @@ export interface CardCollateralContractBalanceDto {
  * collateral on-chain, and a withdrawal above this one is rejected.
  */
 export interface CardCollateralAvailableDto {
-  /** Withdrawable amount in dollars — the binding cap, floored to the cent. */
+  /** Withdrawable dollars for the default asset, floored to the cent. */
   availableUsd: number;
-  /** `availableUsd` in the selected token's smallest units. */
+  /** `availableUsd` in the default token's smallest units. */
   availableRaw: string;
-  /** On-chain collateral of the selected contract, in dollars. */
+  /** On-chain collateral of the default asset, in dollars. */
   onChainCollateralUsd: number;
+  /** On-chain collateral summed across every asset and contract, in dollars. */
+  totalCollateralUsd: number;
   /** Rain's credit-side spending power, in dollars, when known. */
   spendingPowerUsd?: number;
-  /** Which of the two caps is currently binding. */
+  /** Which of the two caps is currently binding for the default asset. */
   limitedBy: 'collateral' | 'spendingPower' | 'none';
-  /** Contract a withdrawal would draw from; absent when the user has none. */
+  /** Default asset a withdrawal draws from; absent when the user has none. */
   chainId?: number;
   collateralProxy?: string;
   tokenAddress?: string;
+  symbol?: string;
   decimals?: number;
-  contracts: CardCollateralContractBalanceDto[];
+  /** Every collateral asset, richest first — the source for the asset picker. */
+  tokens: CardCollateralTokenBalanceDto[];
 }
 
 export type OnrampAutomationRail = 'ach' | 'wire';


### PR DESCRIPTION
The withdraw screen offered a single asset, labelled from a static `'USDC'` constant. A card's spending balance is credited against every collateral asset the proxy holds, but a withdrawal moves one of them — so a user funded in USDT saw a $100.60 balance, a $0.42 maximum, and had no way to reach the USDT behind the difference.

- The "To" dropdown now lists every collateral asset with its balance and switches the withdrawal to it; the trigger shows the real ERC-20 symbol instead of a hard-coded "USDC".
- Available, Max, and validation follow the selected asset, and the amount clears on switch so a figure is never validated against a cap the new asset never had.
- The shortfall hint names where the rest of the balance actually is ("held as $100.53 of USDT — switch asset above to withdraw it") rather than just reporting a smaller number.
- Chain and token for the signed withdrawal both come from the response that priced the amount, so validation and execution cannot drift apart.


Claude-Session: https://claude.ai/code/session_01BVUpcPpGFF9w4VxH4rvT9r