### PR TITLE
fix(deposit): stop shipping web-only deposit components to native

### DIFF
--- a/__tests__/platformBarrels.test.ts
+++ b/__tests__/platformBarrels.test.ts
@@ -1,0 +1,113 @@
+import fs from 'fs';
+import path from 'path';
+
+/**
+ * Guards the wiring that decides which platform variant actually ships.
+ *
+ * Metro platform-resolves the *specifier being imported*, not the contents of
+ * the file it lands on. So a directory barrel that names a variant outright —
+ * `export { default } from './Foo.web'` — serves that variant to every platform
+ * unless an `index.<platform>` sibling exists to be resolved ahead of it. The
+ * mistake is invisible on web and to `tsc`, because both read the file that
+ * works.
+ *
+ * It shipped the thirdweb-backed web `DepositExternalWalletOptions` to Android,
+ * where `useActiveAccount()` throws "must be used within <ThirdwebProvider>"
+ * (the provider is mounted on desktop only) — the largest error-boundary crash
+ * in the August Amplitude data at 57 events. Two sibling barrels had the same
+ * defect without crashing: they silently rendered the web component on native.
+ */
+
+const REPO_ROOT = path.join(__dirname, '..');
+const SEARCH_ROOTS = ['components', 'lib', 'hooks', 'app'];
+const EXTS = ['.tsx', '.ts'] as const;
+
+type Barrel = { file: string; target: string; platform: string };
+
+/** Every file that re-exports from a hardcoded platform-specific sibling. */
+function hardcodedBarrels(): Barrel[] {
+  const found: Barrel[] = [];
+  const skip = new Set(['node_modules', '.git', 'ios', 'android', '.expo', 'dist', '__tests__']);
+
+  const walk = (dir: string) => {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        if (!skip.has(entry.name)) walk(full);
+        continue;
+      }
+      if (!/\.tsx?$/.test(entry.name)) continue;
+      for (const m of fs
+        .readFileSync(full, 'utf8')
+        .matchAll(/(?:from|require\()\s*['"]\.\/([\w.-]+)\.(native|web|ios|android)['"]/g)) {
+        found.push({ file: full, target: m[1], platform: m[2] });
+      }
+    }
+  };
+
+  for (const root of SEARCH_ROOTS) {
+    const dir = path.join(REPO_ROOT, root);
+    if (fs.existsSync(dir)) walk(dir);
+  }
+  return found;
+}
+
+const exists = (dir: string, base: string) =>
+  EXTS.some(e => fs.existsSync(path.join(dir, base + e)));
+
+describe('platform-variant barrels', () => {
+  it('gives every platform variant a matching index entry', () => {
+    const offenders: string[] = [];
+
+    for (const { file, target, platform } of hardcodedBarrels()) {
+      const dir = path.dirname(file);
+      const barrelPlatform =
+        path
+          .basename(file)
+          .replace(/\.tsx?$/, '')
+          .split('.')[1] ?? '';
+      const isIndex =
+        path
+          .basename(file)
+          .replace(/\.tsx?$/, '')
+          .split('.')[0] === 'index';
+
+      // Only `index*` barrels are reached by a directory import. A sibling barrel
+      // named `Foo.tsx` is shadowed by `Foo.<platform>` on every platform that
+      // has one, so it is inert.
+      if (!isIndex) continue;
+      // `index.native.tsx` pointing at `.native` is the counterpart, not a bug.
+      if (barrelPlatform && barrelPlatform === platform) continue;
+
+      // Every *other* variant present in this directory needs its own index
+      // entry, or Metro never reaches it.
+      for (const other of ['native', 'web', 'ios', 'android']) {
+        if (other === platform) continue;
+        if (!exists(dir, `${target}.${other}`)) continue;
+        if (exists(dir, `index.${other}`)) continue;
+        offenders.push(
+          `${path.relative(REPO_ROOT, file)}: serves ${target}.${platform} to all platforms — ` +
+            `${target}.${other}.tsx exists but there is no index.${other}, so it is dead code`,
+        );
+      }
+    }
+
+    expect(offenders).toEqual([]);
+  });
+
+  it('resolves the deposit barrels that crashed to their native variants', () => {
+    // Belt and braces on the specific regression: these are reached by a
+    // directory import, so the entry Metro lands on decides what Android runs.
+    // jest-expo resolves through the native platform extensions, as Metro does.
+    for (const rel of [
+      'components/DepositOption/DepositExternalWalletOptions',
+      'components/DepositOption/DepositBuyCryptoOptions',
+      'components/DepositToVault/DepositTokenSelector',
+    ]) {
+      const dir = path.join(REPO_ROOT, rel);
+      expect(require.resolve(dir)).toMatch(/index\.native\.tsx$/);
+      // ...and that entry must lead to the native component, not the web one.
+      expect(fs.readFileSync(require.resolve(dir), 'utf8')).toMatch(/\.native';/);
+    }
+  });
+});

--- a/app/(protected)/(tabs)/settings/security.tsx
+++ b/app/(protected)/(tabs)/settings/security.tsx
@@ -1,4 +1,4 @@
-import { lazy, Suspense, useCallback, useEffect, useState } from 'react';
+import { Suspense, useCallback, useEffect, useState } from 'react';
 import { ActivityIndicator, Pressable, Text, View } from 'react-native';
 import { Image } from 'expo-image';
 import * as Sentry from '@sentry/react-native';
@@ -14,13 +14,14 @@ import useUser from '@/hooks/useUser';
 import { getTotpStatus } from '@/lib/api';
 import { getAsset } from '@/lib/assets';
 import { EXPO_PUBLIC_TURNKEY_ORGANIZATION_ID } from '@/lib/config';
+import { lazyWithRetry } from '@/lib/lazyWithRetry';
 import { cn } from '@/lib/utils';
 
 // Lazy load heavy modal components - only loaded when user opens them
-const SecurityEmailModal = lazy(() =>
+const SecurityEmailModal = lazyWithRetry(() =>
   import('@/components/SecurityEmailModal').then(m => ({ default: m.SecurityEmailModal })),
 );
-const SecurityTotpModal = lazy(() =>
+const SecurityTotpModal = lazyWithRetry(() =>
   import('@/components/SecurityTotpModal').then(m => ({ default: m.SecurityTotpModal })),
 );
 

--- a/app/(protected)/_layout.tsx
+++ b/app/(protected)/_layout.tsx
@@ -1,4 +1,4 @@
-import { lazy, Suspense, useCallback, useEffect, useState } from 'react';
+import { Suspense, useCallback, useEffect, useState } from 'react';
 import { ActivityIndicator, InteractionManager, Platform, StyleSheet, View } from 'react-native';
 import {
   Redirect,
@@ -32,13 +32,14 @@ import { useWebhookStatus } from '@/hooks/useWebhookStatus';
 import FuseVault from '@/lib/abis/FuseVault';
 import { trackIdentity } from '@/lib/analytics';
 import { ADDRESSES } from '@/lib/config';
+import { lazyWithRetry } from '@/lib/lazyWithRetry';
 import { config } from '@/lib/wagmi';
 import { useDepositStore } from '@/store/useDepositStore';
 import { useOnboardingStore } from '@/store/useOnboardingStore';
 import { useUserStore } from '@/store/useUserStore';
 
 // Lazy load Loading component - only used during hydration
-const Loading = lazy(() => import('@/components/Loading'));
+const Loading = lazyWithRetry(() => import('@/components/Loading'));
 
 export default function ProtectedLayout() {
   const { user } = useUser();

--- a/components/Dashboard/LazyHomeBanners.tsx
+++ b/components/Dashboard/LazyHomeBanners.tsx
@@ -8,11 +8,13 @@ import Animated, {
   withTiming,
 } from 'react-native-reanimated';
 
+import { lazyWithRetry } from '@/lib/lazyWithRetry';
+
 // Lazy load HomeBanners - this is promotional content at the bottom of the home page
 // and doesn't need to be part of the initial bundle for FCP optimization
 // This component includes heavy dependencies: react-native-reanimated-carousel,
 // PointsBanner, CardBanner, DepositBanner - all deferred for better FCP
-const HomeBannersLazy = React.lazy(() => import('./HomeBanners'));
+const HomeBannersLazy = lazyWithRetry(() => import('./HomeBanners'));
 
 /**
  * Animated skeleton box with pulsing opacity

--- a/components/DepositOption/DepositBuyCryptoOptions/index.native.tsx
+++ b/components/DepositOption/DepositBuyCryptoOptions/index.native.tsx
@@ -1,0 +1,2 @@
+// Native entry — Metro resolves this ahead of `index.tsx` on iOS/Android.
+export { default } from './DepositBuyCryptoOptions.native';

--- a/components/DepositOption/DepositBuyCryptoOptions/index.tsx
+++ b/components/DepositOption/DepositBuyCryptoOptions/index.tsx
@@ -1,3 +1,8 @@
-// This file will be replaced by the platform-specific version at build time
-// Export web version by default (for development/testing)
+// Web entry. `index.native.tsx` is the native counterpart — Metro resolves that
+// on iOS/Android and this file on web.
+//
+// Both entries are needed: a barrel's *contents* are not platform-resolved, only
+// the specifier being imported is, and consumers import this directory. With no
+// `index.native` sibling this file served every platform, which shipped the web
+// variant to native and left `DepositBuyCryptoOptions.native.tsx` dead.
 export { default } from './DepositBuyCryptoOptions.web';

--- a/components/DepositOption/DepositExternalWalletOptions/index.native.tsx
+++ b/components/DepositOption/DepositExternalWalletOptions/index.native.tsx
@@ -1,0 +1,2 @@
+// Native entry — Metro resolves this ahead of `index.tsx` on iOS/Android.
+export { default } from './DepositExternalWalletOptions.native';

--- a/components/DepositOption/DepositExternalWalletOptions/index.tsx
+++ b/components/DepositOption/DepositExternalWalletOptions/index.tsx
@@ -1,3 +1,8 @@
-// This file will be replaced by the platform-specific version at build time
-// Export web version by default (for development/testing)
+// Web entry. `index.native.tsx` is the native counterpart — Metro resolves that
+// on iOS/Android and this file on web.
+//
+// Both entries are needed: a barrel's *contents* are not platform-resolved, only
+// the specifier being imported is, and consumers import this directory. With no
+// `index.native` sibling this file served every platform, which shipped the web
+// variant to native and left `DepositExternalWalletOptions.native.tsx` dead.
 export { default } from './DepositExternalWalletOptions.web';

--- a/components/DepositOption/LazyDepositOptionModal.tsx
+++ b/components/DepositOption/LazyDepositOptionModal.tsx
@@ -1,8 +1,10 @@
 import React, { Suspense } from 'react';
 
+import { lazyWithRetry } from '@/lib/lazyWithRetry';
+
 // Lazy load DepositOptionModal - this modal is hidden by default and only
 // shown when user clicks on certain activity items
-const DepositOptionModal = React.lazy(() => import('./DepositOptionModal'));
+const DepositOptionModal = lazyWithRetry(() => import('./DepositOptionModal'));
 
 /**
  * Props for LazyDepositOptionModal

--- a/components/DepositToVault/DepositTokenSelector/index.native.tsx
+++ b/components/DepositToVault/DepositTokenSelector/index.native.tsx
@@ -1,0 +1,2 @@
+// Native entry — Metro resolves this ahead of `index.tsx` on iOS/Android.
+export { default } from './DepositTokenSelector.native';

--- a/components/DepositToVault/DepositTokenSelector/index.tsx
+++ b/components/DepositToVault/DepositTokenSelector/index.tsx
@@ -1,3 +1,8 @@
-// This file will be replaced by the platform-specific version at build time
-// Export web version by default (for development/testing)
+// Web entry. `index.native.tsx` is the native counterpart — Metro resolves that
+// on iOS/Android and this file on web.
+//
+// Both entries are needed: a barrel's *contents* are not platform-resolved, only
+// the specifier being imported is, and consumers import this directory. With no
+// `index.native` sibling this file served every platform, which shipped the web
+// variant to native and left `DepositTokenSelector.native.tsx` dead.
 export { default } from './DepositTokenSelector.web';

--- a/components/LazyAreaChart.tsx
+++ b/components/LazyAreaChart.tsx
@@ -2,22 +2,10 @@ import React, { Component, Suspense } from 'react';
 import { ActivityIndicator, Pressable, View } from 'react-native';
 
 import { Text } from '@/components/ui/text';
+import { lazyWithRetry } from '@/lib/lazyWithRetry';
 import { ChartPayload } from '@/lib/types';
 
 import type { StyleProp, ViewStyle } from 'react-native';
-
-function lazyWithRetry(importFn: () => Promise<{ default: React.ComponentType<any> }>) {
-  return React.lazy(() => {
-    const attempt = (retries: number): ReturnType<typeof importFn> =>
-      importFn().catch((error: unknown) => {
-        if (retries <= 0) throw error;
-        return new Promise<{ default: React.ComponentType<any> }>(resolve =>
-          setTimeout(() => resolve(attempt(retries - 1)), 1000),
-        );
-      });
-    return attempt(3);
-  });
-}
 
 const AreaChart = lazyWithRetry(() => import('@/components/AreaChart'));
 

--- a/components/LazyThirdwebProvider.tsx
+++ b/components/LazyThirdwebProvider.tsx
@@ -1,9 +1,13 @@
-import React, { lazy, ReactNode, Suspense } from 'react';
+import React, { ReactNode, Suspense } from 'react';
 import { ActivityIndicator, View } from 'react-native';
 
+import { lazyWithRetry } from '@/lib/lazyWithRetry';
+
 // Lazy load the ThirdwebProvider - this defers loading the thirdweb bundle
-// until it's actually needed (when wallet/deposit features are used)
-const ThirdwebProvider = lazy(() =>
+// until it's actually needed (when wallet/deposit features are used).
+// This boundary wraps nearly the whole app, so a single failed chunk fetch used
+// to crash all of it; retry the import before surfacing that.
+const ThirdwebProvider = lazyWithRetry(() =>
   import('thirdweb/react').then(module => ({
     default: module.ThirdwebProvider,
   })),

--- a/components/LazyWhatsNewModal.tsx
+++ b/components/LazyWhatsNewModal.tsx
@@ -1,12 +1,13 @@
 import React, { Suspense, useEffect, useMemo, useState } from 'react';
 import { Image } from 'expo-image';
 
+import { lazyWithRetry } from '@/lib/lazyWithRetry';
 import { WhatsNew } from '@/lib/types';
 
 // Lazy load WhatsNewModal - this component imports react-native-reanimated-carousel
 // which is a heavy library. Since WhatsNewModal is only shown conditionally for
 // authenticated users, we defer its bundle to improve FCP for all routes.
-const WhatsNewModal = React.lazy(() => import('./WhatsNewModal'));
+const WhatsNewModal = lazyWithRetry(() => import('./WhatsNewModal'));
 
 interface LazyWhatsNewModalProps {
   whatsNew: WhatsNew;

--- a/components/Wallet/LazyWalletTabs.tsx
+++ b/components/Wallet/LazyWalletTabs.tsx
@@ -1,10 +1,12 @@
 import React, { Suspense } from 'react';
 
+import { lazyWithRetry } from '@/lib/lazyWithRetry';
+
 import TokenListSkeleton from './WalletTokenTab/TokenListSkeleton';
 
 // Lazy load WalletTabs - this shows the token list and is below the fold
 // Deferring it improves FCP while maintaining perceived performance with skeleton
-const WalletTabs = React.lazy(() => import('./WalletTabs'));
+const WalletTabs = lazyWithRetry(() => import('./WalletTabs'));
 
 /**
  * Lazy-loaded wrapper for WalletTabs component

--- a/lib/__tests__/lazyWithRetry.test.tsx
+++ b/lib/__tests__/lazyWithRetry.test.tsx
@@ -1,0 +1,85 @@
+import React from 'react';
+
+import { lazyWithRetry } from '@/lib/lazyWithRetry';
+
+/**
+ * `lazyWithRetry` wraps `React.lazy`, so the loader it builds is only invoked
+ * when React renders the component. These tests reach for that loader directly
+ * via the lazy type's internal payload rather than mounting a tree, because
+ * mounting pulls in the RN component stack that this Jest config cannot
+ * transform. What matters is the retry behavior of the loader itself.
+ */
+type LazyInternals = { _payload: { _result: () => Promise<unknown> } };
+
+function loaderOf(component: unknown): () => Promise<unknown> {
+  return (component as unknown as LazyInternals)._payload._result;
+}
+
+describe('lazyWithRetry', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  /** Runs a promise to settlement while draining the retry timers. */
+  async function settle<T>(
+    p: Promise<T>,
+  ): Promise<{ ok: true; value: T } | { ok: false; err: any }> {
+    const wrapped = p.then(
+      value => ({ ok: true as const, value }),
+      err => ({ ok: false as const, err }),
+    );
+    // Each retry waits on a setTimeout; advance until nothing is pending.
+    for (let i = 0; i < 10; i++) {
+      await Promise.resolve();
+      jest.runOnlyPendingTimers();
+    }
+    return wrapped;
+  }
+
+  it('resolves without retrying when the import succeeds', async () => {
+    const Component = () => null;
+    const load = jest.fn().mockResolvedValue({ default: Component });
+
+    const result = await settle(loaderOf(lazyWithRetry(load as any))());
+
+    expect(result).toEqual({ ok: true, value: { default: Component } });
+    expect(load).toHaveBeenCalledTimes(1);
+  });
+
+  it('recovers from a transient failure instead of crashing the boundary', async () => {
+    const Component = () => null;
+    // One dropped request — the case that took out the whole subtree under
+    // LazyThirdwebProvider before this existed.
+    const load = jest
+      .fn()
+      .mockRejectedValueOnce(new Error('AsyncRequireError'))
+      .mockResolvedValue({ default: Component });
+
+    const result = await settle(loaderOf(lazyWithRetry(load as any))());
+
+    expect(result).toEqual({ ok: true, value: { default: Component } });
+    expect(load).toHaveBeenCalledTimes(2);
+  });
+
+  it('retries a bounded number of times, then rethrows', async () => {
+    // A chunk removed by a deploy 404s on every attempt; the retry budget has to
+    // run out rather than loop, and the original error must reach the boundary.
+    const err = new Error('AsyncRequireError');
+    const load = jest.fn().mockRejectedValue(err);
+
+    const result = await settle(loaderOf(lazyWithRetry(load as any))());
+
+    expect(result).toEqual({ ok: false, err });
+    // Initial attempt plus MAX_RETRIES.
+    expect(load).toHaveBeenCalledTimes(4);
+  });
+
+  it('produces a usable lazy component', () => {
+    const Component = () => null;
+    const Lazy = lazyWithRetry(async () => ({ default: Component }));
+    expect((Lazy as any).$$typeof).toBe(React.lazy(async () => ({ default: Component })).$$typeof);
+  });
+});

--- a/lib/lazyWithRetry.tsx
+++ b/lib/lazyWithRetry.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+
+type Loader<T extends React.ComponentType<any>> = () => Promise<{ default: T }>;
+
+const MAX_RETRIES = 3;
+const RETRY_DELAY_MS = 1000;
+
+/**
+ * `React.lazy` that retries the dynamic import before giving up.
+ *
+ * A code-split chunk is fetched over the network at the moment it is first
+ * rendered, so any blip — a dropped connection, a slow mobile handoff, a
+ * transient CDN error — rejects the import. React surfaces that rejection as a
+ * render error, which means one failed request takes out the whole subtree under
+ * the Suspense boundary; `LazyThirdwebProvider` wraps nearly the entire app, so
+ * there it took out the app. `AsyncRequireError` was the third-largest
+ * error-boundary crash in the August data at ~17 events, all on web.
+ *
+ * Retrying is not a cure-all: when a deploy has replaced the content-hashed
+ * chunk this bundle asks for, every attempt 404s and the boundary still shows.
+ * Only a fresh document fixes that, which is a product call rather than a
+ * default we should take on a user's behalf.
+ *
+ * Extracted from the copy in `LazyAreaChart`, which already did this, so every
+ * lazy boundary gets the same behavior instead of one of them.
+ */
+export function lazyWithRetry<T extends React.ComponentType<any>>(
+  load: Loader<T>,
+): React.LazyExoticComponent<T> {
+  return React.lazy(() => {
+    const attempt = (retries: number): Promise<{ default: T }> =>
+      load().catch((error: unknown) => {
+        if (retries <= 0) throw error;
+        return new Promise<{ default: T }>(resolve =>
+          setTimeout(() => resolve(attempt(retries - 1)), RETRY_DELAY_MS),
+        );
+      });
+    return attempt(MAX_RETRIES);
+  });
+}
+
+export default lazyWithRetry;


### PR DESCRIPTION
Fixes the two largest error-boundary crashes in the August Amplitude export, and the wiring class behind them.

`useActiveAccount must be used within <ThirdwebProvider>` — 57 events, the largest group, every one of them Android. The stacks all read `useActiveAccount <- useDepositExternalWalletOptions <- DepositExternalWalletOptions`, which is the *web* component: it calls a thirdweb hook, and `app/_layout.tsx` mounts `LazyThirdwebProvider` with `enabled={isDesktop}`, so on a phone there is no provider to find.

Native was never meant to run it. `DepositExternalWalletOptions.native.tsx` exists and builds its options without thirdweb. It was dead code: consumers import the directory, so they land on `index.tsx`, and that file named `./DepositExternalWalletOptions.web` outright. Its comment — "this file will be replaced by the platform-specific version at build time" — is the misunderstanding at the root of it. Metro platform-resolves the specifier being imported, never the contents of the file it lands on, so a barrel naming `.web` serves `.web` everywhere unless an `index.<platform>` sibling is resolved ahead of it. Neither `tsc` nor the web bundle can catch that: both read the variant that works.

Two sibling barrels had the same defect without crashing, silently rendering the web component on native: `DepositBuyCryptoOptions` and `DepositTokenSelector`.

- Add `index.native.tsx` to all three, matching the pattern `components/Intercom` already uses. Keeping both concrete entries (rather than re-exporting the extensionless specifier) is what keeps `tsc` able to resolve them — it does not understand platform extensions.
- Add a guard asserting every platform variant has a matching index entry, app-wide. It fails on the pre-fix tree, naming all three.

`AsyncRequireError` — ~17 events, third largest, all web. A code-split chunk is fetched when first rendered, so any network blip rejects the import and React turns that into a render error, taking out everything under the Suspense boundary; `LazyThirdwebProvider` wraps nearly the whole app. `LazyAreaChart` already retried its import locally, so extract that as `lib/lazyWithRetry` and use it at all nine lazy boundaries instead of one.

Retrying does not help when a deploy has replaced the content-hashed chunk a stale bundle asks for — every attempt 404s. Only loading a fresh document fixes that, which is a product decision rather than a default to take on a user's behalf, so it is left out.

The 49 `undefined is not a function` events are `CardWithdrawForm`, already fixed earlier on this branch. Not addressed here: ~13 React #185 / max-update-depth events (web, minified, no app frames to localise) and 2 `RangeError` events recursing through a third-party `getOwnPropertyDescriptor` proxy.


Claude-Session: https://claude.ai/code/session_01QSdrQ83u4F7TReemag6kFC