### PR TITLE
Fix assetLabel export mismatch between native and web platforms

### DIFF
--- a/components/Card/CardWithdrawForm.tsx
+++ b/components/Card/CardWithdrawForm.tsx
@@ -6,7 +6,7 @@ import { Wallet as WalletIcon } from 'lucide-react-native';
 import { z } from 'zod';
 import { useShallow } from 'zustand/react/shallow';
 
-import ToDestinationSelector, { assetLabel } from '@/components/Card/ToDestinationSelector';
+import ToDestinationSelector from '@/components/Card/ToDestinationSelector';
 import Max from '@/components/Max';
 import { Button } from '@/components/ui/button';
 import Skeleton from '@/components/ui/skeleton';
@@ -20,7 +20,7 @@ import { withdrawFromCard, withdrawFromCardToSavings } from '@/lib/api';
 import { EXPO_PUBLIC_CARD_FUNDING_CHAIN_ID } from '@/lib/config';
 import { CardProvider } from '@/lib/types';
 import { cn, formatNumber, getCardDepositTokenSymbol } from '@/lib/utils';
-import { toAmountInputValue } from '@/lib/utils/cardHelpers';
+import { assetLabel, toAmountInputValue } from '@/lib/utils/cardHelpers';
 import { CardDepositSource } from '@/store/useCardDepositStore';
 import { useCardWithdrawStore } from '@/store/useCardWithdrawStore';
 

--- a/components/Card/ToDestinationSelector.native.tsx
+++ b/components/Card/ToDestinationSelector.native.tsx
@@ -4,11 +4,20 @@ import { ChevronDown, Wallet as WalletIcon } from 'lucide-react-native';
 
 import { Text } from '@/components/ui/text';
 import { formatNumber } from '@/lib/utils';
+import { assetLabel } from '@/lib/utils/cardHelpers';
 import { CardDepositSource } from '@/store/useCardDepositStore';
 
-import { assetLabel, type ToDestinationProps } from './ToDestinationSelector.web';
+import type { ToDestinationProps } from './ToDestinationSelector.types';
 
 export type { ToDestinationProps };
