### PR TITLE
feat(rewards): preview locked tier benefits off production

### DIFF
--- a/components/Rewards/NewRewards/RewardsScreenNew.tsx
+++ b/components/Rewards/NewRewards/RewardsScreenNew.tsx
@@ -26,6 +26,7 @@ import { useUserStore } from '@/store/useUserStore';
 import PointsHeadline from './PointsHeadline';
 import RewardsHelpModal from './RewardsHelpModal';
 import RewardsSummaryCard from './RewardsSummaryCard';
+import { resolveTierBenefitRates } from './tierBenefitCards';
 import TierBenefitsGrid from './TierBenefitsGrid';
 
 /**
@@ -141,6 +142,19 @@ export default function RewardsScreenNew() {
   const referrals = referralSummary?.totalRewardedUsd ?? 0;
   const allTimeCashback = Math.max(cardDetails?.cashback?.totalUsdValue ?? 0, cashback);
 
+  // Core grants neither the yield boost nor subscription cashback, so on a
+  // Core test account both cards correctly disappear — which leaves nothing to
+  // review. Off production, preview them at stock Prime rates instead.
+  const benefitRates = resolveTierBenefitRates(
+    {
+      yieldBoostPercentage: rewardsData?.yieldBoostPercentage ?? 0,
+      yieldBoostCap: rewardsData?.yieldBoostCap ?? 0,
+      yieldBoostEarned: rewardsData?.yieldBoostEarned ?? 0,
+      subscriptionDiscountRate: rewardsData?.subscriptionDiscountRate ?? 0,
+    },
+    isDevFeatureEnabled,
+  );
+
   return (
     <PageLayout
       mobileTitle={null}
@@ -203,10 +217,7 @@ export default function RewardsScreenNew() {
             cashbackThisMonth={cashback}
             maxCashbackMonthly={rewardsData?.maxCashbackMonthly ?? 0}
             allTimeCashback={allTimeCashback}
-            yieldBoostPercentage={rewardsData?.yieldBoostPercentage ?? 0}
-            yieldBoostCap={rewardsData?.yieldBoostCap ?? 0}
-            yieldBoostEarned={rewardsData?.yieldBoostEarned ?? 0}
-            subscriptionDiscountRate={rewardsData?.subscriptionDiscountRate ?? 0}
+            {...benefitRates}
             onGetMoreCashback={() => router.push(path.REWARDS_BENEFITS)}
             onReferralsPress={() => setIsReferralModalOpen(true)}
           />

--- a/components/Rewards/NewRewards/__tests__/tierBenefitCards.test.ts
+++ b/components/Rewards/NewRewards/__tests__/tierBenefitCards.test.ts
@@ -1,7 +1,9 @@
 /// <reference types="jest" />
 import {
   chunkIntoRows,
+  PREVIEW_BENEFIT_RATES,
   resolveTierBenefitKeys,
+  resolveTierBenefitRates,
 } from '@/components/Rewards/NewRewards/tierBenefitCards';
 
 /**
@@ -45,6 +47,77 @@ describe('resolveTierBenefitKeys', () => {
         resolveTierBenefitKeys({ yieldBoostPercentage: rate, subscriptionDiscountRate: rate }),
       ).toEqual(['cashback', 'referrals']);
     }
+  });
+});
+
+/**
+ * Off production, a locked perk is previewed at stock Prime rates so design QA
+ * can review the yield boost and subscription cards from an ordinary Core test
+ * account. Production must keep showing only what the tier really grants.
+ */
+describe('resolveTierBenefitRates', () => {
+  const core = {
+    yieldBoostPercentage: 0,
+    yieldBoostCap: 0,
+    yieldBoostEarned: 0,
+    subscriptionDiscountRate: 0,
+  };
+  const ultra = {
+    yieldBoostPercentage: 5,
+    yieldBoostCap: 100,
+    yieldBoostEarned: 420.65,
+    subscriptionDiscountRate: 50,
+  };
+
+  it('passes rates straight through when preview is off', () => {
+    expect(resolveTierBenefitRates(core, false)).toEqual(core);
+    expect(resolveTierBenefitRates(ultra, false)).toEqual(ultra);
+  });
+
+  it('leaves a Core tier with no cards in production', () => {
+    expect(resolveTierBenefitKeys(resolveTierBenefitRates(core, false))).toEqual([
+      'cashback',
+      'referrals',
+    ]);
+  });
+
+  it('substitutes preview rates for locked perks so all four cards render', () => {
+    const previewed = resolveTierBenefitRates(core, true);
+
+    expect(previewed).toEqual({
+      ...PREVIEW_BENEFIT_RATES,
+      yieldBoostEarned: 0,
+    });
+    expect(resolveTierBenefitKeys(previewed)).toEqual([
+      'cashback',
+      'referrals',
+      'yield-boost',
+      'subscription',
+    ]);
+  });
+
+  it('never overwrites rates the tier really grants', () => {
+    expect(resolveTierBenefitRates(ultra, true)).toEqual(ultra);
+  });
+
+  it('substitutes each locked perk independently', () => {
+    const boostOnly = { ...core, yieldBoostPercentage: 3, yieldBoostCap: 75 };
+
+    expect(resolveTierBenefitRates(boostOnly, true)).toEqual({
+      yieldBoostPercentage: 3,
+      yieldBoostCap: 75,
+      yieldBoostEarned: 0,
+      subscriptionDiscountRate: PREVIEW_BENEFIT_RATES.subscriptionDiscountRate,
+    });
+  });
+
+  it('reports real earnings rather than inventing them', () => {
+    // A Core account previewing the boost has genuinely earned nothing, and the
+    // sheet and savings strip should say so.
+    expect(
+      resolveTierBenefitRates({ ...core, yieldBoostEarned: 12.5 }, true).yieldBoostEarned,
+    ).toBe(12.5);
+    expect(resolveTierBenefitRates(core, true).yieldBoostEarned).toBe(0);
   });
 });
 

