### PR TITLE
Split card funds access logic: allow withdrawals from frozen cards

### DIFF
--- a/components/Card/NewCardDetails/CardActionsRow.tsx
+++ b/components/Card/NewCardDetails/CardActionsRow.tsx
@@ -62,12 +62,17 @@ interface CardActionsRowProps {
   onFreezeToggle: () => void;
   onMorePress: () => void;
   /**
-   * Whether funds can move to/from the card at all (not frozen, KYC not paused).
-   * Gates Add funds and Withdraw together — the parent derives it once so the row
-   * and the desktop header cannot offer different actions for the same card.
+   * Whether funds can move onto the card: not frozen, and KYC not paused or
+   * offboarded. Derived by the parent (`canAddFundsToCard`) rather than here, so
+   * this row and the freeze state it renders come from one reading of the card.
    */
   canAddFunds: boolean;
-  /** Withdraw is hidden while funds can't be moved off the card (frozen / paused KYC). */
+  /**
+   * Whether funds can move off the card (`canWithdrawFromCard`). Not the mirror of
+   * `canAddFunds`: a freeze stops the card spending but leaves the collateral
+   * withdrawable, so this stays true on a frozen card and only a paused or
+   * offboarded customer turns it off.
+   */
   canWithdraw: boolean;
 }
 

--- a/components/Card/NewCardDetails/CardDetailsPane.tsx
+++ b/components/Card/NewCardDetails/CardDetailsPane.tsx
@@ -30,8 +30,13 @@ import { useCardStatus } from '@/hooks/useCardStatus';
 import { useCustomer } from '@/hooks/useCustomer';
 import { useRewardsUserData } from '@/hooks/useRewards';
 import { freezeCard, unfreezeCard } from '@/lib/api';
-import { CardStatus, KycStatus } from '@/lib/types';
-import { canToggleCardFreeze } from '@/lib/utils/cardHelpers';
+import { CardStatus } from '@/lib/types';
+import {
+  canAddFundsToCard,
+  canToggleCardFreeze,
+  canWithdrawFromCard,
+  isCustomerFundsRestricted,
+} from '@/lib/utils/cardHelpers';
 import { useCardHeroStore } from '@/store/useCardHeroStore';
 import { useCardPaneStore } from '@/store/useCardPaneStore';
 import { useCardWelcomePopupStore } from '@/store/useCardWelcomePopupStore';