+
+/**
+ * Re-exported so `import { assetLabel } from '.../ToDestinationSelector'`
+ * resolves on native too. Metro picks this `.native` file over the `.web` one,
+ * so anything the web module exports has to be exported here as well or it
+ * silently becomes `undefined` on device.
+ */
+export { assetLabel };
 
 export default function ToDestinationSelector({
   onChange,

--- a/components/Card/ToDestinationSelector.tsx
+++ b/components/Card/ToDestinationSelector.tsx
@@ -1,3 +1,3 @@
-export type { ToDestinationProps } from './ToDestinationSelector.web';
-export { assetLabel } from './ToDestinationSelector.web';
+export type { ToDestinationProps } from './ToDestinationSelector.types';
 export { default } from './ToDestinationSelector.web';
+export { assetLabel } from '@/lib/utils/cardHelpers';

--- a/components/Card/ToDestinationSelector.types.ts
+++ b/components/Card/ToDestinationSelector.types.ts
@@ -1,0 +1,17 @@
+import { CardCollateralTokenBalanceDto } from '@/lib/types';
+import { CardDepositSource } from '@/store/useCardDepositStore';
+
+export type ToDestinationProps = {
+  onChange: (value: CardDepositSource) => void;
+  tokenSymbol?: string;
+  /**
+   * Collateral assets the card actually holds, richest first. A card funded in
+   * USDT and one funded in USDC both back the same spending balance, but each
+   * is withdrawn separately — so every asset has to be offered, not just the
+   * one the app happens to default to.
+   */
+  assets?: CardCollateralTokenBalanceDto[];
+  /** Address of the asset currently selected. */
+  selectedTokenAddress?: string;
+  onSelectAsset?: (asset: CardCollateralTokenBalanceDto) => void;
+};

--- a/components/Card/ToDestinationSelector.web.tsx
+++ b/components/Card/ToDestinationSelector.web.tsx
@@ -8,28 +8,19 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { Text } from '@/components/ui/text';
-import { CardCollateralTokenBalanceDto } from '@/lib/types';
 import { formatNumber } from '@/lib/utils';
+import { assetLabel } from '@/lib/utils/cardHelpers';
 import { CardDepositSource } from '@/store/useCardDepositStore';
 
-export type ToDestinationProps = {
-  onChange: (value: CardDepositSource) => void;
-  tokenSymbol?: string;
-  /**
-   * Collateral assets the card actually holds, richest first. A card funded in
-   * USDT and one funded in USDC both back the same spending balance, but each
-   * is withdrawn separately — so every asset has to be offered, not just the
-   * one the app happens to default to.
-   */
-  assets?: CardCollateralTokenBalanceDto[];
-  /** Address of the asset currently selected. */
-  selectedTokenAddress?: string;
-  onSelectAsset?: (asset: CardCollateralTokenBalanceDto) => void;
-};
+import type { ToDestinationProps } from './ToDestinationSelector.types';
 
-/** "USDC" when the chain answered `symbol()`, else a short address. */
-export const assetLabel = (asset: CardCollateralTokenBalanceDto): string =>
-  asset.symbol || `${asset.tokenAddress.slice(0, 6)}…${asset.tokenAddress.slice(-4)}`;
+export type { ToDestinationProps };
+
+/**
+ * Re-exported so callers already importing it from the selector keep working.
+ * The implementation is platform-neutral on purpose — see `assetLabel`.
+ */
+export { assetLabel };
 
 export default function ToDestinationSelector({
   onChange,

--- a/components/Card/__tests__/toDestinationSelectorExports.test.ts
+++ b/components/Card/__tests__/toDestinationSelectorExports.test.ts
@@ -1,0 +1,154 @@
+import fs from 'fs';
+import path from 'path';
+
+import { assetLabel } from '@/lib/utils/cardHelpers';
+
+/**
+ * Regression guard for the Rain card withdrawal crash.
+ *
+ * `CardWithdrawForm` renders a hint naming the other assets a card holds, and
+ * built it with `assetLabel`. `assetLabel` was exported from
+ * `ToDestinationSelector.web.tsx`; the `.native.tsx` sibling imported it for its
+ * own use but never re-exported it. Metro resolves `.native` ahead of `.web` on
+ * iOS/Android, so on device
+ * `import { assetLabel } from '.../ToDestinationSelector'` was `undefined`, and
+ * calling it threw "undefined is not a function" from inside a `useMemo` during
+ * render — which took the whole app to the error boundary the moment the
+ * collateral query resolved. Because the query refetches on an interval, "Try
+ * again" crashed straight back.
+ *
+ * Two things are checked: the helper is reachable wherever the withdraw form
+ * imports it from, and platform variants never disagree about their exports
+ * again.
+ */
+
+const CARD_DIR = path.join(__dirname, '..');
+const REPO_ROOT = path.join(CARD_DIR, '..', '..');
+
+/** Value (non-type) named exports declared in a source file. */
+function valueExports(file: string): Set<string> {
+  const src = fs.readFileSync(file, 'utf8');
+  const names = new Set<string>();
+
+  for (const m of src.matchAll(
+    /^export\s+(?:const|let|var|function|async\s+function|class)\s+(\w+)/gm,
+  )) {
+    names.add(m[1]);
+  }
+
+  // `export { a, b as c }` / `export { a } from '...'`, skipping `export type {}`
+  // and inline `type` specifiers, which are erased before the bundle runs.
+  for (const m of src.matchAll(/^export\s*\{([^}]*)\}/gm)) {
+    const isTypeOnly = /^export\s+type\s*\{/.test(m[0]);
+    if (isTypeOnly) continue;
+    for (const spec of m[1].split(',')) {
+      const name = spec.trim();
+      if (!name || name.startsWith('type ')) continue;
+      names.add(
+        name
+          .split(/\s+as\s+/)
+          .pop()!
+          .trim(),
+      );
+    }
+  }
+
+  if (/^export\s+default/m.test(src)) names.add('default');
+  return names;
+}
+
+describe('assetLabel is reachable on every platform', () => {
+  it('is a callable function where CardWithdrawForm imports it from', () => {
+    // The form imports from the platform-neutral helper module, so this is the
+    // same binding the device gets. Under jest-expo this resolves through the
+    // native platform extensions, exactly as Metro does on device.
+    expect(typeof assetLabel).toBe('function');
+  });
+
+  it('names the asset by symbol, falling back to a short address', () => {
+    const base = {
+      rainCollateralContractId: 'c1',
+      chainId: 1,
+      collateralProxy: '0xproxy',
+      tokenAddress: '0xdAC17F958D2ee523a2206206994597C13D831ec7',
+      decimals: 6,
+      rawBalance: '1000000',
+      balanceUsd: 1,
+    };
+
+    expect(assetLabel({ ...base, symbol: 'USDT' })).toBe('USDT');
+    // An unreadable `symbol()` must still produce something nameable rather
+    // than an empty string in the middle of a sentence.
+    expect(assetLabel({ ...base, symbol: '' })).toBe('0xdAC1…1ec7');
+  });
+
+  it('is exported from every ToDestinationSelector platform variant', () => {
+    // The form no longer imports it from here, but the selector modules still
+    // re-export it, and a caller reaching for the old path must not get
+    // `undefined` on one platform and a function on another.
+    for (const file of [
+      'ToDestinationSelector.tsx',
+      'ToDestinationSelector.web.tsx',
+      'ToDestinationSelector.native.tsx',
+    ]) {
+      expect(valueExports(path.join(CARD_DIR, file))).toContain('assetLabel');
+    }
+  });
+});
+
+describe('platform variants agree about their exports', () => {
+  /** Groups every `X.native.*` / `X.web.*` pair in the app. */
+  function platformGroups(): Map<string, { native?: string; web?: string }> {
+    const groups = new Map<string, { native?: string; web?: string }>();
+    const skip = new Set(['node_modules', '.git', 'ios', 'android', '.expo', 'dist']);
+
+    const walk = (dir: string) => {
+      for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+        const full = path.join(dir, entry.name);
+        if (entry.isDirectory()) {
+          if (!skip.has(entry.name)) walk(full);
+          continue;
+        }
+        const m = entry.name.match(/^(.*?)\.(native|web)\.tsx?$/);
+        if (!m) continue;
+        const key = path.join(dir, m[1]);
+        const group = groups.get(key) ?? {};
+        group[m[2] as 'native' | 'web'] = full;
+        groups.set(key, group);
+      }
+    };
+
+    for (const top of ['components', 'lib', 'hooks', 'app']) {
+      const dir = path.join(REPO_ROOT, top);
+      if (fs.existsSync(dir)) walk(dir);
+    }
+    return groups;
+  }
+
+  it('exports the same value names from .native and .web siblings', () => {
+    const mismatches: string[] = [];
+
+    for (const [key, { native, web }] of platformGroups()) {
+      if (!native || !web) continue; // a variant with no counterpart can't diverge
+      const nativeExports = valueExports(native);
+      const webExports = valueExports(web);
+
+      const missingOnNative = [...webExports].filter(n => !nativeExports.has(n));
+      const missingOnWeb = [...nativeExports].filter(n => !webExports.has(n));
+
+      const rel = path.relative(REPO_ROOT, key);
+      if (missingOnNative.length) {
+        mismatches.push(`${rel}: .web exports ${missingOnNative.join(', ')} but .native does not`);
+      }
+      if (missingOnWeb.length) {
+        mismatches.push(`${rel}: .native exports ${missingOnWeb.join(', ')} but .web does not`);
+      }
+    }
+
+    // A name present on one platform and absent on the other is `undefined` at
+    // runtime on that platform — a crash that no amount of type-checking or
+    // web testing catches, because tsc and the web bundle both read the variant
+    // that has it.
+    expect(mismatches).toEqual([]);
+  });
+});

--- a/lib/utils/cardHelpers.ts
+++ b/lib/utils/cardHelpers.ts
@@ -1,4 +1,5 @@
 import {
+  CardCollateralTokenBalanceDto,
   CardProvider,
   CardResponse,
   CardStatus,
@@ -127,6 +128,22 @@ export const toAmountInputValue = (amount: number): string => {
   if (!Number.isFinite(amount) || amount <= 0) return '0';
   return (Math.floor(amount * 100) / 100).toFixed(2);
 };
+
+/**
+ * How a collateral asset is named in the UI: "USDC" when the chain answered
+ * `symbol()`, else a short address.
+ *
+ * This lives here, platform-neutral, rather than beside the selector that first
+ * needed it. It used to be exported from `ToDestinationSelector.web.tsx`, which
+ * the native selector imported but never re-exported — so on iOS/Android
+ * `import { assetLabel } from '.../ToDestinationSelector'` resolved to the
+ * `.native` file and produced `undefined`. Calling it then threw "undefined is
+ * not a function" from inside a render, taking the whole app to the error
+ * boundary. A helper every platform shares has no business hanging off a
+ * platform-specific module.
+ */
+export const assetLabel = (asset: CardCollateralTokenBalanceDto): string =>
+  asset.symbol || `${asset.tokenAddress.slice(0, 6)}…${asset.tokenAddress.slice(-4)}`;
 
 /**
  * Format card transaction amount with proper sign and currency symbol.


### PR DESCRIPTION
## Summary
Fixes a critical crash on iOS/Android where `assetLabel` was undefined when imported from `ToDestinationSelector`, causing "undefined is not a function" errors during card withdrawal operations.

## Root Cause
The `assetLabel` helper was defined in `ToDestinationSelector.web.tsx` but not re-exported from `ToDestinationSelector.native.tsx`. Since Metro prioritizes `.native` files over `.web` on iOS/Android, imports of `assetLabel` from the selector module resolved to the native variant and returned `undefined`, crashing the app when called in a `useMemo` during render.

## Key Changes
- **Moved `assetLabel` to platform-neutral location**: Relocated the helper from `ToDestinationSelector.web.tsx` to `lib/utils/cardHelpers.ts` where it belongs with other card utilities
- **Extracted shared types**: Created `ToDestinationSelector.types.ts` to hold `ToDestinationProps`, eliminating duplication between platform variants
- **Updated all imports**: 
  - `CardWithdrawForm.tsx` now imports `assetLabel` from `cardHelpers` instead of the selector
  - Both `.native` and `.web` variants re-export `assetLabel` from the shared helper for backward compatibility
  - `ToDestinationSelector.tsx` (index) re-exports from the new locations
- **Added regression test**: New test suite (`toDestinationSelectorExports.test.ts`) ensures:
  - `assetLabel` is callable and works correctly
  - The helper is exported from all selector platform variants
  - Platform variants never diverge in their exports again

## Implementation Details
The `assetLabel` function displays asset names as their symbol (e.g., "USDT") or falls back to a shortened address format (e.g., "0xdAC1…1ec7") when the symbol is unavailable. By placing it in a platform-neutral utility module, it's now guaranteed to be available consistently across all platforms.

https://claude.ai/code/session_01QSdrQ83u4F7TReemag6kFC