### PR TITLE
Add timeout and error handling to deposit address requests

### DIFF
--- a/components/Savings/SavingsFund/SavingsFundDepositAddress.tsx
+++ b/components/Savings/SavingsFund/SavingsFundDepositAddress.tsx
@@ -30,6 +30,10 @@ type SavingsFundDepositAddressProps = {
   address?: string;
   symbol: string;
   chainId: number;
+  /** The address request failed — the screen offers a retry instead of a spinner. */
+  hasError?: boolean;
+  /** Re-runs the address request for the network already chosen. */
+  onRetry?: () => void;
   /** Returns to network selection — the chevron on the network summary row. */
   onChangeNetwork: () => void;
   /**
@@ -48,6 +52,8 @@ const SavingsFundDepositAddress = ({
   address,
   symbol,
   chainId,
+  hasError,
+  onRetry,
   onChangeNetwork,
   onDepositDetected,
 }: SavingsFundDepositAddressProps) => {
@@ -61,8 +67,13 @@ const SavingsFundDepositAddress = ({
     [onDepositDetected],
   );
 
+  // Polling only runs once there is an address to watch, so the status chip
+  // below has to follow the same condition - it used to claim it was scanning
+  // while no address existed and nothing was being polled.
+  const isScanning = !!address;
+
   const { isDetected } = useDetectedDirectDeposit({
-    enabled: !!address,
+    enabled: isScanning,
     destinationType: 'PROTOCOL',
     onDetected: handleDetected,
   });
@@ -119,17 +130,33 @@ const SavingsFundDepositAddress = ({
               logoBorderRadius={Math.round(qrSize * 0.11)}
               logoBackgroundColor="transparent"
             />
+          ) : hasError ? (
+            <View className="items-center gap-y-3 px-6">
+              <Text className="text-center text-sm text-white/70">
+                Could not load the deposit address.
+              </Text>
+              <Button
+                variant="secondary"
+                className="h-10 rounded-full px-6"
+                onPress={onRetry}
+                disabled={!onRetry}
+              >
+                <Text className="text-sm font-semibold">Try again</Text>
+              </Button>
+            </View>
           ) : (
             <ActivityIndicator color="white" />
           )}
         </View>
 
-        <View className="flex-row items-center gap-x-2 rounded-[18px] bg-[#333333] px-4 py-2">
-          <Text className="text-sm leading-4 text-white">
-            {isDetected ? 'Deposit detected' : 'Scanning for deposits'}
-          </Text>
-          <ActivityIndicator color="white" size="small" />
-        </View>
+        {isScanning ? (
+          <View className="flex-row items-center gap-x-2 rounded-[18px] bg-[#333333] px-4 py-2">
+            <Text className="text-sm leading-4 text-white">
+              {isDetected ? 'Deposit detected' : 'Scanning for deposits'}
+            </Text>
+            <ActivityIndicator color="white" size="small" />
+          </View>
+        ) : null}
       </View>
 
       <Text className="text-center text-sm text-white/70">

--- a/components/Savings/SavingsFund/SavingsFundScreen.tsx
+++ b/components/Savings/SavingsFund/SavingsFundScreen.tsx
@@ -22,8 +22,10 @@ const SavingsFundScreen = ({ step }: { step: SavingsFundStep }) => {
     selectedChainId,
     depositAddress,
     isPreparingSession,
+    hasSessionError,
     selectToken,
     selectNetwork,
+    retryPrepareSession,
     moveFromWallet,
     depositFromExternalWallet,
     openDetectedDeposit,
@@ -45,6 +47,8 @@ const SavingsFundScreen = ({ step }: { step: SavingsFundStep }) => {
         address={depositAddress}
         symbol={selectedToken}
         chainId={selectedChainId ?? 0}
+        hasError={hasSessionError}
+        onRetry={retryPrepareSession}
         onChangeNetwork={() => setModal(DEPOSIT_MODAL.OPEN_SAVINGS_FUND_NETWORKS)}
         onDepositDetected={openDetectedDeposit}
       />

--- a/hooks/useSavingsFundFlow.ts
+++ b/hooks/useSavingsFundFlow.ts
@@ -12,6 +12,17 @@ import { withRefreshToken } from '@/lib/utils';
 import { useDepositStore } from '@/store/useDepositStore';
 
 /**
+ * Failures here arrive as a rejected `Response` as often as an `Error`, and the
+ * status is the part worth having: it separates a backend fault from a gateway
+ * timeout when this shows up in analytics.
+ */
+const describeSessionError = (error: unknown): string => {
+  if (error instanceof Error) return error.message;
+  const status = (error as { status?: number } | null)?.status;
+  return status ? `HTTP ${status}` : 'Unknown error';
+};
+
+/**
  * Drives the savings direct-deposit screens ("Deposit to savings"): token →
  * network → deposit address, with the address prepared as soon as a network is
  * picked and the deposit polled for so the user lands on its activity the moment
@@ -38,16 +49,33 @@ export const useSavingsFundFlow = () => {
   const selectedChainId = session.chainId;
   const depositAddress = session.walletAddress;
 
-  const { mutate: prepareSession, isPending: isPreparingSession } = useMutation({
-    mutationFn: ({ chainId, token }: { chainId: number; token: string }) =>
-      withRefreshToken(() => createDirectDepositSession(chainId, token, 'PROTOCOL')),
+  const {
+    mutate: prepareSession,
+    isPending: isPreparingSession,
+    isError: hasSessionError,
+  } = useMutation({
+    mutationFn: async ({ chainId, token }: { chainId: number; token: string }) => {
+      const data = await withRefreshToken(() =>
+        createDirectDepositSession(chainId, token, 'PROTOCOL'),
+      );
+      // A response without an address leaves the screen with nothing to show,
+      // so it is a failure here rather than a success the UI cannot render.
+      if (!data?.walletAddress) throw new Error('No deposit address returned');
+      return data;
+    },
     onSuccess: data => {
-      if (data?.walletAddress) {
-        setDirectDepositSession({
-          walletAddress: data.walletAddress,
-          clientTxId: data.clientTxId,
-        });
-      }
+      setDirectDepositSession({
+        walletAddress: data.walletAddress,
+        clientTxId: data.clientTxId,
+      });
+    },
+    onError: (error, { chainId, token }) => {
+      track(TRACKING_EVENTS.DEPOSIT_DIRECT_SESSION_CREATION_FAILED, {
+        deposit_method: 'savings_direct_deposit',
+        chain_id: chainId,
+        selected_token: token,
+        error: describeSessionError(error),
+      });
     },
   });
 
@@ -92,6 +120,12 @@ export const useSavingsFundFlow = () => {
     [selectNetwork, setDirectDepositSession, setModal],
   );
 
+  /** Re-runs the address request for the network already chosen. */
+  const retryPrepareSession = useCallback(() => {
+    if (!selectedChainId) return;
+    prepareSession({ chainId: selectedChainId, token: selectedToken });
+  }, [prepareSession, selectedChainId, selectedToken]);
+
   /** "Move from wallet or savings" — the existing deposit-from-Solid form. */
   const moveFromWallet = useCallback(() => {
     setDepositFromSolid(true);
@@ -118,8 +152,10 @@ export const useSavingsFundFlow = () => {
     selectedChainId,
     depositAddress,
     isPreparingSession,
+    hasSessionError,
     selectToken,
     selectNetwork,
+    retryPrepareSession,
     moveFromWallet,
     depositFromExternalWallet,
     openDetectedDeposit,

--- a/lib/__tests__/fetchWithTimeout.test.ts
+++ b/lib/__tests__/fetchWithTimeout.test.ts
@@ -1,0 +1,71 @@
+/// <reference types="jest" />
+
+import { FetchTimeoutError, fetchWithTimeout } from '@/lib/fetchWithTimeout';
+
+/**
+ * The bug this covers: the deposit-address request had no timeout, so a backend
+ * stuck behind a slow webhook provider left the deposit screen spinning with no
+ * address, no error and nothing to retry.
+ */
+describe('fetchWithTimeout', () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    jest.useRealTimers();
+  });
+
+  /** A fetch that never answers on its own and only settles once aborted. */
+  const hangingFetch = () =>
+    jest.fn(
+      (_input: string, init?: RequestInit) =>
+        new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener('abort', () => {
+            const error = new Error('Aborted');
+            error.name = 'AbortError';
+            reject(error);
+          });
+        }),
+    );
+
+  it('passes the response through when the request answers in time', async () => {
+    const response = { ok: true } as Response;
+    global.fetch = jest.fn(() => Promise.resolve(response)) as unknown as typeof fetch;
+
+    await expect(fetchWithTimeout('https://example.test', {}, 1000)).resolves.toBe(response);
+  });
+
+  it('rejects with FetchTimeoutError once the deadline passes', async () => {
+    jest.useFakeTimers();
+    global.fetch = hangingFetch() as unknown as typeof fetch;
+
+    const pending = fetchWithTimeout('https://example.test', {}, 30000);
+    // Attach the assertion before advancing so the rejection is never unhandled.
+    const assertion = expect(pending).rejects.toBeInstanceOf(FetchTimeoutError);
+
+    await jest.advanceTimersByTimeAsync(30000);
+
+    await assertion;
+  });
+
+  it('leaves a caller-supplied abort reported as an AbortError', async () => {
+    // A superseded request must stay distinguishable from a timeout - callers
+    // deliberately ignore AbortError.
+    const aborted = new Error('Aborted');
+    aborted.name = 'AbortError';
+    global.fetch = jest.fn(() => Promise.reject(aborted)) as unknown as typeof fetch;
+
+    await expect(fetchWithTimeout('https://example.test', {}, 30000)).rejects.toBe(aborted);
+  });
+
+  it('does not leave its timer running after the request settles', async () => {
+    jest.useFakeTimers();
+    global.fetch = jest.fn(() =>
+      Promise.resolve({ ok: true } as Response),
+    ) as unknown as typeof fetch;
+
+    await fetchWithTimeout('https://example.test', {}, 30000);
+
+    expect(jest.getTimerCount()).toBe(0);
+  });
+});

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -6,6 +6,7 @@ import { fuse } from 'viem/chains';
 
 import { MOCK_REWARDS_USER_DATA, MOCK_TIER_BENEFITS } from '@/constants/rewards';
 import { fetchTokenTransferWithFallback } from '@/lib/data-source';