@@ -118,9 +123,11 @@ const CardDetailsPane = () => {
 
   const isCardFrozen = cardDetails?.status === CardStatus.FROZEN;
   const canToggleFreeze = canToggleCardFreeze(cardDetails);
-  const isCustomerPausedOrOffboarded =
-    customer?.status === KycStatus.PAUSED || customer?.status === KycStatus.OFFBOARDED;
-  const canMoveCardFunds = !isCardFrozen && !isCustomerPausedOrOffboarded;
+  // Add funds and Withdraw part ways on a frozen card — see the two helpers.
+  const fundsAccess = {
+    isCardFrozen,
+    isCustomerRestricted: isCustomerFundsRestricted(customer?.status),
+  };
 
   /**
    * Dismiss: fly the card back to where it came from, then let the pane's sections
@@ -224,8 +231,8 @@ const CardDetailsPane = () => {
               isFreezing={isFreezing}
               onFreezeToggle={handleFreezeToggle}
               onMorePress={() => setIsAddToWalletOpen(true)}
-              canAddFunds={canMoveCardFunds}
-              canWithdraw={canMoveCardFunds}
+              canAddFunds={canAddFundsToCard(fundsAccess)}
+              canWithdraw={canWithdrawFromCard(fundsAccess)}
             />
           </HeroEnter>
           <HeroEnter spec={HERO_ENTER.cashback} style={styles.cashbackCard}>

--- a/lib/utils/__tests__/cardFundsAccess.test.ts
+++ b/lib/utils/__tests__/cardFundsAccess.test.ts
@@ -1,0 +1,71 @@
+import { KycStatus } from '@/lib/types';
+import {
+  canAddFundsToCard,
+  canWithdrawFromCard,
+  isCustomerFundsRestricted,
+} from '@/lib/utils/cardHelpers';
+
+/**
+ * These two decide whether the card action row renders Add funds and Withdraw at
+ * all, and they are deliberately not the same answer. The case that matters is a
+ * frozen card: hiding Withdraw there left the cardholder no way to reach
+ * collateral the API would have released, which is the whole reason the two were
+ * split apart.
+ */
+describe('card funds access', () => {
+  const live = { isCardFrozen: false, isCustomerRestricted: false };
+  const frozen = { isCardFrozen: true, isCustomerRestricted: false };
+  const restricted = { isCardFrozen: false, isCustomerRestricted: true };
+
+  describe('canWithdrawFromCard', () => {
+    it('offers Withdraw on a live card', () => {
+      expect(canWithdrawFromCard(live)).toBe(true);
+    });
+
+    it('offers Withdraw on a frozen card', () => {
+      // A freeze stops the card spending; the collateral proxy still pays out,
+      // and the backend's withdraw endpoints don't check card status.
+      expect(canWithdrawFromCard(frozen)).toBe(true);
+    });
+
+    it('hides Withdraw for a paused or offboarded customer', () => {
+      expect(canWithdrawFromCard(restricted)).toBe(false);
+      expect(canWithdrawFromCard({ isCardFrozen: true, isCustomerRestricted: true })).toBe(false);
+    });
+  });
+
+  describe('canAddFundsToCard', () => {
+    it('offers Add funds on a live card', () => {
+      expect(canAddFundsToCard(live)).toBe(true);
+    });
+
+    it('hides Add funds on a frozen card', () => {
+      // Funding a card that can't spend only moves the balance somewhere worse.
+      expect(canAddFundsToCard(frozen)).toBe(false);
+    });
+
+    it('hides Add funds for a paused or offboarded customer', () => {
+      expect(canAddFundsToCard(restricted)).toBe(false);
+    });
+  });
+
+  describe('isCustomerFundsRestricted', () => {
+    it('restricts paused and offboarded customers', () => {
+      expect(isCustomerFundsRestricted(KycStatus.PAUSED)).toBe(true);
+      expect(isCustomerFundsRestricted(KycStatus.OFFBOARDED)).toBe(true);
+    });
+
+    it('leaves every other status alone', () => {
+      expect(isCustomerFundsRestricted(KycStatus.APPROVED)).toBe(false);
+      expect(isCustomerFundsRestricted(KycStatus.UNDER_REVIEW)).toBe(false);
+      expect(isCustomerFundsRestricted(KycStatus.REJECTED)).toBe(false);
+    });
+
+    it('does not restrict before the customer has loaded', () => {
+      // An unloaded customer is not a paused one — the row should render its
+      // actions rather than drop columns and reflow once the query answers.
+      expect(isCustomerFundsRestricted(undefined)).toBe(false);
+      expect(isCustomerFundsRestricted(null)).toBe(false);
+    });
+  });
+});

--- a/lib/utils/cardHelpers.ts
+++ b/lib/utils/cardHelpers.ts
@@ -12,6 +12,7 @@ import {
   CashbackInfo,
   CashbackStatus,
   FreezeInitiator,
+  KycStatus,
 } from '@/lib/types';
 
 /** The freeze fields every card surface reads, so callers can pass a partial. */
@@ -45,6 +46,60 @@ const canCustomerUnfreezeCard = (cardDetails: FreezeState): boolean => {
  */
 export const canToggleCardFreeze = (cardDetails: FreezeState): boolean =>
   cardDetails?.status !== CardStatus.FROZEN || canCustomerUnfreezeCard(cardDetails);
+
+/**
+ * KYC states where we move no money for the customer in either direction.
+ *
+ * Paused and offboarded are holds on the person rather than on the card, so they
+ * are the one thing that stops a withdrawal too — a card-level problem doesn't.
+ * Anything else, an unresolved status included, leaves both actions offered.
+ *
+ * Takes a bare string because that is what `/bridge-customer` is typed as: the
+ * endpoint passes Bridge's status through unmodelled, and only the two values
+ * named here are acted on, so an unrecognised one restricts nothing.
+ */
+export const isCustomerFundsRestricted = (status: string | undefined | null): boolean =>
+  status === KycStatus.PAUSED || status === KycStatus.OFFBOARDED;
+
+/** What the card action row needs to know before offering to move money. */
+export interface CardFundsAccess {
+  /** The card is frozen — by the cardholder or by the provider. */
+  isCardFrozen: boolean;
+  /** KYC is paused or the customer is offboarded — see `isCustomerFundsRestricted`. */
+  isCustomerRestricted: boolean;
+}
+
+/**
+ * Whether to offer Add funds.
+ *
+ * A frozen card cannot spend, so a deposit onto one only moves the user's
+ * balance somewhere it does less for them. The action waits for the unfreeze.
+ */
+export const canAddFundsToCard = ({
+  isCardFrozen,
+  isCustomerRestricted,
+}: CardFundsAccess): boolean => !isCardFrozen && !isCustomerRestricted;
+
+/**
+ * Whether to offer Withdraw. Deliberately does **not** read `isCardFrozen`.
+ *
+ * Withdrawing used to be gated with Add funds on one `canMoveCardFunds` flag,
+ * which read as symmetric and isn't. A freeze stops the card spending; it does
+ * not touch the collateral, and a Rain withdrawal doesn't go through the card at
+ * all — it moves tokens out of the collateral proxy, which Rain signs for a
+ * frozen card exactly as it does for a live one. Our own withdraw endpoints
+ * carry no card-status check either. So hiding the button withheld an action
+ * that was available the whole time, from the users most likely to want it: a
+ * card frozen for suspected fraud, or one the cardholder froze precisely because
+ * they were done with it and wanted their money back.
+ *
+ * A provider freeze is treated the same as the customer's own here. Unlike
+ * unfreezing — which would undo a compliance hold and so has to go through
+ * support — taking collateral out is not a way around the freeze, and the API
+ * permits it either way; hiding the button would only hide it from the app.
+ */
+export const canWithdrawFromCard = ({ isCustomerRestricted }: CardFundsAccess): boolean =>
+  !isCustomerRestricted;
 
 /**
  * Whether this card can be funded by depositing onto it.


### PR DESCRIPTION
## Summary
Refactored card funds access control to distinguish between adding funds and withdrawing funds. Previously, both actions were gated by a single `canMoveCardFunds` flag. Now they use separate logic that allows withdrawals from frozen cards while still preventing deposits.

## Key Changes
- **New utility functions in `cardHelpers.ts`**:
  - `isCustomerFundsRestricted()`: Determines if a customer's KYC status (PAUSED or OFFBOARDED) restricts fund movements
  - `canAddFundsToCard()`: Returns false if card is frozen OR customer is restricted
  - `canWithdrawFromCard()`: Returns false only if customer is restricted (ignores card freeze status)
  - `CardFundsAccess` interface: Encapsulates the two conditions needed for fund access decisions

- **Updated `CardDetailsPane.tsx`**:
  - Replaced single `canMoveCardFunds` boolean with `fundsAccess` object
  - Calls separate `canAddFundsToCard()` and `canWithdrawFromCard()` helpers
  - Extracts customer restriction check into `isCustomerFundsRestricted()`

- **Updated `CardActionsRow.tsx`**:
  - Enhanced prop documentation to clarify the asymmetry between `canAddFunds` and `canWithdraw`
  - Explains why frozen cards allow withdrawals but not deposits

- **Added comprehensive test suite** (`cardFundsAccess.test.ts`):
  - Tests all three utility functions with various card and customer states
  - Documents the rationale: frozen cards cannot spend but collateral remains withdrawable

## Implementation Details
The key insight is that a card freeze prevents spending but doesn't affect the collateral proxy that handles withdrawals. Rain withdrawal endpoints don't check card status, so hiding the withdraw button from users with frozen cards (especially those who froze it themselves) was unnecessarily restrictive. Customer-level restrictions (paused/offboarded KYC) still block both operations since they represent holds on the person rather than the card.

https://claude.ai/code/session_018kdRrYMaZBsb4H2VaMKqs9