### PR TITLE
Clarify Wirex routing is per-user and must not be cached

### DIFF
--- a/lib/api.ts
+++ b/lib/api.ts
@@ -771,9 +771,13 @@ export const getSumsubVerificationStatus = async (): Promise<SumsubVerificationS
  * Which providers a country routes to.
  *
  * `flow` matters: the backend gates the `card` answer on whether Wirex is enabled
- * in that environment (it is staging-only), while `onramp` gets the ungated
- * geographic answer because TransFi's use of Sumsub is live independently. The
- * backend defaults to the gated `card` answer, so omitting it is the safe choice.
+ * in that environment and on who is asking (production serves Wirex to an
+ * internal team cohort only), while `onramp` gets the ungated geographic answer
+ * because TransFi's use of Sumsub is live independently. The backend defaults to
+ * the gated `card` answer, so omitting it is the safe choice.
+ *
+ * The card answer is per-user — the backend reads the caller from the JWT below,
+ * never from a parameter — so it must not be cached across accounts.
  */
 export const getProviderRouting = async (
   countryCode: string,

--- a/lib/kycProviderRouting.ts
+++ b/lib/kycProviderRouting.ts
@@ -43,8 +43,11 @@ const resolveRoutingCountry = async (): Promise<string | undefined> => {
  * available everywhere.
  *
  * The card answer is gated server-side on whether Wirex is enabled in that
- * environment, so a Wirex country resolves to Didit in production. That gate is
- * why the country alone is not enough to decide: the routing must be asked for.
+ * environment AND on the caller's own identity: production runs Wirex for an
+ * internal team cohort only, so the same Wirex country resolves to Sumsub for a
+ * team member and Didit for everyone else. That per-user gate is why the country
+ * alone is not enough to decide — the routing must be asked for, over an
+ * authenticated request, and must not be cached across accounts.
  *
  * @param fallbackProvider provider to keep when the country or routing is
  *   unavailable — the buy-crypto flow passes the backend's own suggestion here.


### PR DESCRIPTION
This PR updates documentation comments to clarify important caching and authentication requirements for KYC provider routing.

**Summary**
Updated comments in the provider routing API and related utilities to explicitly document that Wirex routing decisions are per-user (based on caller identity from JWT) and must not be cached across different accounts.

**Key changes**
- Updated `getProviderRouting()` JSDoc to clarify that Wirex availability in production is gated not just by environment but also by the caller's identity (internal team cohort only)
- Added explicit note that the card answer is per-user and must not be cached across accounts
- Updated `resolveRoutingCountry()` comments to explain that the same country can resolve to different providers depending on the authenticated user
- Emphasized that routing must be requested over an authenticated request and cannot be determined by country alone

**Implementation details**
- No functional code changes; this is purely documentation/comment clarification
- The changes highlight that the backend reads caller identity from the JWT, never from parameters
- This documentation ensures developers understand the security and correctness implications of the routing API

https://claude.ai/code/session_01WbXLQmYzZVWfNuP23S7yaN