### PR TITLE
Gate card deposit flow to soUSD-minting tokens only

### DIFF
--- a/components/Savings/SavingsFund/SavingsFundOptions.tsx
+++ b/components/Savings/SavingsFund/SavingsFundOptions.tsx
@@ -10,9 +10,10 @@ import CardFundRow from '@/components/Card/CardFund/CardFundRow';
 import NeedHelp from '@/components/NeedHelp';
 import {
   getSavingsFundNetworkChips,
-  SAVINGS_FUND_CRYPTO,
-  SAVINGS_FUND_STABLECOINS,
+  getSavingsFundTokenGroups,
 } from '@/components/Savings/SavingsFund/constants';
+
+import type { SavingsFundIntent } from '@/lib/types';
 
 const TOKEN_ICON_STYLE = { width: 36, height: 36, borderRadius: 18 };
 
@@ -24,6 +25,8 @@ type SavingsFundOptionsProps = {
   /** Send from a connected external wallet. */
   onExternalWalletPress: () => void;
   isExternalWalletLoading?: boolean;
+  /** Why the flow was opened — scopes which tokens are on offer. */
+  intent?: SavingsFundIntent;
 };
 
 /** Step 1 of the savings funding flow — "Deposit to savings". */
@@ -32,53 +35,60 @@ const SavingsFundOptions = ({
   onMoveFromWalletPress,
   onExternalWalletPress,
   isExternalWalletLoading,
-}: SavingsFundOptionsProps) => (
-  <View className="gap-y-8">
-    <CardFundGroup label="Stablecoins">
-      {SAVINGS_FUND_STABLECOINS.map(token => (
+  intent = 'savings',
+}: SavingsFundOptionsProps) => {
+  const { stablecoins, crypto } = getSavingsFundTokenGroups(intent);
+
+  return (
+    <View className="gap-y-8">
+      <CardFundGroup label="Stablecoins">
+        {stablecoins.map(token => (
+          <CardFundRow
+            key={token.symbol}
+            icon={<Image source={token.icon} style={TOKEN_ICON_STYLE} contentFit="cover" />}
+            title={token.symbol}
+            chips={getSavingsFundNetworkChips(token.symbol)}
+            onPress={() => onTokenPress(token.symbol)}
+          />
+        ))}
+      </CardFundGroup>
+
+      {crypto.length > 0 ? (
+        <CardFundGroup label="Crypto">
+          {crypto.map(token => (
+            <CardFundRow
+              key={token.symbol}
+              icon={<Image source={token.icon} style={TOKEN_ICON_STYLE} contentFit="cover" />}
+              title={token.symbol}
+              subtitle={`Earns as ${token.vaultToken}`}
+              chips={getSavingsFundNetworkChips(token.symbol)}
+              onPress={() => onTokenPress(token.symbol)}
+            />
+          ))}
+        </CardFundGroup>
+      ) : null}
+
+      <CardFundGroup label="Other">
         <CardFundRow
-          key={token.symbol}
-          icon={<Image source={token.icon} style={TOKEN_ICON_STYLE} contentFit="cover" />}
-          title={token.symbol}
-          chips={getSavingsFundNetworkChips(token.symbol)}
-          onPress={() => onTokenPress(token.symbol)}
+          icon={<FundMoveSavings width={22} height={25} />}
+          title="Move from wallet or savings"
+          subtitle="Use funds you already hold in Solid"
+          onPress={onMoveFromWalletPress}
         />
-      ))}
-    </CardFundGroup>
-
-    <CardFundGroup label="Crypto">
-      {SAVINGS_FUND_CRYPTO.map(token => (
         <CardFundRow
-          key={token.symbol}
-          icon={<Image source={token.icon} style={TOKEN_ICON_STYLE} contentFit="cover" />}
-          title={token.symbol}
-          subtitle={`Earns as ${token.vaultToken}`}
-          chips={getSavingsFundNetworkChips(token.symbol)}
-          onPress={() => onTokenPress(token.symbol)}
+          icon={<FundExternalWallet width={26} height={26} />}
+          title="Deposit from an external wallet"
+          subtitle="Send from any supported network"
+          onPress={onExternalWalletPress}
+          isLoading={isExternalWalletLoading}
         />
-      ))}
-    </CardFundGroup>
+      </CardFundGroup>
 
-    <CardFundGroup label="Other">
-      <CardFundRow
-        icon={<FundMoveSavings width={22} height={25} />}
-        title="Move from wallet or savings"
-        subtitle="Use funds you already hold in Solid"
-        onPress={onMoveFromWalletPress}
-      />
-      <CardFundRow
-        icon={<FundExternalWallet width={26} height={26} />}
-        title="Deposit from an external wallet"
-        subtitle="Send from any supported network"
-        onPress={onExternalWalletPress}
-        isLoading={isExternalWalletLoading}
-      />
-    </CardFundGroup>
-
-    <View className="items-center">
-      <NeedHelp />
+      <View className="items-center">
+        <NeedHelp />
+      </View>
     </View>
-  </View>
-);
+  );
+};
 
 export default SavingsFundOptions;

