### PR TITLE
fix(rewards): separate the USD value from the FUSE ratio in Skip the …

### DIFF
--- a/components/Rewards/NewRewards/SkipTheLineSection.tsx
+++ b/components/Rewards/NewRewards/SkipTheLineSection.tsx
@@ -86,12 +86,22 @@ const SkipLineTierRow = ({
     <View className="gap-[13px] px-5 py-[18px]">
       <View className="gap-[3px]">
         <Text className="text-base font-semibold text-white">{tierName}</Text>
-        {/* Reads "$2,000 128,000 / 400,000 FUSE · 272,000 needed to upgrade" —
-            the ratio carries the weight because it's the number that moves. */}
+        {/* Reads "128,000 ($2,000) / 400,000 FUSE · 272,000 needed to upgrade".
+            The ratio is bold because it's the number that moves. The USD sits
+            in brackets straight after the balance — it annotates what the user
+            holds, not the target — and a step dimmer, so it reads as an aside
+            rather than running into the figures on either side. */}
         <Text className="text-xs font-medium text-white/[0.45]">
-          {formatWholeDollars(balanceUsd)}{' '}
+          <Text className="text-xs font-bold text-white/[0.45]">{formatFuse(balanceFuse)}</Text>
+          {balanceUsd > 0 ? (
+            <Text className="text-xs font-medium text-white/30">
+              {' '}
+              ({formatWholeDollars(balanceUsd)})
+            </Text>
+          ) : null}
           <Text className="text-xs font-bold text-white/[0.45]">
-            {formatFuse(balanceFuse)} / {formatFuse(rung.requiredFuse)} FUSE
+            {' '}
+            / {formatFuse(rung.requiredFuse)} FUSE
           </Text>{' '}
           · {formatFuse(rung.remainingFuse)} needed to upgrade
         </Text>


### PR DESCRIPTION
…line

Leading with the dollar value ran it straight into the balance — "$10 5,353 / 15,000 FUSE" scans as one number sequence, and the reader has to stop and work out which figure is which.

Move it into brackets directly after the balance and drop it a step in opacity. It has to sit after the numerator rather than after the whole ratio: placed at the end it would read as the price of the 15,000 FUSE target instead of the value of what the user actually holds.

Also hide the brackets entirely when the value is 0, so a new user with no FUSE sees "0 / 15,000 FUSE" rather than a meaningless "($0)" — which is also what the row shows if the FUSE price lookup fails and the backend zeroes the figure.


Claude-Session: https://claude.ai/code/session_014gDZgJmHRcPMGEKm35qLLx