+import { fetchWithTimeout } from '@/lib/fetchWithTimeout';
 import { BridgeApiTransfer } from '@/lib/types/bank-transfer';
 import { useUserStore } from '@/store/useUserStore';
 
@@ -2981,6 +2982,15 @@ export const fetchActivityEvent = async (clientTxId: string): Promise<ActivityEv
 };
 
 // Direct Deposit Session API
+
+/**
+ * Deposit-address requests block a screen that can show nothing until they
+ * answer, so they fail rather than hang: the backend derives the address over
+ * an RPC call and registers it with webhook providers, and a stalled provider
+ * used to leave the client on an endless spinner.
+ */
+const DIRECT_DEPOSIT_SESSION_TIMEOUT_MS = 30000;
+
 export const createDirectDepositSession = async (
   chainId: number,
   tokenSymbol: string,
@@ -2988,7 +2998,7 @@ export const createDirectDepositSession = async (
 ): Promise<DirectDepositSessionResponse> => {
   const jwt = getJWTToken();
 
-  const response = await fetch(
+  const response = await fetchWithTimeout(
     `${EXPO_PUBLIC_FLASH_API_BASE_URL}/accounts/v1/deposit/direct-session`,
     {
       method: 'POST',
@@ -3004,6 +3014,7 @@ export const createDirectDepositSession = async (
         ...(destinationType ? { destinationType } : {}),
       }),
     },
+    DIRECT_DEPOSIT_SESSION_TIMEOUT_MS,
   );
 
   if (!response.ok) throw response;

--- a/lib/fetchWithTimeout.ts
+++ b/lib/fetchWithTimeout.ts
@@ -1,0 +1,40 @@
+/** Thrown when a request outlives the deadline `fetchWithTimeout` gave it. */
+export class FetchTimeoutError extends Error {
+  constructor(timeoutMs: number) {
+    super(`Request timed out after ${timeoutMs}ms`);
+    this.name = 'FetchTimeoutError';
+  }
+}
+
+/**
+ * `fetch` with a deadline.
+ *
+ * Nothing times out a fetch on its own, so a request whose response is the only
+ * thing a screen can render will keep that screen loading for as long as the
+ * backend takes — which is how a slow dependency turns into a permanent spinner.
+ *
+ * The rejection is a `FetchTimeoutError`, not the bare `AbortError` an abort
+ * produces: callers treat `AbortError` as a superseded request rather than a
+ * failure, so a timeout raised that way would be swallowed.
+ */
+export const fetchWithTimeout = async (
+  input: string,
+  init: RequestInit,
+  timeoutMs: number,
+): Promise<Response> => {
+  const controller = new AbortController();
+  let timedOut = false;
+  const timer = setTimeout(() => {
+    timedOut = true;
+    controller.abort();
+  }, timeoutMs);
+
+  try {
+    return await fetch(input, { ...init, signal: controller.signal });
+  } catch (error) {
+    if (timedOut) throw new FetchTimeoutError(timeoutMs);
+    throw error;
+  } finally {
+    clearTimeout(timer);
+  }
+};


### PR DESCRIPTION
## Summary
This PR adds timeout protection and improved error handling to the direct deposit session flow, preventing the deposit screen from spinning indefinitely when backend requests hang due to slow webhook providers.

## Key Changes

- **New `fetchWithTimeout` utility**: Implements fetch with a configurable deadline that throws `FetchTimeoutError` (distinct from `AbortError`) when requests exceed the timeout, allowing callers to distinguish timeouts from intentional aborts.

- **Timeout on deposit address requests**: Applied 30-second timeout to `createDirectDepositSession` API calls, which block the deposit screen and can hang if backend dependencies (like webhook providers) are slow.

- **Enhanced error tracking**: Added `onError` handler to the session mutation that tracks failures with error details (message or HTTP status), improving observability in analytics.

- **Validation of address responses**: Treats missing wallet addresses as failures rather than successes, preventing the UI from rendering an empty state.

- **Retry mechanism**: Added `retryPrepareSession` callback and UI button to allow users to retry the address request without reselecting the network.

- **Fixed scanning status**: Corrected the "Scanning for deposits" indicator to only display when an address exists, preventing misleading status messages while the address is still loading or failed.

## Implementation Details

- The `FetchTimeoutError` is thrown instead of bare `AbortError` because callers intentionally ignore `AbortError` (for superseded requests), which would cause timeouts to be silently swallowed.
- Timer cleanup is guaranteed via `finally` block to prevent timer leaks.
- Error description helper normalizes both `Error` objects and response objects for consistent analytics reporting.
- The polling for deposit detection is now gated by the same condition as the status indicator, ensuring consistency between what's displayed and what's being monitored.

https://claude.ai/code/session_015FVRY16ybC3jxEqrayVHjo