### PR TITLE
docs(card): describe the spender as our card-spend wallet

### DIFF
--- a/hooks/useCardSpendAuthorization.ts
+++ b/hooks/useCardSpendAuthorization.ts
@@ -28,7 +28,7 @@ export const CARD_SPEND_AUTHORIZATION_QUERY_KEY = 'cardSpendAuthorization';
  * the card balance are the same money.
  *
  * What the user grants instead is standing permission: an ERC-20 `approve` on
- * soUSD (Fuse) naming the Card Deposit Manager as spender. That is the one on-chain
+ * soUSD (Fuse) naming our card-spend wallet as spender. That is the one on-chain
  * action, and it is signed from their Safe like every other transaction in the app.
  *
  * ## Why the button turns itself back on

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -2726,7 +2726,7 @@ export const revealCardDetailsComplete = async (
   return revealCardDetailsCompleteRain();
 };
 
-// --- Wirex card spending (soUSD allowance to the Card Deposit Manager) ---
+// --- Wirex card spending (soUSD allowance to our card-spend wallet) ---
 
 /**
  * The user's current card-spend authorization.

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -750,7 +750,7 @@ export interface WirexRevealSessionResponse {
 
 /**
  * Wirex card-spend authorization: the soUSD allowance the cardholder grants the
- * Card Deposit Manager, and everything needed to build the `approve` call.
+ * card-spend wallet, and everything needed to build the `approve` call.
  *
  * A Wirex card is not prefunded like a Rain card. Wirex pays the merchant from its
  * own Master Account and our backend reimburses itself by pulling soUSD from the
@@ -759,8 +759,8 @@ export interface WirexRevealSessionResponse {
  * standing permission to take it, which is what this describes.
  *
  * Token, spender and chain all come from the backend rather than app config: the
- * Card Deposit Manager address is environment-specific, and a stale client-side
- * copy would have users approving an allowance nobody can spend.
+ * spender address is environment-specific, and a stale client-side copy would have
+ * users approving an allowance nobody can spend.
  */
 export interface WirexSpendAuthorizationResponse {
   /** False re-enables the Authorize control — the allowance ran out, or the soUSD did. */
@@ -779,13 +779,13 @@ export interface WirexSpendAuthorizationResponse {
   held: string;
   /** soUSD ERC-20 address to call `approve` on. */
   tokenAddress: string;
-  /** The `spender` argument — the Card Deposit Manager. */
+  /** The `spender` argument — our card-spend wallet. */
   spenderAddress: string;
   /** Chain the approval must be sent on. Always Fuse (122). */
   chainId: number;
   /** soUSD decimals, so the client scales without assuming 18. */
   decimals: number;
-  /** False when this environment has no Card Deposit Manager — hide the control. */
+  /** False when this environment has no card-spend wallet — hide the control. */
   available: boolean;
 }
 


### PR DESCRIPTION
The backend no longer resolves a dedicated Card Deposit Manager key; the Wirex card-spend signer is now the Cashback Payout Wallet, named outright. Nothing in the UI depends on which wallet it is — `spenderAddress` comes from the backend precisely so a client-side copy cannot go stale — so this is comment and type-doc wording only, keeping the app's description of the approval accurate.


Claude-Session: https://claude.ai/code/session_01Cxwk3dHHkqSkSfWto67USC