### PR TITLE
Fix text input and support drawer handler type safety issues

### DIFF
--- a/app/(protected)/(tabs)/settings/index.tsx
+++ b/app/(protected)/(tabs)/settings/index.tsx
@@ -193,7 +193,7 @@ const MobileSettings = () => {
       {
         title: 'Help & Support',
         icon: <IconImage source={HelpSupportIcon} width={24} height={24} />,
-        onPress: openSupportDrawer,
+        onPress: () => openSupportDrawer(),
       },
     ],
     [
@@ -332,7 +332,7 @@ const DesktopSettings = () => {
           <SettingsCard
             title="Help & Support"
             icon={<IconImage source={HelpSupportIcon} width={24} height={24} />}
-            onPress={openSupportDrawer}
+            onPress={() => openSupportDrawer()}
             isDesktop={isDesktop}
             hideIconBackground
           />

--- a/components/Card/NewCardDetails/CardLinksList.tsx
+++ b/components/Card/NewCardDetails/CardLinksList.tsx
@@ -52,7 +52,11 @@ const CardLinksList = () => {
         onPress={() => router.push(path.REWARDS_BENEFITS)}
       />
       <View style={styles.divider} />
-      <LinkRow icon={<SupportRowIcon />} label="Contact support" onPress={openSupportDrawer} />
+      <LinkRow
+        icon={<SupportRowIcon />}
+        label="Contact support"
+        onPress={() => openSupportDrawer()}
+      />
     </View>
   );
 };

--- a/components/DepositOption/VirtualAccountDetails/VirtualAccountDetailsModal.tsx
+++ b/components/DepositOption/VirtualAccountDetails/VirtualAccountDetailsModal.tsx
@@ -205,7 +205,11 @@ export const VirtualAccountDetailsModal = ({ onRetry }: VirtualAccountDetailsMod
             label="More information"
             onPress={() => Linking.openURL(MORE_INFORMATION_URL)}
           />
-          <LinkRow icon={<SupportRowIcon />} label="Contact support" onPress={openSupportDrawer} />
+          <LinkRow
+            icon={<SupportRowIcon />}
+            label="Contact support"
+            onPress={() => openSupportDrawer()}
+          />
         </View>
       </ScrollView>
 

--- a/components/DepositToVault/DepositToVaultForm.tsx
+++ b/components/DepositToVault/DepositToVaultForm.tsx
@@ -44,6 +44,7 @@ import { getAttributionChannel } from '@/lib/attribution';
 import { EXPO_PUBLIC_FUSE_GAS_RESERVE } from '@/lib/config';
 import { Status, TokenBalance, TokenType } from '@/lib/types';
 import { compactNumberFormat, eclipseAddress, formatNumber } from '@/lib/utils';
+import { showTextInputFromStart } from '@/lib/utils/textInput';
 import { getAllowedTokensForChain, getDefaultDepositSelection } from '@/lib/vaults';
 import { useAttributionStore } from '@/store/useAttributionStore';
 import { useDepositStore } from '@/store/useDepositStore';
@@ -389,26 +390,10 @@ function DepositToVaultForm() {
 
   const amountInputRef = useRef<TextInput>(null);
 
-  // "Max" fills the field with the full-precision balance (up to 18 decimals),
-  // which is far wider than the input on small screens. Left alone the field
-  // keeps its caret at the end and shows only the trailing decimals, so the
-  // amount reads as gibberish. Pull the caret/scroll back to the start so the
-  // leading digits — the ones the user cares about — stay visible.
+  // "Max" fills the field with the full-precision balance, which overflows the
+  // input on small screens; keep the leading digits in view.
   const showAmountFromStart = useCallback(() => {
-    requestAnimationFrame(() => {
-      const input = amountInputRef.current as any;
-      if (!input) return;
-      // Native: TextInput's imperative command. Web (RN-web): the DOM input.
-      if (typeof input.setSelection === 'function') input.setSelection(0, 0);
-      if (typeof input.setSelectionRange === 'function') {
-        try {
-          input.setSelectionRange(0, 0);
-        } catch {
-          // Some browsers throw on number-ish inputs; the scroll reset below still applies.
-        }
-      }
-      if ('scrollLeft' in input) input.scrollLeft = 0;
-    });
+    requestAnimationFrame(() => showTextInputFromStart(amountInputRef.current));
   }, []);
 
   // Track form viewed (once per mount)

--- a/lib/intercom.native.ts
+++ b/lib/intercom.native.ts
@@ -10,7 +10,12 @@ export const useIntercom = (): IntercomAPI => {
         Intercom.present();
       },
       showNewMessage: (message?: string) => {
-        if (message) {
+        // presentMessageComposer is a native HostFunction: hand it anything other
+        // than a string and it throws out of the bridge, which is a fatal,
+        // unhandled crash rather than a failed chat. Callers upstream are typed
+        // for a string but can still leak a press event, so re-check at the
+        // boundary and fall back to opening Intercom without a prefilled message.
+        if (typeof message === 'string' && message !== '') {
           Intercom.presentMessageComposer(message);
         } else {
           Intercom.present();

--- a/lib/utils/__tests__/textInput.test.ts
+++ b/lib/utils/__tests__/textInput.test.ts
@@ -1,0 +1,84 @@
+/// <reference types="jest" />
+
+import { Platform } from 'react-native';
+
+import { showTextInputFromStart } from '@/lib/utils/textInput';
+
+/**
+ * Stands in for the ref React Native hands back under Fabric: a
+ * `ReactNativeElement`, whose DOM-shaped accessors are getters with no setter.
+ * `'scrollLeft' in ref` is true and assigning to it throws — the crash a Max tap
+ * used to trigger on Android.
+ */
+const nativeRef = () => {
+  const ref = { setSelection: jest.fn() };
+  Object.defineProperty(ref, 'scrollLeft', { get: () => 0, configurable: true });
+  return ref;
+};
+
+/** Stands in for the DOM input react-native-web forwards its ref to. */
+const webRef = () => ({ setSelectionRange: jest.fn(), scrollLeft: 120 });
+
+const withPlatform = (os: string, run: () => void) => {
+  const original = Platform.OS;
+  // Platform.OS is a plain property on the module object, so tests set it directly.
+  (Platform as { OS: string }).OS = os;
+  try {
+    run();
+  } finally {
+    (Platform as { OS: string }).OS = original;
+  }
+};
+
+describe('showTextInputFromStart', () => {
+  it('never assigns to a read-only scrollLeft on native', () => {
+    withPlatform('android', () => {
+      const ref = nativeRef();
+
+      expect(() => showTextInputFromStart(ref)).not.toThrow();
+      expect(ref.setSelection).toHaveBeenCalledWith(0, 0);
+    });
+  });
+
+  it('leaves the DOM-only calls alone on native even when the ref exposes them', () => {
+    withPlatform('ios', () => {
+      const ref = { ...nativeRef(), setSelectionRange: jest.fn() };
+
+      showTextInputFromStart(ref);
+
+      expect(ref.setSelectionRange).not.toHaveBeenCalled();
+    });
+  });
+
+  it('resets caret and scroll offset on web', () => {
+    withPlatform('web', () => {
+      const ref = webRef();
+
+      showTextInputFromStart(ref);
+
+      expect(ref.setSelectionRange).toHaveBeenCalledWith(0, 0);
+      expect(ref.scrollLeft).toBe(0);
+    });
+  });
+
+  it('still scrolls to the start when a browser rejects setSelectionRange', () => {
+    withPlatform('web', () => {
+      const ref = {
+        setSelectionRange: jest.fn(() => {
+          throw new Error('not supported on inputs of type number');
+        }),
+        scrollLeft: 120,
+      };
+
+      expect(() => showTextInputFromStart(ref)).not.toThrow();
+      expect(ref.scrollLeft).toBe(0);
+    });
+  });
+
+  it('does nothing when the field has already unmounted', () => {
+    withPlatform('android', () => {
+      expect(() => showTextInputFromStart(null)).not.toThrow();
+      expect(() => showTextInputFromStart(undefined)).not.toThrow();
+    });
+  });
+});

--- a/lib/utils/textInput.ts
+++ b/lib/utils/textInput.ts
@@ -1,0 +1,47 @@
+import { Platform } from 'react-native';
+
+/**
+ * The members of a text-input ref this helper touches. Native and web hand back
+ * different objects — a Fabric `ReactNativeElement` and a DOM `<input>` — and
+ * each carries only some of these.
+ */
+export type TextInputScrollTarget = {
+  setSelection?: (start: number, end: number) => void;
+  setSelectionRange?: (start: number, end: number) => void;
+  scrollLeft?: number;
+};
+
+/**
+ * Scrolls an amount field back to its first character.
+ *
+ * A "Max" button fills the field with a full-precision balance — up to 18
+ * decimals — which is far wider than the input on a phone. Left alone the field
+ * keeps its caret at the end and shows only the trailing decimals, so the amount
+ * reads as gibberish. Pulling the caret and the scroll offset back to the start
+ * keeps the leading digits, the ones the user cares about, in view.
+ *
+ * Native must not be handled as a DOM node. Under Fabric the ref is a
+ * `ReactNativeElement`, which inherits DOM-shaped accessors such as `scrollLeft`
+ * as getters with no setter: they answer `'scrollLeft' in ref` with true and then
+ * throw `TypeError: Cannot assign to property 'scrollLeft' which has only a
+ * getter` on assignment. Feature-detecting with `in` therefore reads as "web"
+ * on Android and crashed the app straight out of a Max tap, so the platform
+ * decides which branch runs.
+ */
+export const showTextInputFromStart = (input: TextInputScrollTarget | null | undefined): void => {
+  if (!input) return;
+
+  if (Platform.OS !== 'web') {
+    input.setSelection?.(0, 0);
+    return;
+  }
+
+  if (typeof input.setSelectionRange === 'function') {
+    try {
+      input.setSelectionRange(0, 0);
+    } catch {
+      // Some browsers throw on number-ish inputs; the scroll reset below still applies.
+    }
+  }
+  input.scrollLeft = 0;
+};

--- a/store/__tests__/useSupportDrawerStore.test.ts
+++ b/store/__tests__/useSupportDrawerStore.test.ts
@@ -35,4 +35,29 @@ describe('useSupportDrawerStore', () => {
       chatMessage: undefined,
     });
   });
+
+  it('ignores the press event a bare onPress binding passes', () => {
+    // `onPress: () => void` accepts openSupportDrawer — a function with an
+    // optional parameter satisfies one with none — so `onPress={openSupportDrawer}`
+    // type-checks and Pressable then calls it with the press event. That object
+    // reached Intercom's native message composer, which takes a string only, and
+    // crashed the app rather than opening a chat.
+    const pressEvent = { nativeEvent: { locationX: 12, locationY: 8 }, target: 42 };
+
+    (openSupportDrawer as (chatMessage?: unknown) => void)(pressEvent);
+
+    expect(useSupportDrawerStore.getState()).toMatchObject({
+      isOpen: true,
+      chatMessage: undefined,
+    });
+  });
+
+  it('treats blank context as no context', () => {
+    openSupportDrawer('   ');
+
+    expect(useSupportDrawerStore.getState()).toMatchObject({
+      isOpen: true,
+      chatMessage: undefined,
+    });
+  });
 });

--- a/store/useSupportDrawerStore.ts
+++ b/store/useSupportDrawerStore.ts
@@ -7,10 +7,21 @@ interface SupportDrawerState {
   close: () => void;
 }
 
+/**
+ * `openSupportDrawer` reads as a bare handler, so it gets wired straight into
+ * `onPress` — and `onPress: () => void` happily accepts it, because a function
+ * with an optional parameter satisfies one with none. At runtime Pressable then
+ * hands it a press event, which travelled all the way into Intercom's native
+ * message composer and hard-crashed the app: that API takes a string only.
+ * Anything that is not a usable message means "no prefilled message".
+ */
+const asChatMessage = (chatMessage?: unknown): string | undefined =>
+  typeof chatMessage === 'string' && chatMessage.trim() !== '' ? chatMessage : undefined;
+
 export const useSupportDrawerStore = create<SupportDrawerState>()(set => ({
   isOpen: false,
   chatMessage: undefined,
-  open: chatMessage => set({ isOpen: true, chatMessage }),
+  open: chatMessage => set({ isOpen: true, chatMessage: asChatMessage(chatMessage) }),
   close: () => set({ isOpen: false, chatMessage: undefined }),
 }));
 


### PR DESCRIPTION
## Summary
This PR fixes two related type safety issues that were causing runtime crashes:

1. **Text input scroll handling**: Extracted logic for scrolling text inputs back to the start into a dedicated utility function with proper platform detection
2. **Support drawer handler**: Added validation to prevent press events from being passed to Intercom's native message composer, which only accepts strings

## Key Changes

- **New utility function `showTextInputFromStart`** (`lib/utils/textInput.ts`):
  - Handles platform-specific text input manipulation (native vs web)
  - Uses `Platform.OS` to avoid feature-detection pitfalls with read-only DOM properties on Android
  - Safely resets caret position and scroll offset when the "Max" button fills an amount field
  - Includes comprehensive test coverage for edge cases (unmounted refs, browser incompatibilities, etc.)

- **Support drawer handler validation** (`store/useSupportDrawerStore.ts`):
  - Added `asChatMessage` function to validate and sanitize chat message input
  - Filters out non-string values and blank strings
  - Prevents press events from reaching Intercom's native API, which crashes on non-string input

- **Intercom boundary check** (`lib/intercom.native.ts`):
  - Added defensive type check before calling `presentMessageComposer`
  - Falls back to opening Intercom without a prefilled message on invalid input

- **Updated call sites** to wrap `openSupportDrawer` in arrow functions:
  - `CardLinksList.tsx`
  - `VirtualAccountDetailsModal.tsx`
  - `settings/index.tsx` (both mobile and desktop)
  - This prevents the function from receiving the press event as an argument

- **Refactored `DepositToVaultForm`** to use the new `showTextInputFromStart` utility, removing inline platform-specific logic

## Notable Implementation Details

- The text input utility uses `Platform.OS` for platform detection rather than feature detection (`'scrollLeft' in ref`) because React Native's Fabric layer exposes DOM-shaped getters that throw on assignment, causing crashes on Android
- The support drawer validation is defensive at multiple layers (store, native bridge) to prevent crashes from type mismatches between TypeScript and native code
- All new code includes comprehensive test coverage and detailed comments explaining the rationale

https://claude.ai/code/session_01YP1aFfGG6idnpzWjDJaRup