--- a/components/Rewards/NewRewards/tierBenefitCards.ts
+++ b/components/Rewards/NewRewards/tierBenefitCards.ts
@@ -24,12 +24,69 @@ export const resolveTierBenefitKeys = ({
   yieldBoostPercentage,
   subscriptionDiscountRate,
 }: TierBenefitAvailability): TierBenefitKey[] => {
-  const unlocked = (rate: number) => Number.isFinite(rate) && rate > 0;
-
   const keys: TierBenefitKey[] = ['cashback', 'referrals'];
-  if (unlocked(yieldBoostPercentage)) keys.push('yield-boost');
-  if (unlocked(subscriptionDiscountRate)) keys.push('subscription');
+  if (isUnlocked(yieldBoostPercentage)) keys.push('yield-boost');
+  if (isUnlocked(subscriptionDiscountRate)) keys.push('subscription');
   return keys;
+};
+
+const isUnlocked = (rate: number) => Number.isFinite(rate) && rate > 0;
+
+export interface TierBenefitRates extends TierBenefitAvailability {
+  /** Ceiling on yield boost payouts for the tier, in USD. */
+  yieldBoostCap: number;
+  /** Yield boost payouts the user has actually received, in USD. */
+  yieldBoostEarned: number;
+}
+
+/**
+ * Stand-in rates for a perk the current tier hasn't unlocked, matching the
+ * stock Prime configuration.
+ *
+ * Only ever reached on non-production builds (see {@link resolveTierBenefitRates}).
+ * They are deliberately constants rather than a lookup against the live tier
+ * config: qa and preview builds routinely run against a backend that predates
+ * the yield-boost/subscription fields entirely, and a preview that only works
+ * once the backend catches up is no use for reviewing the screen today. Real
+ * numbers always win when the backend sends them.
+ */
+export const PREVIEW_BENEFIT_RATES = {
+  yieldBoostPercentage: 2,
+  yieldBoostCap: 50,
+  subscriptionDiscountRate: 25,
+} as const;
+
+/**
+ * The rates the benefit cards render with.
+ *
+ * In production this is exactly what the user's tier grants, so a locked perk
+ * reports 0 and {@link resolveTierBenefitKeys} drops its card.
+ *
+ * When `previewLockedBenefits` is set — non-production builds only — a locked
+ * perk borrows {@link PREVIEW_BENEFIT_RATES} instead, which lifts its rate above
+ * zero and brings the card back. That lets design QA review the yield boost and
+ * subscription cards on qa/staging/preview without holding a Prime or Ultra test
+ * account. `yieldBoostEarned` is never substituted: a preview account really has
+ * earned nothing, and $0 is the honest number to show.
+ */
+export const resolveTierBenefitRates = (
+  rates: TierBenefitRates,
+  previewLockedBenefits: boolean,
+): TierBenefitRates => {
+  if (!previewLockedBenefits) return rates;
+
+  const hasBoost = isUnlocked(rates.yieldBoostPercentage);
+
+  return {
+    yieldBoostEarned: rates.yieldBoostEarned,
+    yieldBoostPercentage: hasBoost
+      ? rates.yieldBoostPercentage
+      : PREVIEW_BENEFIT_RATES.yieldBoostPercentage,
+    yieldBoostCap: hasBoost ? rates.yieldBoostCap : PREVIEW_BENEFIT_RATES.yieldBoostCap,
+    subscriptionDiscountRate: isUnlocked(rates.subscriptionDiscountRate)
+      ? rates.subscriptionDiscountRate
+      : PREVIEW_BENEFIT_RATES.subscriptionDiscountRate,
+  };
 };
 
 /**

--- a/components/Savings/NewSavings/SavingsYieldBoostCard.tsx
+++ b/components/Savings/NewSavings/SavingsYieldBoostCard.tsx
@@ -1,7 +1,9 @@
 import { View } from 'react-native';
 
+import { resolveTierBenefitRates } from '@/components/Rewards/NewRewards/tierBenefitCards';
 import { Text } from '@/components/ui/text';
 import { useRewardsUserData } from '@/hooks/useRewards';
+import { isDevFeatureEnabled } from '@/lib/config';
 import { formatBalanceUSD, formatNumber } from '@/lib/utils';
 
 /**
@@ -9,12 +11,23 @@ import { formatBalanceUSD, formatNumber } from '@/lib/utils';
  * savings yield, and what it has paid out so far.
  *
  * Renders nothing for tiers that grant no boost, so Core users don't see an
- * empty box for a perk they haven't unlocked.
+ * empty box for a perk they haven't unlocked. Off production the boost is
+ * previewed at stock Prime rates instead, matching the rewards screen so the
+ * strip is reviewable from a Core test account.
  */
 const SavingsYieldBoostCard = () => {
   const { data: rewardsData } = useRewardsUserData();
 
-  const boostPercentage = rewardsData?.yieldBoostPercentage ?? 0;
+  const { yieldBoostPercentage: boostPercentage, yieldBoostEarned } = resolveTierBenefitRates(
+    {
+      yieldBoostPercentage: rewardsData?.yieldBoostPercentage ?? 0,
+      yieldBoostCap: rewardsData?.yieldBoostCap ?? 0,
+      yieldBoostEarned: rewardsData?.yieldBoostEarned ?? 0,
+      subscriptionDiscountRate: rewardsData?.subscriptionDiscountRate ?? 0,
+    },
+    isDevFeatureEnabled,
+  );
+
   if (boostPercentage <= 0) return null;
 
   return (
@@ -39,7 +52,7 @@ const SavingsYieldBoostCard = () => {
             className="mt-[7px] text-[22px] text-white"
             style={{ fontFamily: 'MonaSans_600SemiBold', lineHeight: 24 }}
           >
-            {formatBalanceUSD(rewardsData?.yieldBoostEarned ?? 0)}
+            {formatBalanceUSD(yieldBoostEarned)}
           </Text>
         </View>
       </View>


### PR DESCRIPTION
Core grants neither the yield boost nor subscription cashback, so on an ordinary Core test account both new cards correctly hide — which leaves design QA with nothing to review on qa/staging/preview, and no way to reach the two sheets behind them at all.

Off production, a locked perk now renders at stock Prime rates instead of disappearing. Production is untouched: `resolveTierBenefitRates` returns its input verbatim unless the preview flag is set, and the flag is the existing `isDevFeatureEnabled` (`EXPO_PUBLIC_ENVIRONMENT !== 'production'`), which this screen already imported.

The stand-in rates are constants rather than a lookup against the live tier config, because qa and preview routinely run against a backend that predates these fields entirely — a preview that only works once the backend catches up wouldn't help review the screen today. Real rates always win when the backend sends them, and `yieldBoostEarned` is never substituted: a preview account really has earned nothing, and $0 is the honest number for the sheet and the savings strip to show.

The savings boost strip takes the same treatment so both surfaces agree.


Claude-Session: https://claude.ai/code/session_01By9pz71BqVCTFVd5u7K8zK