--- a/components/Savings/SavingsFund/SavingsFundScreen.tsx
+++ b/components/Savings/SavingsFund/SavingsFundScreen.tsx
@@ -17,6 +17,7 @@ type SavingsFundStep = 'options' | 'networks' | 'address';
  */
 const SavingsFundScreen = ({ step }: { step: SavingsFundStep }) => {
   const setModal = useDepositStore(state => state.setModal);
+  const savingsFundIntent = useDepositStore(state => state.savingsFundIntent);
   const {
     selectedToken,
     selectedChainId,
@@ -56,6 +57,7 @@ const SavingsFundScreen = ({ step }: { step: SavingsFundStep }) => {
       onTokenPress={selectToken}
       onMoveFromWalletPress={moveFromWallet}
       onExternalWalletPress={depositFromExternalWallet}
+      intent={savingsFundIntent}
     />
   );
 };

--- a/components/Savings/SavingsFund/__tests__/savingsFundTokenGroups.test.ts
+++ b/components/Savings/SavingsFund/__tests__/savingsFundTokenGroups.test.ts
@@ -1,0 +1,44 @@
+import {
+  getSavingsFundTokenGroups,
+  SAVINGS_FUND_CRYPTO,
+  SAVINGS_FUND_STABLECOINS,
+} from '@/components/Savings/SavingsFund/constants';
+
+// constants.ts resolves token icons through the asset barrel; the group policy
+// under test only cares about which tokens are listed.
+jest.mock('@/lib/assets', () => ({ getAsset: (path: string) => path }));
+
+describe('getSavingsFundTokenGroups', () => {
+  it('offers stablecoins and crypto for an ordinary savings deposit', () => {
+    const { stablecoins, crypto } = getSavingsFundTokenGroups('savings');
+
+    expect(stablecoins.map(t => t.symbol)).toEqual(['USDC', 'USDT']);
+    expect(crypto.map(t => t.symbol)).toEqual(['ETH', 'WFUSE']);
+  });
+
+  // The card's "Deposit at least $5" gate reads the soUSD balance alone, so a $5
+  // deposit of ETH or WFUSE would fund soETH / soFUSE and leave the step stuck.
+  it('offers only the soUSD-minting stablecoins for the card deposit gate', () => {
+    const { stablecoins, crypto } = getSavingsFundTokenGroups('card_deposit');
+
+    expect(crypto).toEqual([]);
+    expect(stablecoins.map(t => t.vaultToken)).toEqual(['soUSD', 'soUSD']);
+  });
+
+  it('keeps every offered token mapped to a vault, in both intents', () => {
+    for (const intent of ['savings', 'card_deposit'] as const) {
+      const { stablecoins, crypto } = getSavingsFundTokenGroups(intent);
+
+      for (const token of [...stablecoins, ...crypto]) {
+        expect(token.vaultToken).toBeTruthy();
+      }
+    }
+  });
+
+  it('does not mutate the underlying token lists', () => {
+    getSavingsFundTokenGroups('card_deposit');
+
+    expect(SAVINGS_FUND_STABLECOINS.map(t => t.symbol)).toEqual(['USDC', 'USDT']);
+    expect(SAVINGS_FUND_CRYPTO.map(t => t.symbol)).toEqual(['ETH', 'WFUSE']);
+  });
+});

--- a/components/Savings/SavingsFund/constants.ts
+++ b/components/Savings/SavingsFund/constants.ts
@@ -5,6 +5,8 @@ import { BRIDGE_TOKENS } from '@/constants/bridge';
 import { getAsset } from '@/lib/assets';
 import { getAllowedTokensForChain, getVaultDepositConfig } from '@/lib/vaults';
 
+import type { SavingsFundIntent } from '@/lib/types';
+
 export type SavingsFundToken = {
   symbol: string;
   /** Share token minted for this deposit — shown as the row's subtitle. */
@@ -68,6 +70,22 @@ export const SAVINGS_FUND_TOKENS: SavingsFundToken[] = [
   ...SAVINGS_FUND_STABLECOINS,
   ...SAVINGS_FUND_CRYPTO,
 ];
+
+/**
+ * The token groups a savings direct deposit offers, for the flow's intent.
+ *
+ * `card_deposit` is the card's "Deposit at least $5" gate, which completes off
+ * the soUSD balance alone — so it offers only the stablecoins that mint soUSD.
+ * Were ETH or WFUSE on offer there, a user could deposit the full $5, fund
+ * soETH / soFUSE instead, and leave the step stuck at "not met" with nothing
+ * on screen explaining why.
+ */
+export const getSavingsFundTokenGroups = (
+  intent: SavingsFundIntent,
+): { stablecoins: SavingsFundToken[]; crypto: SavingsFundToken[] } => ({
+  stablecoins: SAVINGS_FUND_STABLECOINS,
+  crypto: intent === 'card_deposit' ? [] : SAVINGS_FUND_CRYPTO,
+});
 
 /** Deposits are credited within roughly this window on every supported chain. */
 export const SAVINGS_FUND_ESTIMATED_TIME = '~3 min';

--- a/hooks/useCardSteps/__tests__/savingsDepositEntry.test.ts
+++ b/hooks/useCardSteps/__tests__/savingsDepositEntry.test.ts
@@ -1,0 +1,62 @@
+import { DEPOSIT_MODAL } from '@/constants/modals';
+import {
+  CARD_DEPOSIT_SOURCE,
+  openCardSavingsDeposit,
+} from '@/hooks/useCardSteps/savingsDepositEntry';
+
+const setup = () => {
+  const state = {
+    setDepositFromSolid: jest.fn(),
+    setSavingsFundIntent: jest.fn(),
+    clearDirectDepositSession: jest.fn(),
+  };
+  const openDepositFlow = jest.fn();
+
+  openCardSavingsDeposit(state, openDepositFlow);
+
+  return { state, openDepositFlow };
+};
+
+describe('openCardSavingsDeposit', () => {
+  it('opens the savings direct-deposit flow, not the legacy deposit options', () => {
+    const { openDepositFlow } = setup();
+
+    expect(openDepositFlow).toHaveBeenCalledTimes(1);
+    expect(openDepositFlow).toHaveBeenCalledWith({
+      modal: DEPOSIT_MODAL.OPEN_SAVINGS_FUND,
+      source: CARD_DEPOSIT_SOURCE,
+      buttonText: 'Deposit',
+    });
+  });
+
+  // The regression this replaced: OPEN_OPTIONS led to the static Safe address
+  // ("Share your deposit address" → "Your Solid address"), which cannot tell the
+  // user their deposit was seen.
+  it('never routes to the static-address options screen', () => {
+    const { openDepositFlow } = setup();
+    const { modal } = openDepositFlow.mock.calls[0][0];
+
+    expect(modal.name).not.toBe(DEPOSIT_MODAL.OPEN_OPTIONS.name);
+    expect(modal.name).not.toBe(DEPOSIT_MODAL.OPEN_PUBLIC_ADDRESS.name);
+  });
+
+  it('marks the flow as the card deposit so only soUSD-minting tokens are offered', () => {
+    const { state } = setup();
+
+    expect(state.setSavingsFundIntent).toHaveBeenCalledWith('card_deposit');
+  });
+
+  it('sends new funds in rather than moving an existing Solid balance', () => {
+    const { state } = setup();
+
+    expect(state.setDepositFromSolid).toHaveBeenCalledWith(false);
+  });
+
+  // directDepositSession is persisted, so without this the step can reopen on a
+  // stale address for a chain the user is no longer depositing on.
+  it('clears any persisted direct-deposit session before opening', () => {
+    const { state } = setup();
+
+    expect(state.clearDirectDepositSession).toHaveBeenCalledTimes(1);
+  });
+});

--- a/hooks/useCardSteps/savingsDepositEntry.ts
+++ b/hooks/useCardSteps/savingsDepositEntry.ts
@@ -1,0 +1,54 @@
+import { DEPOSIT_MODAL } from '@/constants/modals';
+import { DepositModal, SavingsFundIntent } from '@/lib/types';
+
+/** Tracking source for the card activation screen's minimum-deposit step. */
+export const CARD_DEPOSIT_SOURCE = 'card_activation_deposit_step';
+
+/** The deposit-store setters the card's deposit step needs to prime the flow. */
+type DepositFlowState = {
+  setDepositFromSolid: (v: boolean) => void;
+  setSavingsFundIntent: (intent: SavingsFundIntent) => void;
+  clearDirectDepositSession: () => void;
+};
+
+type OpenDepositFlow = (options: {
+  modal: DepositModal;
+  source: string;
+  buttonText: string;
+}) => void;
+
+/**
+ * Opens the savings direct-deposit flow from the card's "Deposit at least $5"
+ * step: token → network → per-session deposit address, polled for the incoming
+ * transfer.
+ *
+ * This replaced the legacy `OPEN_OPTIONS` route, which led to the static Safe
+ * address ("Share your deposit address" → "Your Solid address"). That address is
+ * the same for every chain and every purpose, so nothing tied a transfer to this
+ * step and the screen could not tell the user their deposit had been seen — they
+ * were left watching an unchanging QR and a "5-10 minutes" note. Point this back
+ * at `OPEN_OPTIONS` and Bangladesh card applicants get that screen again.
+ */
+export function openCardSavingsDeposit(
+  state: DepositFlowState,
+  openDepositFlow: OpenDepositFlow,
+): void {
+  // Send new money in rather than moving an existing Solid balance, so the flow
+  // opens on the token list instead of the deposit-from-Solid form.
+  state.setDepositFromSolid(false);
+
+  // Only soUSD counts towards this step (see `savingsDepositMet`), so the flow
+  // offers just the stablecoins that mint it.
+  state.setSavingsFundIntent('card_deposit');
+
+  // directDepositSession is persisted: drop any token / chain / address left
+  // from an earlier deposit so this open starts on the token list with a fresh
+  // session, never a stale address for a chain the user is no longer on.
+  state.clearDirectDepositSession();
+
+  openDepositFlow({
+    modal: DEPOSIT_MODAL.OPEN_SAVINGS_FUND,
+    source: CARD_DEPOSIT_SOURCE,
+    buttonText: 'Deposit',
+  });
+}

--- a/hooks/useCardSteps/useCardSteps.ts
+++ b/hooks/useCardSteps/useCardSteps.ts
@@ -3,11 +3,11 @@ import Toast from 'react-native-toast-message';
 import { useRouter } from 'expo-router';
 import { useShallow } from 'zustand/react/shallow';
 
-import { DEPOSIT_MODAL } from '@/constants/modals';
 import { path } from '@/constants/path';
 import { TRACKING_EVENTS } from '@/constants/tracking-events';
 import { useBalances } from '@/hooks/useBalances';
 import { useCustomer, useKycLinkFromBridge } from '@/hooks/useCustomer';
+import { useOpenDepositFlow } from '@/hooks/useOpenDepositFlow';
 import { track } from '@/lib/analytics';
 import { getCustomerFromBridge, getKycLinkFromBridge } from '@/lib/api';
 import { EXPO_PUBLIC_CARD_ISSUER } from '@/lib/config';
@@ -31,6 +31,7 @@ import {
 } from './kycFlowHelpers';
 import { computeKycStatus, computeUiKycStatus, useProcessingWindow } from './kycStatusHelpers';
 import { resolveRainKycAction } from './rainKycAction';
+import { openCardSavingsDeposit } from './savingsDepositEntry';
 import { buildCardSteps, useCardActivation, useStepNavigation } from './stepHelpers';
 
 // Re-export types
@@ -114,9 +115,14 @@ export function useCardSteps(
   // Opens the deposit-to-savings (soUSD) flow used by the BD "deposit first"
   // step. The global DepositModalProvider is mounted app-wide, so this works
   // from the card activation screen without mounting a modal locally.
+  //
+  // See openCardSavingsDeposit: this is the savings direct-deposit flow (token →
+  // network → per-session address, polled for the transfer), replacing the
+  // legacy static-Safe-address route.
+  const openDepositFlow = useOpenDepositFlow();
   const openSavingsDepositModal = useCallback(
-    () => useDepositStore.getState().setModal(DEPOSIT_MODAL.OPEN_OPTIONS),
-    [],
+    () => openCardSavingsDeposit(useDepositStore.getState(), openDepositFlow),
+    [openDepositFlow],
   );
 
   // The BD minimum-deposit step now completes from the savings (soUSD) balance,

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1105,6 +1105,15 @@ export type StakeModal = (typeof STAKE_MODAL)[keyof typeof STAKE_MODAL];
 export type DepositFromSafeAccountModal =
   (typeof DEPOSIT_FROM_SAFE_ACCOUNT_MODAL)[keyof typeof DEPOSIT_FROM_SAFE_ACCOUNT_MODAL];
 
+/**
+ * Why the savings direct-deposit flow was opened.
+ *
+ * `card_deposit` is the Bangladesh card gate ("Deposit at least $5"), which
+ * completes off the soUSD balance alone — so that entry point only offers the
+ * stablecoins that mint soUSD.
+ */
+export type SavingsFundIntent = 'savings' | 'card_deposit';
+
 export type TransactionStatusModal = {
   amount?: number;
   address?: Address;

--- a/store/useDepositStore.ts
+++ b/store/useDepositStore.ts
@@ -9,7 +9,12 @@ import {
 import { DEPOSIT_MODAL } from '@/constants/modals';
 import { USER } from '@/lib/config';
 import mmkvStorage from '@/lib/mmvkStorage';
-import { DepositModal, SourceDepositInstructions, TransactionStatusModal } from '@/lib/types';
+import {
+  DepositModal,
+  SavingsFundIntent,
+  SourceDepositInstructions,
+  TransactionStatusModal,
+} from '@/lib/types';
 
 // Type-only imports (erased at build → no thirdweb runtime cost on mobile).
 import type { Account, Wallet } from 'thirdweb/wallets';
@@ -95,10 +100,18 @@ interface DepositState {
   directDepositSession: DirectDepositSession;
   sessionStartTime?: number;
   depositFromSolid: boolean;
+  /**
+   * Why the savings direct-deposit flow was open. Deliberately kept out of
+   * `directDepositSession` (which is persisted) so a stale intent can never leak
+   * into a later open from the Savings tab; like `depositFromSolid` it lives for
+   * one flow and is cleared by `resetDepositFlow`.
+   */
+  savingsFundIntent: SavingsFundIntent;
   /** Transient (not persisted) — populated only on desktop by ThirdwebConnectionBridge. */
   externalWallet: ExternalWalletState;
   setExternalWallet: (data: ExternalWalletState) => void;
   setDepositFromSolid: (v: boolean) => void;
+  setSavingsFundIntent: (intent: SavingsFundIntent) => void;
   setModal: (modal: DepositModal) => void;
   setTransaction: (transaction: TransactionStatusModal) => void;
   setBankTransferData: (data: Partial<BankTransferData>) => void;
@@ -127,6 +140,7 @@ export const useDepositStore = create<DepositState>()(
       directDepositSession: {},
       sessionStartTime: undefined,
       depositFromSolid: false,
+      savingsFundIntent: 'savings',
       externalWallet: {
         address: undefined,
         status: 'unknown',
@@ -136,6 +150,7 @@ export const useDepositStore = create<DepositState>()(
       },
       setExternalWallet: data => set({ externalWallet: data }),
       setDepositFromSolid: (v: boolean) => set({ depositFromSolid: v }),
+      setSavingsFundIntent: (intent: SavingsFundIntent) => set({ savingsFundIntent: intent }),
 
       setModal: modal => {
         const isClose = modal.name === DEPOSIT_MODAL.CLOSE.name;
@@ -168,6 +183,7 @@ export const useDepositStore = create<DepositState>()(
           directDepositSession: {},
           sessionStartTime: undefined,
           depositFromSolid: false,
+          savingsFundIntent: 'savings',
         }),
     }),
     {


### PR DESCRIPTION
## Summary
This PR introduces intent-based token filtering for the savings direct-deposit flow, enabling the Bangladesh card's "Deposit at least $5" gate to restrict token offerings to only those that mint soUSD. This prevents users from depositing funds that mint alternative vault tokens (soETH, soFUSE) and getting stuck with an incomplete gate.

## Key Changes

- **Added `SavingsFundIntent` type** (`lib/types.ts`): New union type (`'savings' | 'card_deposit'`) to distinguish between regular savings deposits and card activation deposits.

- **Implemented `getSavingsFundTokenGroups` function** (`components/Savings/SavingsFund/constants.ts`): Filters token offerings based on intent—`card_deposit` intent excludes crypto tokens and only offers stablecoins that mint soUSD, while `'savings'` intent offers the full token list.

- **Updated `SavingsFundOptions` component** (`components/Savings/SavingsFund/SavingsFundOptions.tsx`): 
  - Added `intent` prop (defaults to `'savings'`)
  - Replaced hardcoded token constants with dynamic `getSavingsFundTokenGroups` call
  - Made crypto group conditionally render (hidden when empty for card deposits)

- **Created `openCardSavingsDeposit` entry point** (`hooks/useCardSteps/savingsDepositEntry.ts`): New function that primes the deposit flow state for card activation:
  - Sets `depositFromSolid` to `false` (new money, not moving existing balance)
  - Sets `savingsFundIntent` to `'card_deposit'`
  - Clears any stale persisted session
  - Opens the direct-deposit flow (not the legacy static-address route)

- **Extended `useDepositStore`** (`store/useDepositStore.ts`): Added `savingsFundIntent` state and `setSavingsFundIntent` setter, kept separate from persisted `directDepositSession` to prevent stale intent leakage between flows.

- **Updated card activation flow** (`hooks/useCardSteps/useCardSteps.ts`): Replaced direct modal open with `openCardSavingsDeposit` call to properly initialize the constrained deposit flow.

- **Added comprehensive tests**: 
  - `savingsFundTokenGroups.test.ts`: Validates token filtering logic for both intents
  - `savingsDepositEntry.test.ts`: Ensures card deposit flow initialization and regression prevention

## Implementation Details

The `savingsFundIntent` state is deliberately kept transient (cleared on flow reset) rather than persisted with `directDepositSession`, preventing a stale `'card_deposit'` intent from leaking into a later deposit opened from the Savings tab. This mirrors the existing `depositFromSolid` pattern.

The card gate completes based on soUSD balance alone, so offering non-soUSD-minting tokens would allow users to deposit the full $5 but fund alternative vault tokens, leaving the gate stuck with no explanation on screen.

https://claude.ai/code/session_01DgjbCE6UAbuR7ghkMH8N75