### PR TITLE
Make referral program amounts dynamic from admin config

### DIFF
--- a/components/Points/ReferralProgramBanner.tsx
+++ b/components/Points/ReferralProgramBanner.tsx
@@ -7,15 +7,28 @@ import ReferralProgramModal from '@/components/Referral/ReferralProgramModal';
 import { Button } from '@/components/ui/button';
 import { Text } from '@/components/ui/text';
 import { useDimension } from '@/hooks/useDimension';
+import { useReferralSummary } from '@/hooks/useRewards';
 import { getAsset } from '@/lib/assets';
+
+/** Whole-dollar formatting for the program copy, e.g. "$15". */
+const formatUsdWhole = (value: number) => `$${Math.round(value || 0).toLocaleString('en-US')}`;
 
 /**
  * Referral program banner, shown to all users. Tapping (the banner or the
  * "Refer friends" button) opens the referral program popup.
+ *
+ * The amounts come from the referral summary (admin-managed on the rewards
+ * config dashboard) so the banner never advertises a stale offer. The same
+ * query backs the popup this opens, so it is served from cache there.
  */
 const ReferralProgramBanner = () => {
   const { isScreenMedium } = useDimension();
   const [isModalOpen, setIsModalOpen] = useState(false);
+  const { data: summary } = useReferralSummary();
+
+  // Fallbacks mirror the backend's shipped defaults.
+  const referrerUsd = summary?.rewards.referrerUsd ?? 15;
+  const newUserUsd = summary?.rewards.newUserUsd ?? 15;
 
   const openModal = () => setIsModalOpen(true);
 
@@ -27,7 +40,8 @@ const ReferralProgramBanner = () => {
             <Text className="text-lg font-medium leading-5 text-brand/70">Invite friends</Text>
             <Text className="text-3xl font-semibold">Refer & Earn</Text>
             <Text className="text-base font-semibold opacity-70">
-              Earn $15 for you and $10 for friends for using the card
+              Earn {formatUsdWhole(referrerUsd)} for you and {formatUsdWhole(newUserUsd)} for
+              friends for using the card
             </Text>
             <Button
               variant="secondary"

--- a/components/Referral/ReferralProgramContent.tsx
+++ b/components/Referral/ReferralProgramContent.tsx
@@ -122,8 +122,10 @@ export default function ReferralProgramContent({ onClose }: ReferralProgramConte
   const referralCode = user?.referralCode ?? '';
   const referralLink = `${REFERRAL_BASE_URL}${referralCode}`;
 
+  // Fallbacks mirror the backend's shipped defaults; the live figures are
+  // admin-managed and always arrive with the summary.
   const referrerUsd = summary?.rewards.referrerUsd ?? 15;
-  const newUserUsd = summary?.rewards.newUserUsd ?? 10;
+  const newUserUsd = summary?.rewards.newUserUsd ?? 15;
   const spendTarget = summary?.qualification.spendTargetUsd ?? 75;
   const merchantTarget = summary?.qualification.merchantTarget ?? 3;
   const windowDays = summary?.qualification.windowDays ?? 30;

--- a/components/Referral/ReferralProgramContentNew.tsx
+++ b/components/Referral/ReferralProgramContentNew.tsx
@@ -105,8 +105,10 @@ export default function ReferralProgramContentNew({
   const referralLink = `${REFERRAL_BASE_URL}${referralCode}`;
   const message = `Join me on Solid — order a card, spend, and we both earn. Use my link: ${referralLink}`;
 
+  // Fallbacks mirror the backend's shipped defaults; the live figures are
+  // admin-managed and always arrive with the summary.
   const referrerUsd = summary?.rewards.referrerUsd ?? 15;
-  const newUserUsd = summary?.rewards.newUserUsd ?? 10;
+  const newUserUsd = summary?.rewards.newUserUsd ?? 15;
   const spendTarget = summary?.qualification.spendTargetUsd ?? 75;
   const merchantTarget = summary?.qualification.merchantTarget ?? 3;
   const windowDays = summary?.qualification.windowDays ?? 30;


### PR DESCRIPTION
## Summary
Updated the referral program banner and modals to display dynamic reward amounts fetched from the admin-managed rewards configuration, rather than hardcoded values. This ensures the UI always reflects the current offer without requiring code changes.

## Key Changes
- **ReferralProgramBanner**: Now fetches referral summary data via `useReferralSummary()` hook and displays dynamic `referrerUsd` and `newUserUsd` amounts in the banner copy
- **Formatting utility**: Added `formatUsdWhole()` helper to consistently format dollar amounts as whole numbers (e.g., "$15")
- **Fallback values**: Updated default fallbacks in `ReferralProgramContent` and `ReferralProgramContentNew` from `$10` to `$15` for `newUserUsd` to match backend defaults
- **Documentation**: Added clarifying comments explaining that amounts are admin-managed and fallbacks mirror backend shipped defaults

## Implementation Details
- The banner now uses the same `useReferralSummary()` query that backs the referral program modal, ensuring consistency and leveraging cached data
- All three components (`ReferralProgramBanner`, `ReferralProgramContent`, `ReferralProgramContentNew`) now use aligned fallback values
- The solution maintains backward compatibility with fallback values while enabling real-time updates when admin configuration changes

https://claude.ai/code/session_01PeBPx8fJaQwJmCCsG6zPkW